### PR TITLE
browse documents by topic cluster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-parasolr
+# using parasolr features added for ppa support that are not yet released
+#parasolr<=0.6
+git+https://github.com/Princeton-CDH/parasolr.git@develop#egg=parasolr
 flask
 pytest
 flask

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -45,9 +45,7 @@ def index():
         tags = [tag.strip() for tag in row['Tags'].split('#') if tag.strip()]
         # create a combined, sorted version of tag list for grouping
         # records with the same set of tags
-        sorted_tags = tags.copy()
-        sorted_tags.sort()
-        tagset = '|'.join(sorted_tags)
+        tagset = '|'.join(sorted(tags))
 
         extlink = row['Link to image']
         iiif_link = None

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -43,6 +43,12 @@ def index():
     index_data = []
     for row in rows:
         tags = [tag.strip() for tag in row['Tags'].split('#') if tag.strip()]
+        # create a combined, sorted version of tag list for grouping
+        # records with the same set of tags
+        sorted_tags = tags.copy()
+        sorted_tags.sort()
+        tagset = '|'.join(sorted_tags)
+
         extlink = row['Link to image']
         iiif_link = None
         # cambridge iiif manifest links use the same id as view links
@@ -73,6 +79,7 @@ def index():
             'shelfmark_txt': row['Shelfmark - Current'],
             'tags_txt': tags,
             'tags_ss': tags,
+            'tagset_s': tagset,
             'link_s': extlink or None,
             'iiif_link_s': iiif_link,
             'editors_txt': row['Editor(s)'] or None,

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -117,9 +117,12 @@ def clusters():
         # todo: group by distinct sets of tags
         documents = document_sqs.get_results(rows=1000)
 
+    current_cluster_tags = selected_cluster.split('/')
+
     return render_template(
         'clusters.html', clusters=clusters,
-        current_cluster=' '.join('#%s' % tag for tag in selected_cluster.split('/')),
+        current_cluster=' '.join('#%s' % tag for tag in current_cluster_tags),
+        current_tags=current_cluster_tags,
         documents=documents, version=__version__,
         env=app.config.get('ENV', None))
 

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -114,12 +114,14 @@ def clusters():
         document_sqs = SolrQuerySet(get_solr()) \
             .filter(tags_ss='(%s)' % tag_query)
 
+        # todo: group by distinct sets of tags
         documents = document_sqs.get_results(rows=1000)
 
-    return render_template('clusters.html', clusters=clusters,
-                           documents=documents,
-                           version=__version__,
-                           env=app.config.get('ENV', None))
+    return render_template(
+        'clusters.html', clusters=clusters,
+        current_cluster=' '.join('#%s' % tag for tag in selected_cluster.split('/')),
+        documents=documents, version=__version__,
+        env=app.config.get('ENV', None))
 
 
 def get_solr():

