### PR TITLE
Basic conversion of TEI transcriptions to IIIIF annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # local settings
 scripts/local_settings.py
-data/transcriptions.json
+data/
 
 # Webpack files
 webpack-stats.json

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -54,7 +54,9 @@ def index():
         extlink = row['Link to image']
         iiif_link = None
         # cambridge iiif manifest links use the same id as view links
-        if 'cudl.lib.cam.ac.uk' in extlink:
+        # NOTE: exclude search link like this one:
+        # https://cudl.lib.cam.ac.uk/search?fileID=&keyword=T-s%2013J33.12&page=1&x=0&y=
+        if 'cudl.lib.cam.ac.uk/view/' in extlink:
             iiif_link = extlink.replace('/view/', '/iiif/')
             # view links end with /1 or /2 but iiif link does not include it
             iiif_link = re.sub(r'/\d$', '', iiif_link)

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -17,9 +17,7 @@ def index():
     solr = SolrClient(current_app.config['SOLR_URL'],
                       current_app.config['SOLR_CORE'])
 
-    # get absolute path to data file relative to this script
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    data_dir = os.path.join(script_dir, '..', 'data')
+    data_dir = current_app.config['DATA_DIR']
 
     with open(os.path.join(data_dir, 'transcriptions.json')) as transcriptionsfile:
         transcriptions = json.load(transcriptionsfile)

--- a/scripts/index.py
+++ b/scripts/index.py
@@ -2,6 +2,7 @@ import codecs
 import csv
 import json
 import os
+import re
 
 import click
 from flask import current_app
@@ -55,6 +56,8 @@ def index():
         # cambridge iiif manifest links use the same id as view links
         if 'cudl.lib.cam.ac.uk' in extlink:
             iiif_link = extlink.replace('/view/', '/iiif/')
+            # view links end with /1 or /2 but iiif link does not include it
+            iiif_link = re.sub(r'/\d$', '', iiif_link)
 
         pgpid = row['PGPID']
         text = text_blob = None

--- a/scripts/local_settings.py.sample
+++ b/scripts/local_settings.py.sample
@@ -4,3 +4,5 @@ SOLR_URL = 'http://localhost:8983/solr/'
 SOLR_CORE = 'geniza'
 METADATA_CSV_URL = ''
 XML_TRANSCRIPTIONS_DIR = ''
+# path to data dir that includes the transcription json file
+DATA_DIR = ''

--- a/scripts/local_settings.py.sample
+++ b/scripts/local_settings.py.sample
@@ -5,4 +5,5 @@ SOLR_CORE = 'geniza'
 METADATA_CSV_URL = ''
 XML_TRANSCRIPTIONS_DIR = ''
 # path to data dir that includes the transcription json file
+# NOTE: must be an absolute path for flask to serve data
 DATA_DIR = ''

--- a/scripts/tei_transcriptions.py
+++ b/scripts/tei_transcriptions.py
@@ -91,41 +91,19 @@ def transcriptions():
         json.dump(data, outfile, indent=4)
 
 
