### PR TITLE
Add save_as feature to document model

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.db.models import Count
 
 from django.utils.html import format_html
-from django.urls import reverse
+from django.urls import reverse, resolve
 
 from geniza.corpus.models import Collection, Document, DocumentType, \
     Fragment, LanguageScript, TextBlock
@@ -99,8 +99,10 @@ class DocumentAdmin(admin.ModelAdmin):
         '''Customize this model's save_model function and then execute the
          existing admin.ModelAdmin save_model function'''
         if '_saveasnew' in request.POST:
-            # HACK: I'm having trouble finding the original ID in the given parameters. Ideas?
-            original_doc = Document.objects.get(pk=int(request.POST['textblock_set-0-document']))
+            # Get the ID from the admin URL
+            original_pk = resolve(request.path).kwargs['object_id']
+            # Get the original object
+            original_doc = obj._meta.concrete_model.objects.get(id=original_pk)
             clone_message = f'Cloned from {str(original_doc)}'
             obj.notes = obj.notes + '\n' + clone_message if obj.notes else clone_message
         super().save_model(request, obj, form, change)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -172,12 +172,12 @@ class Document(models.Model):
         ordering = ['fragments__shelfmark']
 
     def __str__(self):
-        return self.shelfmark
+        return f"{self.shelfmark} ({self.id or '??'})"
 
     def clean(self):
-        pass
-        # if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
-        #     raise ValidationError('Languages cannot be both probable and definite.')
+        if self.pk:
+            if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
+                raise ValidationError('Languages cannot be both probable and definite.')
 
     @property
     def shelfmark(self):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -175,8 +175,9 @@ class Document(models.Model):
         return self.shelfmark
 
     def clean(self):
-        if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
-            raise ValidationError('Languages cannot be both probable and definite.')
+        pass
+        # if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
+        #     raise ValidationError('Languages cannot be both probable and definite.')
 
     @property
     def shelfmark(self):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -172,12 +172,11 @@ class Document(models.Model):
         ordering = ['fragments__shelfmark']
 
     def __str__(self):
-        return f"{self.shelfmark} ({self.id or '??'})"
+        return f"{self.shelfmark or '??'} (PGPID {self.id or '??'})"
 
     def clean(self):
-        if self.pk:
-            if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
-                raise ValidationError('Languages cannot be both probable and definite.')
+        if self.pk and any([plang in self.languages.all() for plang in self.probable_languages.all()]):
+            raise ValidationError('Languages cannot be both probable and definite.')
 
     @property
     def shelfmark(self):

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -69,4 +69,4 @@ class TestDocumentAdmin(TestCase):
         assert Document.objects.count() == 2
         original_id = doc.id
         cloned_doc = Document.objects.exclude(pk=original_id).first()
-        assert 'Cloned from CUL 123' in cloned_doc.notes
+        assert f'Cloned from CUL 123 ({doc.id})' in cloned_doc.notes

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -1,8 +1,10 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.contrib import admin
+from django.urls import reverse
+from django.forms import modelform_factory
 
-from geniza.corpus.models import LanguageScript, Document
-from geniza.corpus.admin import LanguageScriptAdmin
+from geniza.corpus.models import LanguageScript, Document, Fragment
+from geniza.corpus.admin import LanguageScriptAdmin, DocumentAdmin
 
 
 class TestLanguageScriptAdmin(TestCase):
@@ -45,3 +47,26 @@ class TestLanguageScriptAdmin(TestCase):
         french_probable_link = lang_admin.probable_documents(qs.get(language='French'))
         assert f'?probable_languages__id__exact={french.pk}' in french_probable_link
         assert '1</a>' in french_probable_link
+
+
+class TestDocumentAdmin(TestCase):
+    def test_save_model(self):
+        '''Ensure that save_as creates a new document and appends a note'''
+        fragment = Fragment.objects.create(shelfmark='CUL 123')
+        doc = Document.objects.create()
+        doc.fragments.add(fragment)
+
+        request_factory = RequestFactory()
+        url = reverse('admin:corpus_document_change', args=(doc.id,))
+        request = request_factory.post(url, data={'_saveasnew': 'Save as new'})
+        DocumentForm = modelform_factory(Document, exclude=[])
+        form = DocumentForm(doc)
+
+        doc_admin = DocumentAdmin(model=Document, admin_site=admin.site)
+        new_doc = Document.objects.create()
+        response = doc_admin.save_model(request, new_doc, form, False)
+
+        assert Document.objects.count() == 2
+        original_id = doc.id
+        cloned_doc = Document.objects.exclude(pk=original_id).first()
+        assert 'Cloned from CUL 123' in cloned_doc.notes

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -54,7 +54,7 @@ class TestDocumentAdmin(TestCase):
     def test_save_model(self):
         '''Ensure that save_as creates a new document and appends a note'''
         fragment = Fragment.objects.create(shelfmark='CUL 123')
-        doc = Document.objects.create(notes='Test note')
+        doc = Document.objects.create()
         doc.fragments.add(fragment)
 
         request_factory = RequestFactory()
@@ -72,8 +72,10 @@ class TestDocumentAdmin(TestCase):
         new_doc = Document.objects.create()
         response = doc_admin.save_model(request, new_doc, form, False)
 
+        # add notes to test existing notes are preserved
         assert Document.objects.count() == 2
-        original_id = doc.id
-        cloned_doc = Document.objects.exclude(pk=original_id).first()
-        assert f'Cloned from {str(doc)}' in cloned_doc.notes
-        assert 'Test note' in cloned_doc.notes
+        new_doc.notes = 'Test note'
+        new_doc.save()
+        response = doc_admin.save_model(request, new_doc, form, False)
+        assert f'Cloned from {str(doc)}' in new_doc.notes
+        assert 'Test note' in new_doc.notes

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -69,4 +69,4 @@ class TestDocumentAdmin(TestCase):
         assert Document.objects.count() == 2
         original_id = doc.id
         cloned_doc = Document.objects.exclude(pk=original_id).first()
-        assert f'Cloned from CUL 123 ({doc.id})' in cloned_doc.notes
+        assert f'Cloned from {str(doc)}' in cloned_doc.notes

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -139,7 +139,10 @@ class TestDocument:
         frag = Fragment.objects.create(shelfmark='Or.1081 2.25')
         doc = Document.objects.create()
         doc.fragments.add(frag)
-        assert str(doc) == doc.shelfmark
+        assert doc.shelfmark in str(doc) and str(doc.id) in str(doc)
+
+        unsaved_doc = Document()
+        assert str(unsaved_doc) == ' (??)'
 
     def test_collection(self):
         # T-S 8J22.21 + T-S NS J193
@@ -213,6 +216,10 @@ class TestDocument:
         doc.probable_languages.add(lang)
         with pytest.raises(ValidationError):
             doc.clean()
+
+        # ensure unsaved documents doesn't raise an error
+        unsaved_doc = Document()
+        unsaved_doc.clean()
 
 
 @pytest.mark.django_db

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -142,7 +142,7 @@ class TestDocument:
         assert doc.shelfmark in str(doc) and str(doc.id) in str(doc)
 
         unsaved_doc = Document()
-        assert str(unsaved_doc) == ' (??)'
+        assert str(unsaved_doc) == '?? (PGPID ??)'
 
     def test_collection(self):
         # T-S 8J22.21 + T-S NS J193


### PR DESCRIPTION
Customize this model's save_model function and then execute the existing admin.ModelAdmin save_model function. Borrows from existing the `save_as` functionality.

**Questions**
* I can't grab the original document object from the save_as request, any ideas? (`obj` is the new object, its pk is None)
* How would I go about testing this?