### PR TITLE
Add first input and last revised dates to Document admin

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -143,34 +143,6 @@ class DocumentAdmin(admin.ModelAdmin):
             .annotate(shelfmk_all=ArrayAgg('textblock__fragment__shelfmark')) \
             .order_by('shelfmk_all')
 
-    def change_view(self, request, **kwargs):
-        """Add this document's first and last log entries to context.
-        
-        If there was a legacy date included in the log entry, show that info
-        instead of the timestamp of the entry itself.
-        """
-
-        # get first/last log entries; we want the reverse of their default
-        # ordering which is chronological descending
-        obj = Document.objects.get(pk=kwargs["object_id"])
-        first_input = obj.log_entries.last()
-        last_revision = obj.log_entries.first()
-
-        # check for "dated " message in the log entry and add legacy date.
-        # template will use the actual timestamp as a fallback if no legacy date
-        for log in first_input, last_revision:
-            try:
-                log.legacy_date = log.get_change_message().split("dated ")[1]
-            except IndexError:
-                continue
-
-        # add to context & return
-        kwargs["extra_context"] = {
-            "first_input": first_input,  
-            "last_revision": last_revision
-        }
-        return super().change_view(request, **kwargs)
-
     def save_model(self, request, obj, form, change):
         '''Customize this model's save_model function and then execute the
          existing admin.ModelAdmin save_model function'''

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -124,7 +124,6 @@ class DocumentAdmin(admin.ModelAdmin):
         # edition, translation
         'notes',
         # text block
-        ('created', 'last_modified')
     )
     autocomplete_fields = ['languages', 'probable_languages']
     # NOTE: autocomplete does not honor limit_choices_to in model
@@ -143,6 +142,34 @@ class DocumentAdmin(admin.ModelAdmin):
             .prefetch_related('tags', 'languages', 'textblock_set')  \
             .annotate(shelfmk_all=ArrayAgg('textblock__fragment__shelfmark')) \
             .order_by('shelfmk_all')
+
+    def change_view(self, request, **kwargs):
+        """Add this document's first and last log entries to context.
+        
+        If there was a legacy date included in the log entry, show that info
+        instead of the timestamp of the entry itself.
+        """
+
+        # get first/last log entries; we want the reverse of their default
+        # ordering which is chronological descending
+        obj = Document.objects.get(pk=kwargs["object_id"])
+        first_input = obj.log_entries.last()
+        last_revision = obj.log_entries.first()
+
+        # check for "dated " message in the log entry and add legacy date.
+        # template will use the actual timestamp as a fallback if no legacy date
+        for log in first_input, last_revision:
+            try:
+                log.legacy_date = log.get_change_message().split("dated ")[1]
+            except IndexError:
+                continue
+
+        # add to context & return
+        kwargs["extra_context"] = {
+            "first_input": first_input,  
+            "last_revision": last_revision
+        }
+        return super().change_view(request, **kwargs)
 
     def save_model(self, request, obj, form, change):
         '''Customize this model's save_model function and then execute the

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.db.models.functions import Concat
+from django.contrib.admin.models import LogEntry
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.utils.safestring import mark_safe
@@ -215,6 +216,7 @@ class Document(models.Model):
         help_text='Decide whether a document should be publicly visible')
 
     footnotes = GenericRelation(Footnote)
+    log_entries = GenericRelation(LogEntry, related_query_name="document")
 
     # NOTE: default ordering disabled for now because it results in duplicates
     # in django admin; see admin for ArrayAgg sorting solution

--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -3,12 +3,15 @@
 <fieldset class="module aligned">
     <div class="form-row">
         <div class="fieldBox">
-            <label>First input:</label>
-            {% include "admin/corpus/document/rev_log_entry.html" with log_entry=first_input %}
+            <label>Initial entry</label>
+            {% include "admin/corpus/document/log_entry.html" with log_entry=original.log_entries.last %}
+            <a href="{% url "admin:corpus_document_history" object_id=original.pk %}">view full history</a>
         </div>
+    </div>
+    <div class="form-row">
         <div class="fieldBox">
-            <label>Last revision:</label>
-            {% include "admin/corpus/document/rev_log_entry.html" with log_entry=last_revision %}
+            <label>Latest revision</label>
+            {% include "admin/corpus/document/log_entry.html" with log_entry=original.log_entries.first %}
         </div>
     </div>
 </fieldset>

--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% block after_field_sets %}
+<fieldset class="module aligned">
+    <div class="form-row">
+        <div class="fieldBox">
+            <label>First input:</label>
+            {% include "admin/corpus/document/rev_log_entry.html" with log_entry=first_input %}
+        </div>
+        <div class="fieldBox">
+            <label>Last revision:</label>
+            {% include "admin/corpus/document/rev_log_entry.html" with log_entry=last_revision %}
+        </div>
+    </div>
+</fieldset>
+{% endblock %}

--- a/geniza/corpus/templates/admin/corpus/document/log_entry.html
+++ b/geniza/corpus/templates/admin/corpus/document/log_entry.html
@@ -1,0 +1,6 @@
+{% load humanize %}
+<div class="readonly">
+    <span class="action-time">{{ log_entry.action_time|naturalday }}</span>
+    <span class="action-user">{% if log_entry.user.get_full_name %}{{ log_entry.user.get_full_name }}{% else %}{{ log_entry.user.get_username }}{% endif %}</span>
+    <span class="action-msg">{{ log_entry.get_change_message }}</span>
+</div>

--- a/geniza/corpus/templates/admin/corpus/document/rev_log_entry.html
+++ b/geniza/corpus/templates/admin/corpus/document/rev_log_entry.html
@@ -1,0 +1,4 @@
+<div class="readonly">
+<time>{% if log_entry.legacy_date %}{{ log_entry.legacy_date }}{% else %}{{ log_entry.action_time|date:"DATETIME_FORMAT" }}{% endif %}</time>
+<span class="author">by {% if log_entry.user.get_full_name %}{{ log_entry.user.get_full_name }}{% else %}{{ log_entry.user.get_username }}{% endif %}</span>
+</div>

--- a/geniza/corpus/templates/admin/corpus/document/rev_log_entry.html
+++ b/geniza/corpus/templates/admin/corpus/document/rev_log_entry.html
@@ -1,4 +1,0 @@
-<div class="readonly">
-<time>{% if log_entry.legacy_date %}{{ log_entry.legacy_date }}{% else %}{{ log_entry.action_time|date:"DATETIME_FORMAT" }}{% endif %}</time>
-<span class="author">by {% if log_entry.user.get_full_name %}{{ log_entry.user.get_full_name }}{% else %}{{ log_entry.user.get_username }}{% endif %}</span>
-</div>

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -21,3 +21,8 @@ th.column-documents, th.column-probable_documents {
 .field-doc_relation li {
 	list-style-type: none;
 }
+
+/* make first/last revision dates look like actual fields */
+.module + .module {
+	margin-top: -30px;
+}

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -26,3 +26,8 @@ th.column-documents, th.column-probable_documents {
 .module + .module {
 	margin-top: -30px;
 }
+
+/* customize display of first/last revision info */
+.action-time::after { content: ", by "}
+.action-user::after { content: " — "}
+.action-msg { font-style: italic; }


### PR DESCRIPTION
- Adds new admin templates for displaying data after fields
- Adds convenience field to Document to get its log entries
- Adds first/last log entries to admin context with legacy dates

See #112

no tests yet; opening draft to check the approach – it seems to be working for me locally