-# first pass at creating iiif annotations with tei transcriptions
-
-# - iterate over metadata csv (or use solr?)
-# - identify documents with iiif link (cudl only for now) that ALSo have a transcription
-# - generate iiif annotation list; one annotation for each block in the tei
-# - get a local copy of the iiif manifest and add the annotation list
-# - generate test mirador viewer with the manifests loaded (static? in flask?)
-
-
-annotation_list_template = {
-    "@context": "http://iiif.io/api/presentation/2/context.json",
-    "@id": "http://localhost:8003/coin/canvas/AnnotationList",
-    "@type": "sc:AnnotationList",
-    "resources": [
-        {
-            "@id": "https://images.lib.cam.ac.uk/iiif/MS-ADD-02586-000-00001.jp2",
-            "@type": "oa:Annotation",
-            "motivation": "sc:painting",
-            "resource": {
-                "@type": "cnt:ContentAsText",
-                "format": "text/html",
-                "chars": "<p style='direction:rtl'>מעידים אנו <b>חתומי</b> מטה מה שהיה בפנינו באחד בשבת יום אחד ועשרים מחדש סיון בשנת אתקמד לשטרות<br/>למניננו אשר הורגלנו למנות בו פה בפסטאט מצרים אשר על נהר נילוס היא יושבת הדרת אדוננו הנגיד<br/>הגדול מרנו ורבנו אברהם הרב המובהק [. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .]לב.[. . . . . . . . .<br/>לפנינו אלשיך אבו אלפכר הזקן היקר בן מר ורב עמרם הזקן הנכבד נע ויאמר לנו היו עלי עדים וקנו ממני<br/>בכל לשון שלזכות וכתבו וחתמו ותנו לידי בני אלשיך אבו אלפרג הזקן היקר בן מר ורב אלשיך אבו אלפכר הזקן היקר<br/>שצ להיות בידיו לראיה כי רציתי ברצון נפשי ובגמ[ר] דעתי ולא אנוס ולא שוגג ולא מוטעה כי אם בדעתי<br/>שלימה ונטלתי וקבלתי שבעה עשר דינרים זהב מצרים מידיו ומכרתי ל[ו] בעדם את רבע הדירה אשר לי בכט<br/>תגיב במצר אלדאכלה פי כוכה אלמעתמד פי אלדאר אלמ/ע/רופה  בסכן סת אלרצא הזקנה היקרה אם [אבו] אלפכר<br/>הנזכר פה מכירה גמורה שלימה וחלוטה גלויה ומפורסמת ממכר שלם אשר לא ישוב והרבע אשר<br/>מכרתי לו בכלל חלקיהם שלשותפים בדירה הזאת שאיע גיר מקסום בעומקא ורומא מתהום ארעא<br/>ועד רום רקיעא בתחתיותיה ועליותיה חדריה וחלונותיה וקירותיה ותקרותיה על ארבעת רבעיה סביב<br/>ימה וקדמה וצפונה ונגבה ומצריה וגבוליה סביב בכל זכיות אשר לד[יר]ה הזאת כאשר כתובהם בשטר<br/>ערבי הנכתב לדירה הזאת ובכללה מכרתי לבני זה אבו אלפרג את הרבע הנזכר בכל זכיות אשר בו ולא שיירתי<br/>לעצמי מן זכות רבע הזה כלום ומהיום הזה והלאה יש לזה אבו אלפרג רשות לעשות ברבע הזה אשר מכרתי<br/>לו כל מה שירצה לבנות בו ולהרוס ולהשכין ולגרש ולהחליף ולמכור ולהוריש ולתת במתנה לכל מי שירצה<br/>ואין מי שימחה בידו וכל מי שיבא מארבע רוחות העולם לערער מכחי אח או אחות קרוב או רחוק ארמ[י<br/>או יהודי יורש נכסי ופורע חובי יהיו דבריו בטלים ושבורים כשבר נבל יוצרים אשר אין לו תקנה ועלי להשתיק<br/>את כל המערער על רבע הדירה הזה הנזכר ולהעמיד הממכר הזה ביד הקונה אותו אנא איקום ואשפה<br/>ואפצה ואדכה ואמרק זביני רבעא דנן אנון ועמליהון ושבחיהון ואוקמינון בידי זבונא וצבי זבונא דנן וקביל<br/>עלוהי וקניוא מן אלשיך אבו אלפכר בכלי הכשר לקנות בו על הממכר הזה וכתבנו בשטר הזה וחתמנו בו<br/>ונתננו לידי אלשיך אבו אלפרג להיות בידיו לראייה וחומר שטר מכירה דנן כחומר כל שטרי מכירת<br/>קרקעות דנהיגי בישראל דלא כאסמכתא ודלא כטופסי דשטרי אלא כחומר וכחוזק כל שטרי מזורזי<br/>ומוחזקי בבי דינא ונהגין ישראל בהון מן קדמת דנא וקנינא מן תרויהון אכל(!) מאי דכתיב ומפרש לעילא<br/>במנא דכשר למקניא ביה בביטול כל מודעי ותנאי בלשון מעכשיו בנפש חפצה ובגמר דעת<br/>עין אלמערופה דתלי ביני שיטי דין קיומה והכל שריר ובריר מהימן וקיים<br/>אביתר הכהן בר אפרים נין  דניאל בר סעדיה . .<br/>יהוסף בית דין כהן צדק זצל  . .</p>"
-            },
-           "on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-02586/canvas/1#xywh=0,0,6324,7500"
-        }
-    ]
-}
-
-
 @click.command()
 @with_appcontext
 def transcription_iiif():
-    # xml_dir = current_app.config['XML_TRANSCRIPTIONS_DIR']
+    # first pass at creating iiif annotations with tei transcriptions
+    # (currently only for items with IIIF and transcriptions)
+
     data_dir = current_app.config['DATA_DIR']
