### PR TITLE
Revise document/fragment admin

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -132,8 +132,8 @@ class FragmentAdmin(admin.ModelAdmin):
     readonly_fields = ('old_shelfmarks', 'created', 'last_modified',)
     list_filter = (
         'collection',
-        ('multifragment', admin.BooleanFieldListFilter),
-        ('url', admin.BooleanFieldListFilter),
+        ('multifragment', admin.EmptyFieldListFilter),
+        ('url', admin.EmptyFieldListFilter),
     )
     list_editable = ('url',)
     fields = (

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -3,7 +3,6 @@ from django.utils.safestring import mark_safe
 from piffle.image import IIIFImageClient
 from piffle.presentation import IIIFPresentation
 from taggit.managers import TaggableManager
-from django.core.exceptions import ValidationError
 
 
 class CollectionManager(models.Manager):
@@ -155,8 +154,9 @@ class Document(models.Model):
     languages = models.ManyToManyField(LanguageScript, blank=True)
     probable_languages = models.ManyToManyField(
         LanguageScript, blank=True, related_name='probable_document',
-        limit_choices_to=~models.Q(language='Unknown'))
-    language_note = models.TextField(blank=True, help_text='Notes on diacritics, vocalisation, etc.')
+        limit_choices_to=~models.Q(language__exact='Unknown'))
+    language_note = models.TextField(
+        blank=True, help_text='Notes on diacritics, vocalisation, etc.')
     # TODO footnotes for edition/translation
     notes = models.TextField(blank=True)
     old_input_by = models.CharField(
@@ -173,10 +173,6 @@ class Document(models.Model):
 
     def __str__(self):
         return self.shelfmark
-
-    def clean(self):
-        if any([plang in self.languages.all() for plang in self.probable_languages.all()]):
-            raise ValidationError('Languages cannot be both probable and definite.')
 
     @property
     def shelfmark(self):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -3,8 +3,6 @@ from unittest.mock import patch
 from attrdict import AttrDict
 from django.utils.safestring import SafeString
 import pytest
-from django.core.exceptions import ValidationError
-from django.db.utils import IntegrityError
 
 from geniza.corpus.models import Collection, Document, DocumentType, \
     Fragment, LanguageScript, TextBlock
@@ -202,17 +200,6 @@ class TestDocument:
         assert 'women' in tag_list
         assert 'marriage' in tag_list
         assert ', ' in tag_list
-
-    def test_clean(self):
-        doc = Document.objects.create()
-        lang = LanguageScript.objects \
-            .create(language='Judaeo-Arabic', script='Hebrew')
-        doc.languages.add(lang)
-        doc.clean()  # Shouldn't error when not duplicated
-
-        doc.probable_languages.add(lang)
-        with pytest.raises(ValidationError):
-            doc.clean()
 
 
 @pytest.mark.django_db

--- a/geniza/templates/admin/corpus/fragment/change_form.html
+++ b/geniza/templates/admin/corpus/fragment/change_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript" id="embedUV" src="http://universalviewer.io/uv/lib/embed.js"></script>
+<script type="text/javascript" id="embedUV" src="https://universalviewer.io/uv/lib/embed.js"></script>
 {% endblock %}
 
 {% block field_sets %}


### PR DESCRIPTION
- shift `Document` language/probable language validation to admin `DocumentForm` because model `clean` method is insufficient
- configure language and probable languages as autocomplete instead of horizontal filter, to decrease space
- add validation to disallow unknown set as probable language, since admin autocomplete does not honor `limit_choices_to`
- use `EmptyFieldListFilter` instead of `BooleanFieldListFilter` for text field filters (multifragment & url)
- use https to load universalviewer script 