--- a/scripts/templates/cluster_result.html
+++ b/scripts/templates/cluster_result.html
@@ -1,0 +1,20 @@
+{% set result = group_doc or doc %} {# use group doc if defined, otherwise doc #}
+<div class="pb3">
+    {% if show_tags %} {# only show tags if set #}
+    <ul class="list pl0 pb2 dark-gray">
+        {% for tag in result.tags_ss %}
+            <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    <div>{{ result.shelfmark_s }}</div>
+    <div>{{ result.type_s }}</div>
+    <div>{{ result.description_txt.0|truncate(170) }}</div>
+    {% if result.transcription_txt or result.editors_txt or result.translators_txt %}
+    <ul class="list pl0">
+        <li class="di green">✓</li>
+        {% if result.transcription_txt %}<li class="di pr2">Transcription</li>{% endif %}
+        {% if result.editors_txt or result.translators_txt %}<li class="di pr2">Bibliography</li>{% endif %}
+    </ul>
+    {% endif %}
+</div>

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -14,6 +14,10 @@
             text-align: right;
             white-space: pre;
         }
+
+        ol ::marker {
+            font-weight: bold;
+        }
     </style>
 {% endblock %}
 
@@ -43,23 +47,37 @@
       <div class="bl-ns bt bt-0-ns pv4">
         <div class="pl3">
             <div class="f2 lh-copy blue">{{ current_cluster }}</div>
-            <div>{{ documents|length() }} Documents</div>
+            <div>{{ current_cluster_count }} Documents</div>
         </div>
 
           {# todo: group by distinct sets of tags #}
           <ol>
           {% for doc in documents %}
               <li class="pb3">
-                <ul class="list pl0 dark-gray">
-                    {% for tag in doc.tags_ss %}
-                        <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
-                    {% endfor %}
-                </ul>
+                <div class="pb3">
+                    <ul class="list pl0 pb2 dark-gray">
+                        {% for tag in doc.tags_ss %}
+                            <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
+                        {% endfor %}
+                    </ul>
 
-                <div>{{ doc.shelfmark_s }}</div>
-                <div>{{ doc.type_s }}</div>
-                <div>{{ doc.description_txt.0|truncate(170) }}</div>
-                <div>{% if doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}
+                    <div>{{ doc.shelfmark_s }}</div>
+                    <div>{{ doc.type_s }}</div>
+                    <div>{{ doc.description_txt.0|truncate(170) }}</div>
+                    <div>{% if doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}</div>
+                </div>
+                {% if doc.tagset_s in groups %}
+                {% for group_doc in groups[doc.tagset_s]['docs'] %}
+                <div class="pb3">
+                    {# don't repeat tags, since they are the same #}
+                    <div>{{ group_doc.shelfmark_s }}</div>
+                    <div>{{ group_doc.type_s }}</div>
+                    <div>{{ group_doc.description_txt.0|truncate(170) }}</div>
+                    <div>{% if group_doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}</div>
+                </div>
+                {% endfor %}
+                {% endif %}
+
               </li>
           {% endfor %}
           </ol>

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -18,14 +18,52 @@
 {% endblock %}
 
 {% block content %}
-<h2>Clusters</h2>
-<p>Sorted by size</p>
+{# two columns #}
+<div class="mw9 center ph3-ns">
+  <div class="cf ph2-ns">
+    <div class="fl w-100 w-40-ns pa2">
 
-<ol>
-    {% for cluster in clusters %}
-    <li class="pl1 pb2"><div class="f3 lh-copy">{{ cluster.label }}</div>
-        {{ cluster.count }} Documents
-    </li>
-    {% endfor %}
-</ol>
+    <h2>Clusters</h2>
+    <p>Sorted by size</p>
+
+    <ol>
+        {% for cluster in clusters %}
+        <li class="pl1 pb2"><a class="dib no-underline dim black v-mid" href="?cluster={{ cluster.value }}">
+            <div class="f3 lh-copy {% if cluster.selected %}blue{% endif %}">{{ cluster.label }}</div>
+            {{ cluster.count }} Documents
+            </a>
+        </li>
+        {% endfor %}
+    </ol>
+    </div> {# end first column #}
+
+    {# second column, when there are documents #}
+    {% if documents %}
+    <div class="fl w-100 w-60-ns pa2">
+      <div class="bl-ns bt bt-0-ns pv4">
+          {# todo: group by distinct sets of tags #}
+          <ol>
+          {% for doc in documents %}
+              <li class="pb3">
+                <ul class="list pl0 dark-gray">
+                    {% for tag in doc.tags_ss %}
+                        <li class="di">#{{ tag }}</li>
+                    {% endfor %}
+                </ul>
+
+                <div>{{ doc.shelfmark_s }}</div>
+                <div>{{ doc.type_s }}</div>
+                <div>{{ doc.description_txt.0|truncate(150) }}</div>
+                <div>{% if doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}
+              </li>
+          {% endfor %}
+          </ol>
+      </div>
+
+    </div>
+  {% endif %}
+  </div>
+
+</div>
+
 {% endblock %}

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -41,6 +41,11 @@
     {% if documents %}
     <div class="fl w-100 w-60-ns pa2">
       <div class="bl-ns bt bt-0-ns pv4">
+        <div class="pl3">
+            <div class="f2 lh-copy blue">{{ current_cluster }}</div>
+            <div>{{ documents|length() }} Documents</div>
+        </div>
+
           {# todo: group by distinct sets of tags #}
           <ol>
           {% for doc in documents %}

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -49,13 +49,13 @@
             <div class="f2 lh-copy blue">{{ current_cluster }}</div>
             <div>{{ current_cluster_count }} Documents</div>
         </div>
-
-          {# todo: group by distinct sets of tags #}
           <ol>
           {% for doc in documents %}
               <li class="pb3">
+                {# show the first document, with tags #}
                 {% set show_tags = true %}
                 {% include "cluster_result.html" %}
+                {# if there is more than one document in this group, show all others without tags #}
                 {% if doc.tagset_s in groups %}
                 {% for group_doc in groups[doc.tagset_s]['docs'] %}
                     {# don't repeat tags, since they are the same for theg roup #}

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -58,7 +58,7 @@
 
                 <div>{{ doc.shelfmark_s }}</div>
                 <div>{{ doc.type_s }}</div>
-                <div>{{ doc.description_txt.0|truncate(150) }}</div>
+                <div>{{ doc.description_txt.0|truncate(170) }}</div>
                 <div>{% if doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}
               </li>
           {% endfor %}

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -54,27 +54,13 @@
           <ol>
           {% for doc in documents %}
               <li class="pb3">
-                <div class="pb3">
-                    <ul class="list pl0 pb2 dark-gray">
-                        {% for tag in doc.tags_ss %}
-                            <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
-                        {% endfor %}
-                    </ul>
-
-                    <div>{{ doc.shelfmark_s }}</div>
-                    <div>{{ doc.type_s }}</div>
-                    <div>{{ doc.description_txt.0|truncate(170) }}</div>
-                    <div>{% if doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}</div>
-                </div>
+                {% set show_tags = true %}
+                {% include "cluster_result.html" %}
                 {% if doc.tagset_s in groups %}
                 {% for group_doc in groups[doc.tagset_s]['docs'] %}
-                <div class="pb3">
-                    {# don't repeat tags, since they are the same #}
-                    <div>{{ group_doc.shelfmark_s }}</div>
-                    <div>{{ group_doc.type_s }}</div>
-                    <div>{{ group_doc.description_txt.0|truncate(170) }}</div>
-                    <div>{% if group_doc.transcription_txt %}<span class="green">✓</span> Transcription{% endif %}</div>
-                </div>
+                    {# don't repeat tags, since they are the same for theg roup #}
+                    {% set show_tags = false %}
+                     {% include "cluster_result.html" %}
                 {% endfor %}
                 {% endif %}
 

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -52,7 +52,7 @@
               <li class="pb3">
                 <ul class="list pl0 dark-gray">
                     {% for tag in doc.tags_ss %}
-                        <li class="di">#{{ tag }}</li>
+                        <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
                     {% endfor %}
                 </ul>
 


### PR DESCRIPTION
Expands on first topic cluster list — clusters are now clickable, and when you select one you get a list of the documents in that cluster, grouped by distinct sets of tags. 

ref #23