### PR TITLE
Prepare for Solr8

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -33,7 +33,7 @@ def search():
     search_terms = request.args.get('keywords', '')
 
     #: keyword search field query alias field syntax
-    search_query = '{!qf=$keyword_qf pf=$keyword_pf ps=2 v=$search_terms}'
+    search_query = "{!dismax qf=$keyword_qf pf=$keyword_pf ps=2 v=$search_terms}"
 
     queryset = SolrQuerySet(get_solr())
     if search_terms:


### PR DESCRIPTION
A single query change was necessary to prepare the prototype for Solr 8; a default value needed to be explicitly stated. It's also backwards compatible with Solr 6 and parasolr as it currently is, thankfully, so we can make these changes now! Also, all configs exist solely in the CDH_ansible repo, I expect this to be the only changes necessary in `geniza` to move to PUL's solr. Addresses #14. 