-    # TODO: make a subdir for iiif/manifests?
+    # use a subdir for iiif manifests; make sure it exists
+    manifest_dir = os.path.join(data_dir, 'iiif', 'manifests')
+    os.makedirs(manifest_dir, exist_ok=True)
+    # and another subdir for annotations
+    annotation_dir = os.path.join(data_dir, 'iiif', 'annotations')
+    os.makedirs(annotation_dir, exist_ok=True)
 
     with open(os.path.join(data_dir, 'transcriptions.json')) as transcriptionsfile:
         transcriptions = json.load(transcriptionsfile)
@@ -133,14 +111,14 @@ def transcription_iiif():
     solr = SolrClient(current_app.config['SOLR_URL'],
                       current_app.config['SOLR_CORE'])
     # find documents that have a IIIF link that ALSO have transcription
-    iiifdocs = SolrQuerySet(solr).filter(iiif_link_s='*', transcription_txt='*')
+    iiifdocs = SolrQuerySet(solr).filter(iiif_link_s='*',
+                                         transcription_txt='*')
     print('%d documents' % iiifdocs.count())
-    for doc in iiifdocs[:3]:
-        print(doc)
+    for doc in iiifdocs[:2000]:
         # get the manifest for this document
         response = requests.get(doc['iiif_link_s'])
         if response.status_code != requests.codes.ok:
-            print('Error retrieving manifest: %s' % response)
+            print('Error retrieving manifest: %s' % doc['iiif_link_s'])
             continue
 
         manifest = response.json()
@@ -182,7 +160,8 @@ def transcription_iiif():
             annotation_list['resources'].append(annotation)
 
         # write the new annotation list to a file
-        annotation_filename = os.path.join(data_dir, '%s_annotation.json' % doc['id'])
+        base_filename = '%s.json' % doc['id']
+        annotation_filename = os.path.join(annotation_dir, base_filename)
         with open(annotation_filename, 'w') as outfile:
             json.dump(annotation_list, outfile, indent=2)
 
@@ -190,12 +169,12 @@ def transcription_iiif():
         canvas1['otherContent'] = [
             {
                 "@context": "http://iiif.io/api/presentation/2/context.json",
-                "@id": annotation_filename,  # FIXME: needs uri?
+                "@id": 'http://FLASK_URL/iiif/annotations/%s' % base_filename,
                 "@type": "sc:AnnotationList"
             }
         ]
 
-        manifest_filename = os.path.join(data_dir, '%s_manifest.json' % doc['id'])
+        # write out a local copy of the modified manifest
+        manifest_filename = os.path.join(manifest_dir, base_filename)
         with open(manifest_filename, 'w') as outfile:
             json.dump(manifest, outfile, indent=2)
-

--- a/scripts/tei_transcriptions.py
+++ b/scripts/tei_transcriptions.py
@@ -7,6 +7,9 @@ from eulxml import xmlmap
 from eulxml.xmlmap import teimap
 from flask import current_app
 from flask.cli import with_appcontext
+from parasolr.query import SolrQuerySet
+from parasolr.solr.client import SolrClient
+import requests
 
 
 class GenizaTeiLine(teimap.TeiLine):
@@ -86,3 +89,113 @@ def transcriptions():
     with open(os.path.join(data_dir,
                            'transcriptions.json'), 'w') as outfile:
         json.dump(data, outfile, indent=4)
