### PR TITLE
Make data dir configurable so it can be kept external to deploys

### DIFF
--- a/scripts/index.py
+++ b/scripts/index.py
@@ -17,9 +17,7 @@ def index():
     solr = SolrClient(current_app.config['SOLR_URL'],
                       current_app.config['SOLR_CORE'])
 
-    # get absolute path to data file relative to this script
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    data_dir = os.path.join(script_dir, '..', 'data')
+    data_dir = current_app.config['DATA_DIR']
 
     with open(os.path.join(data_dir, 'transcriptions.json')) as transcriptionsfile:
         transcriptions = json.load(transcriptionsfile)

--- a/scripts/local_settings.py.sample
+++ b/scripts/local_settings.py.sample
@@ -4,3 +4,5 @@ SOLR_URL = 'http://localhost:8983/solr/'
 SOLR_CORE = 'geniza'
 METADATA_CSV_URL = ''
 XML_TRANSCRIPTIONS_DIR = ''
+# path to data dir that includes the transcription json file
+DATA_DIR = ''

--- a/scripts/tei_transcriptions.py
+++ b/scripts/tei_transcriptions.py
@@ -34,6 +34,7 @@ class GenizaTei(teimap.Tei):
 @with_appcontext
 def transcriptions():
     xml_dir = current_app.config['XML_TRANSCRIPTIONS_DIR']
+    data_dir = current_app.config['DATA_DIR']
 
     data = {}
 
@@ -82,5 +83,6 @@ def transcriptions():
         }
         data[tei.pgpid] = docdata
 
-    with open('data/transcriptions.json', 'w') as outfile:
+    with open(os.path.join(data_dir,
+                           'transcriptions.json'), 'w') as outfile:
         json.dump(data, outfile, indent=4)


### PR DESCRIPTION
Small change to make data dir configurable instead of assuming it's local to the deploy, so we can preserve data files across deploys in qa/prod.