### PR TITLE
Experiment/search clusters

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -10,12 +10,40 @@ Run a debug server for development with:
     $ flask run
 
 '''
+from logging.config import dictConfig
+
 from flask import Flask, g, render_template, request
 from parasolr.query import SolrQuerySet
 from parasolr.solr.client import SolrClient
 
 from scripts import __version__
 from scripts import index, tei_transcriptions
+
+
+dictConfig({
+    'version': 1,
+    'formatters': {
+        'default': {
+            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+            'level': 'DEBUG',
+        },
+    },
+    'root': {
+        'level': 'INFO',
+        'handlers': ['console']
+    },
+    'parasolr': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+        'propagate': False
+    },
+})
 
 
 # create a new flask app from this module
@@ -26,14 +54,14 @@ app.config.from_pyfile('local_settings.py')
 app.cli.add_command(index.index)
 app.cli.add_command(tei_transcriptions.transcriptions)
 
+#: keyword search field query alias field syntax
+search_query = "{!dismax qf=$keyword_qf pf=$keyword_pf ps=2 v=$search_terms}"
+
 
 @app.route('/', methods=['GET'])
 def search():
     '''Search PGP records and display return a list of matching results.'''
     search_terms = request.args.get('keywords', '')
-
-    #: keyword search field query alias field syntax
-    search_query = "{!dismax qf=$keyword_qf pf=$keyword_pf ps=2 v=$search_terms}"
 
     queryset = SolrQuerySet(get_solr())
     # highlighting lines only instead of text blob; lines in full text are so
@@ -68,6 +96,9 @@ def search():
 def clusters():
     # use a facet pivot query to get tags that occur together on at
     # at least 50 documents
+
+    search_terms = request.args.get('keywords', '')
+
     sqs = SolrQuerySet(get_solr()) \
         .facet('tags_ss', pivot='tags_ss,tags_ss', **{'pivot.mincount': 50})
     facets = sqs.get_facets()
@@ -111,21 +142,34 @@ def clusters():
     clusters = sorted(clusters, key=lambda i: i['count'], reverse=True)
 
     # if a cluster is selected, find all documents
-    documents = cluster_tags = groups = None
-    if selected_cluster:
-        cluster_tags = selected_cluster.split('/')
-        # search for items that match both tags
-        # group them by distinct tag sets, and then expand
-        # to return everything in the collapsed group
-        tag_query = ' AND '.join(['"%s"' % tag for tag in cluster_tags])
-        document_sqs = SolrQuerySet(get_solr()) \
-            .filter(tags_ss='(%s)' % tag_query) \
-            .filter('{!collapse field=tagset_s }') \
-            .raw_query_parameters(
-                expand='true', **{'expand.rows': 1000})
+    documents = cluster_tags = groups = highlights = None
+    if selected_cluster or search_terms:
+        document_sqs = SolrQuerySet(get_solr())
+
+        # if search terms are present, filter by search terms
+        # configure highlighting, and order by relevance
+        if search_terms:
+            document_sqs = document_sqs.search(search_query) \
+                .raw_query_parameters(search_terms=search_terms) \
+                .highlight('transcription_lines_txt', snippets=3, method='unified') \
+                .highlight('description_txt', snippets=3, method='unified') \
+                .order_by('-score')
+
+        # otherwise get all documents for the selected cluster
+        elif selected_cluster:
+            cluster_tags = selected_cluster.split('/')
+            # search for items that match both tags
+            tag_query = ' AND '.join(['"%s"' % tag for tag in cluster_tags])
+            # group documents by distinct tag sets, and then expand
+            # to return everything in the collapsed group
+            document_sqs = document_sqs.filter(tags_ss='(%s)' % tag_query) \
+                .filter('{!collapse field=tagset_s }') \
+                .raw_query_parameters(
+                    expand='true', **{'expand.rows': 1000})
 
         documents = document_sqs.get_results(rows=1000)
         groups = document_sqs.get_expanded()
+        highlights = document_sqs.get_highlighting()
 
     return render_template(
         'clusters.html', clusters=clusters,
@@ -133,6 +177,9 @@ def clusters():
         current_cluster_count=tag_pair_counts[selected_cluster] if selected_cluster else None,
         current_tags=cluster_tags,
         documents=documents, groups=groups,
+        total=document_sqs.count(),
+        search_term=search_terms, highlights=highlights,
+        search_words=search_terms.split(),
         version=__version__, env=app.config.get('ENV', None))
 
 

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -213,7 +213,7 @@ def clusters():
         document_clusters=doc_clusters,
         total=total,
         search_term=search_terms, highlights=highlights,
-        search_words=search_terms.split(),
+        search_words=[term.lower() for term in search_terms.split()],
         version=__version__, env=app.config.get('ENV', None))
 
 

--- a/scripts/templates/cluster_result.html
+++ b/scripts/templates/cluster_result.html
@@ -3,7 +3,7 @@
     {% if show_tags %} {# only show tags if set #}
     <ul class="list pl0 pb2 dark-gray">
         {% for tag in result.tags_ss %}
-            <li class="di {% if current_tags and tag in current_tags or tag in search_words %}blue{% endif %}">#{{ tag }}</li>
+            <li class="di {% if current_tags and tag in current_tags or tag.lower() in search_words %}blue{% endif %}">#{{ tag }}</li>
         {% endfor %}
     </ul>
     {% endif %}
@@ -34,7 +34,7 @@
         <ul class="list pl0 pt1">
         {% for cluster in document_clusters[result.id] %}
             {# NOTE: designs have tag highlighted if it matches the search term; skipping for now #}
-            <li><a class="no-underline pa1 bg-lightest-blue black" href="?cluster={{ cluster.value }}">{{ cluster.label }}</a></li>
+            <li><a class="dib no-underline pa1 mb2 bg-lightest-blue black" href="?cluster={{ cluster.value }}">{{ cluster.label }}</a></li>
         {% endfor %}
         </ul>
     </div>

--- a/scripts/templates/cluster_result.html
+++ b/scripts/templates/cluster_result.html
@@ -3,13 +3,19 @@
     {% if show_tags %} {# only show tags if set #}
     <ul class="list pl0 pb2 dark-gray">
         {% for tag in result.tags_ss %}
-            <li class="di {% if tag in current_tags %}blue{% endif %}">#{{ tag }}</li>
+            <li class="di {% if current_tags and tag in current_tags or tag in search_words %}blue{% endif %}">#{{ tag }}</li>
         {% endfor %}
     </ul>
     {% endif %}
     <div>{{ result.shelfmark_s }}</div>
     <div>{{ result.type_s }}</div>
+    {# display description with highlighted search terms if available #}
+    {% set doc_highlights = highlights[result.id] if highlights and result.id in highlights %}
+    {% if doc_highlights and doc_highlights.description_txt %}
+        <div>{{ doc_highlights.description_txt.0|safe }}</div>
+    {% else %} {# otherwise, display truncated description #}
     <div>{{ result.description_txt.0|truncate(170) }}</div>
+    {% endif %}
     {% if result.transcription_txt or result.editors_txt or result.translators_txt %}
     <ul class="list pl0">
         <li class="di green">✓</li>

--- a/scripts/templates/cluster_result.html
+++ b/scripts/templates/cluster_result.html
@@ -16,11 +16,27 @@
     {% else %} {# otherwise, display truncated description #}
     <div>{{ result.description_txt.0|truncate(170) }}</div>
     {% endif %}
+    {% if doc_highlights and doc_highlights.transcription_txt %}
+        {% for transcription in doc.highlights.transcription_txt %}
+            <div>{{ transcription }}</div>
+        {% endfor %}
+    {% endif %}
     {% if result.transcription_txt or result.editors_txt or result.translators_txt %}
     <ul class="list pl0">
         <li class="di green">✓</li>
         {% if result.transcription_txt %}<li class="di pr2">Transcription</li>{% endif %}
         {% if result.editors_txt or result.translators_txt %}<li class="di pr2">Bibliography</li>{% endif %}
     </ul>
+    {% endif %}
+    {% if result.id in document_clusters %}
+    <div class="bl mt3 pl2">
+        <span class="mid-gray f6">This document appears in the following clusters</span>
+        <ul class="list pl0 pt1">
+        {% for cluster in document_clusters[result.id] %}
+            {# NOTE: designs have tag highlighted if it matches the search term; skipping for now #}
+            <li><a class="no-underline pa1 bg-lightest-blue black" href="?cluster={{ cluster.value }}">{{ cluster.label }}</a></li>
+        {% endfor %}
+        </ul>
+    </div>
     {% endif %}
 </div>

--- a/scripts/templates/clusters.html
+++ b/scripts/templates/clusters.html
@@ -7,7 +7,10 @@
     <style>
         /*input[type=text] {font-size: 16pt; width: 90%;}*/
         /* style highlights tagged by Solr */
-        em {background-color: #3DFF6A; font-weight: bold; font-style: normal; }
+        em {
+            color: #357edd;
+            font-style: normal;
+        }
 
         .transcription {
             direction: rtl;  /* assuming all for now */
@@ -26,10 +29,18 @@
 <div class="mw9 center ph3-ns">
   <div class="cf ph2-ns">
     <div class="fl w-100 w-40-ns pa2">
+        {% set form_url = "/clusters/" %}
+        {% include 'search_form.html' %}
 
+    {% if not search_term %}
     <h2>Clusters</h2>
     <p>Sorted by size</p>
+    {% else %}
+    <div class="fl w-80 pa2">Total results {{ total }} document{% if total != 1 %}s{% endif %}</div>
+    <div class="fl w-20 pa2 b">sorted by relevance</div>
+    {% endif %}
 
+    {% if not search_term %}
     <ol>
         {% for cluster in clusters %}
         <li class="pl1 pb2"><a class="dib no-underline dim black v-mid" href="?cluster={{ cluster.value }}">
@@ -40,15 +51,19 @@
         {% endfor %}
     </ol>
     </div> {# end first column #}
+    {% endif %}
 
-    {# second column, when there are documents #}
     {% if documents %}
-    <div class="fl w-100 w-60-ns pa2">
-      <div class="bl-ns bt bt-0-ns pv4">
-        <div class="pl3">
-            <div class="f2 lh-copy blue">{{ current_cluster }}</div>
-            <div>{{ current_cluster_count }} Documents</div>
-        </div>
+        {% if not search_term %}
+        {# second column, when there are documents but no search term #}
+        <div class="fl w-100 w-60-ns pa2">
+          <div class="bl-ns bt bt-0-ns pv4">
+            <div class="pl3">
+                <div class="f2 lh-copy blue">{{ current_cluster }}</div>
+                <div>{{ current_cluster_count }} Documents</div>
+            </div>
+        {% endif %}
+
           <ol>
           {% for doc in documents %}
               <li class="pb3">

--- a/scripts/templates/search_form.html
+++ b/scripts/templates/search_form.html
@@ -1,7 +1,8 @@
-<form action="/" method="get" class="pa3 black-80">
+{% set action_url = form_url or "/" %} {# use url if specified #}
+<form action="{{ action_url }}" method="get" class="pa3 black-80">
         <label for="keywords" class="f4 b db mb2">Search by keyword or phrase</label>
         <input type="text" name="keywords" size="200"
-            placeholder="search across metadata fields"
+            placeholder="search across metadata fields and transcriptions"
             value="{{ search_term }}"
             class="input-reset ba br3 ba b--black-20 pa2 mb2 db w-100 f5" type="text"/>
         <input class="br3 ba pv1 ph3" type="submit" value="Search"/>


### PR DESCRIPTION
Adds search functionality to the new cluster prototype.

Documents in sea rch results are _not_ grouped; they are displayed similar to the cluster browse view, with an indicator and link to any clusters that the document belongs to.