+
+
+# first pass at creating iiif annotations with tei transcriptions
+
+# - iterate over metadata csv (or use solr?)
+# - identify documents with iiif link (cudl only for now) that ALSo have a transcription
+# - generate iiif annotation list; one annotation for each block in the tei
+# - get a local copy of the iiif manifest and add the annotation list
+# - generate test mirador viewer with the manifests loaded (static? in flask?)
+
+
+annotation_list_template = {
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "@id": "http://localhost:8003/coin/canvas/AnnotationList",
+    "@type": "sc:AnnotationList",
+    "resources": [
+        {
+            "@id": "https://images.lib.cam.ac.uk/iiif/MS-ADD-02586-000-00001.jp2",
+            "@type": "oa:Annotation",
+            "motivation": "sc:painting",
+            "resource": {
+                "@type": "cnt:ContentAsText",
+                "format": "text/html",
+                "chars": "<p style='direction:rtl'>מעידים אנו <b>חתומי</b> מטה מה שהיה בפנינו באחד בשבת יום אחד ועשרים מחדש סיון בשנת אתקמד לשטרות<br/>למניננו אשר הורגלנו למנות בו פה בפסטאט מצרים אשר על נהר נילוס היא יושבת הדרת אדוננו הנגיד<br/>הגדול מרנו ורבנו אברהם הרב המובהק [. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .]לב.[. . . . . . . . .<br/>לפנינו אלשיך אבו אלפכר הזקן היקר בן מר ורב עמרם הזקן הנכבד נע ויאמר לנו היו עלי עדים וקנו ממני<br/>בכל לשון שלזכות וכתבו וחתמו ותנו לידי בני אלשיך אבו אלפרג הזקן היקר בן מר ורב אלשיך אבו אלפכר הזקן היקר<br/>שצ להיות בידיו לראיה כי רציתי ברצון נפשי ובגמ[ר] דעתי ולא אנוס ולא שוגג ולא מוטעה כי אם בדעתי<br/>שלימה ונטלתי וקבלתי שבעה עשר דינרים זהב מצרים מידיו ומכרתי ל[ו] בעדם את רבע הדירה אשר לי בכט<br/>תגיב במצר אלדאכלה פי כוכה אלמעתמד פי אלדאר אלמ/ע/רופה  בסכן סת אלרצא הזקנה היקרה אם [אבו] אלפכר<br/>הנזכר פה מכירה גמורה שלימה וחלוטה גלויה ומפורסמת ממכר שלם אשר לא ישוב והרבע אשר<br/>מכרתי לו בכלל חלקיהם שלשותפים בדירה הזאת שאיע גיר מקסום בעומקא ורומא מתהום ארעא<br/>ועד רום רקיעא בתחתיותיה ועליותיה חדריה וחלונותיה וקירותיה ותקרותיה על ארבעת רבעיה סביב<br/>ימה וקדמה וצפונה ונגבה ומצריה וגבוליה סביב בכל זכיות אשר לד[יר]ה הזאת כאשר כתובהם בשטר<br/>ערבי הנכתב לדירה הזאת ובכללה מכרתי לבני זה אבו אלפרג את הרבע הנזכר בכל זכיות אשר בו ולא שיירתי<br/>לעצמי מן זכות רבע הזה כלום ומהיום הזה והלאה יש לזה אבו אלפרג רשות לעשות ברבע הזה אשר מכרתי<br/>לו כל מה שירצה לבנות בו ולהרוס ולהשכין ולגרש ולהחליף ולמכור ולהוריש ולתת במתנה לכל מי שירצה<br/>ואין מי שימחה בידו וכל מי שיבא מארבע רוחות העולם לערער מכחי אח או אחות קרוב או רחוק ארמ[י<br/>או יהודי יורש נכסי ופורע חובי יהיו דבריו בטלים ושבורים כשבר נבל יוצרים אשר אין לו תקנה ועלי להשתיק<br/>את כל המערער על רבע הדירה הזה הנזכר ולהעמיד הממכר הזה ביד הקונה אותו אנא איקום ואשפה<br/>ואפצה ואדכה ואמרק זביני רבעא דנן אנון ועמליהון ושבחיהון ואוקמינון בידי זבונא וצבי זבונא דנן וקביל<br/>עלוהי וקניוא מן אלשיך אבו אלפכר בכלי הכשר לקנות בו על הממכר הזה וכתבנו בשטר הזה וחתמנו בו<br/>ונתננו לידי אלשיך אבו אלפרג להיות בידיו לראייה וחומר שטר מכירה דנן כחומר כל שטרי מכירת<br/>קרקעות דנהיגי בישראל דלא כאסמכתא ודלא כטופסי דשטרי אלא כחומר וכחוזק כל שטרי מזורזי<br/>ומוחזקי בבי דינא ונהגין ישראל בהון מן קדמת דנא וקנינא מן תרויהון אכל(!) מאי דכתיב ומפרש לעילא<br/>במנא דכשר למקניא ביה בביטול כל מודעי ותנאי בלשון מעכשיו בנפש חפצה ובגמר דעת<br/>עין אלמערופה דתלי ביני שיטי דין קיומה והכל שריר ובריר מהימן וקיים<br/>אביתר הכהן בר אפרים נין  דניאל בר סעדיה . .<br/>יהוסף בית דין כהן צדק זצל  . .</p>"
+            },
+           "on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-02586/canvas/1#xywh=0,0,6324,7500"
+        }
+    ]
+}
+
+
+@click.command()
+@with_appcontext
+def transcription_iiif():
+    # xml_dir = current_app.config['XML_TRANSCRIPTIONS_DIR']
+    data_dir = current_app.config['DATA_DIR']
+    # TODO: make a subdir for iiif/manifests?
+
+    with open(os.path.join(data_dir, 'transcriptions.json')) as transcriptionsfile:
+        transcriptions = json.load(transcriptionsfile)
+
+    solr = SolrClient(current_app.config['SOLR_URL'],
+                      current_app.config['SOLR_CORE'])
+    # find documents that have a IIIF link that ALSO have transcription
+    iiifdocs = SolrQuerySet(solr).filter(iiif_link_s='*', transcription_txt='*')
+    print('%d documents' % iiifdocs.count())
+    for doc in iiifdocs[:3]:
+        print(doc)
+        # get the manifest for this document
+        response = requests.get(doc['iiif_link_s'])
+        if response.status_code != requests.codes.ok:
+            print('Error retrieving manifest: %s' % response)
+            continue
+
+        manifest = response.json()
+        # for now, assume simple structure, single sequence
+        # for now, associate the annotation with the first image
+        canvas1 = manifest['sequences'][0]['canvases'][0]
+        # need id, width, and height
+        canvas_id = canvas1['@id']
+        canvas_width = canvas1['width']
+        canvas_height = canvas1['height']
+
+        annotation_list = {
+            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "@id": "http://localhost:8003/coin/canvas/AnnotationList",
+            "@type": "sc:AnnotationList",
+            "resources": []
+        }
+
+        # for each block
+        for i, text_block in enumerate(transcriptions[doc['id']]['blocks']):
+            text_lines = '%s<br/>%s' % (text_block['label'],
+                                        '<br/>'.join(text_block['lines']))
+            annotation = {
+                # uri for this annotation; make something up
+                "@id": "https://cdh.geniza.princeton.edu/iiif/%s/list/%d" % \
+                       (doc['id'], i),
+                "@type": "oa:Annotation",
+                "motivation": "sc:painting",
+                "resource": {
+                    "@type": "cnt:ContentAsText",
+                    "format": "text/html",
+                    # language todo
+                    "chars": "<p dir='rtl'>%s</p>" % text_lines
+                },
+                # annotate the entire canvas for now
+                "on": "%s#xywh=0,0,%d,%d" % (canvas_id, canvas_width,
+                                             canvas_height)
+            }
+            annotation_list['resources'].append(annotation)
+
+        # write the new annotation list to a file
+        annotation_filename = os.path.join(data_dir, '%s_annotation.json' % doc['id'])
+        with open(annotation_filename, 'w') as outfile:
+            json.dump(annotation_list, outfile, indent=2)
+
+        # add the annotation to our copy of the manifest
+        canvas1['otherContent'] = [
+            {
+                "@context": "http://iiif.io/api/presentation/2/context.json",
+                "@id": annotation_filename,  # FIXME: needs uri?
+                "@type": "sc:AnnotationList"
+            }
+        ]
+
+        manifest_filename = os.path.join(data_dir, '%s_manifest.json' % doc['id'])
+        with open(manifest_filename, 'w') as outfile:
+            json.dump(manifest, outfile, indent=2)
+

--- a/scripts/tei_transcriptions.py
+++ b/scripts/tei_transcriptions.py
@@ -34,6 +34,7 @@ class GenizaTei(teimap.Tei):
 @with_appcontext
 def transcriptions():
     xml_dir = current_app.config['XML_TRANSCRIPTIONS_DIR']
+    data_dir = current_app.config['DATA_DIR']
 
     data = {}
 
@@ -82,5 +83,6 @@ def transcriptions():
         }
         data[tei.pgpid] = docdata
 
-    with open('data/transcriptions.json', 'w') as outfile:
+    with open(os.path.join(data_dir,
+                           'transcriptions.json'), 'w') as outfile:
         json.dump(data, outfile, indent=4)

--- a/scripts/templates/base.html
+++ b/scripts/templates/base.html
@@ -14,6 +14,7 @@
   <div class="flex-grow pa3 flex items-center">
     <a class="bg-mid-gray pa3 f6 link dib dim mr3 mr4-ns white ttu" href="/">Search</a>
     <a class="bg-mid-gray pa3 f6 link dib dim mr3 mr4-ns white ttu" href="/clusters/">Clusters</a>
+    <a class="bg-mid-gray pa3 f6 link dib dim mr3 mr4-ns white ttu" href="/iiif/">Transcriptions</a>
   </div>
 </nav>
 

--- a/scripts/templates/iiif_viewer.html
+++ b/scripts/templates/iiif_viewer.html
@@ -13,18 +13,33 @@
 
     <script type="text/javascript">
     var miradorInstance = Mirador.viewer({
-       id: 'mirador',
-       theme: {
-         transitions: window.location.port === '4488' ?  { create: () => 'none' } : {},
-       },
-       windows: [
-       { manifestId: '/data/3951_manifest.json'}
-       ],
-       catalog: [
-         { manifestId: '/data/3951_manifest.json' },
-         { manifestId: '/data/3952_manifest.json' },
-         { manifestId: '/data/3953_manifest.json' },
-       ]
+        id: 'mirador',
+        theme: {
+            transitions: window.location.port === '4488' ?  { create: () => 'none' } : {},
+        },
+        window: {
+            // open annotations by default, and set wide enough
+            // that most transcription text won't wrap
+            defaultSideBarPanel: 'annotations',
+            sideBarOpenByDefault: true,
+            defaultSidebarPanelWidth: 475,
+        },
+        // show the first manifest by default
+        // (would prefer to show catalog but can't find a config for that!)
+        windows: [
+            { manifestId: '/iiif/manifests/{{ manifests[0] }}' },
+        ],
+        catalog: [
+        {% for manifest in manifests %}
+            { manifestId: '/iiif/manifests/{{ manifest }}' },
+        {% endfor %}
+        ],
+        thumbnailNavigation: {
+            defaultPosition: 'far-right'
+        },
+        workspace: {
+            showZoomControls: true
+        }
      });
     </script>
 

--- a/scripts/templates/iiif_viewer.html
+++ b/scripts/templates/iiif_viewer.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Geniza Prototype | IIIF Transcription test{% endblock %}
+
+{% block head %}
+ {{ super() }}
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
+    <script type='text/javascript' src='https://unpkg.com/mirador@latest/dist/mirador.min.js'></script>
+{% endblock %}
+
+{% block content %}
+    <div id="mirador" style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"></div>
+
+    <script type="text/javascript">
+    var miradorInstance = Mirador.viewer({
+       id: 'mirador',
+       theme: {
+         transitions: window.location.port === '4488' ?  { create: () => 'none' } : {},
+       },
+       windows: [
+       { manifestId: '/data/3951_manifest.json'}
+       ],
+       catalog: [
+         { manifestId: '/data/3951_manifest.json' },
+         { manifestId: '/data/3952_manifest.json' },
+         { manifestId: '/data/3953_manifest.json' },
+       ]
+     });
+    </script>
+
+{% endblock %}

--- a/scripts/templates/iiif_viewer.html
+++ b/scripts/templates/iiif_viewer.html
@@ -24,11 +24,6 @@
             sideBarOpenByDefault: true,
             defaultSidebarPanelWidth: 475,
         },
-        // show the first manifest by default
-        // (would prefer to show catalog but can't find a config for that!)
-        windows: [
-            { manifestId: '/iiif/manifests/{{ manifests[0] }}' },
-        ],
         catalog: [
         {% for manifest in manifests %}
             { manifestId: '/iiif/manifests/{{ manifest }}' },
@@ -38,7 +33,9 @@
             defaultPosition: 'far-right'
         },
         workspace: {
-            showZoomControls: true
+            showZoomControls: true,
+            // show the list of loaded manifests by default
+            isWorkspaceAddVisible: true
         }
      });
     </script>


### PR DESCRIPTION
This is a basic, first-pass conversion of TEI transcriptions to IIIF annotations to help us all understand what transcriptions as annotations might look like and how they would work, and to get a better sense of how the current transcription data needs to be broken up.

Changes include:
- tweak the index script to fix the IIIF urls for Cambridge (I think they changed something recently on their end, because this was working previously)
- new script to generate iiif annotation lists for documents that have both IIIF and transcriptions (currently Cambridge only); for now, all annotations are added to the first image in the manifest and are attached to the whole page; multiple annotations are added when there are multiple blocks in the TEI document (as indicated by labels for new sections)
- new views in the flask server to serve out a mirador page that loads all the local manifests with annotations, so that the annotations created can be seen in context with the corresponding images

To try this out:
- update the index: `flask index`
- generate the transcription data file (or get a copy): `flask transcriptions`
- generate the annotation lists and local manifests: `flask transcriptions-iiif` (currently generates all 1176 of them; could set a max for testing)
- run the flask server and navigate to the transcriptions url (/iiif/); select a manifest to view the image + annotations