### PR TITLE
Stub FragmentTextBlockInline

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -16,15 +16,20 @@ from geniza.footnotes.admin import FootnoteInline
 class FragmentTextBlockInline(admin.TabularInline):
     '''The TextBlockInline class for the Fragment admin'''
     model = TextBlock
-    fields = ('document', 'side', 'extent_label', 'document_link') # document_link
-    readonly_fields = ('document', 'document_link')  # 'document__description')
+    fields = ('document_link',  'document_description', 'side', 'extent_label',)
+    readonly_fields = ('document_link', 'document_description')
     extra = 0
 
     def document_link(self, obj):
-        document_path = reverse('admin:corpus_document_change', args=[obj.document])
+        document_path = reverse('admin:corpus_document_change', args=[obj.document.id])
         return format_html(
             f'<a href="{document_path}">{str(obj.document)}</a>'
         )
+    document_link.short_description = 'Document'
+
+    def document_description(self, obj):
+        return obj.document.description
+    
 
 
 @admin.register(Collection)

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -13,6 +13,20 @@ from geniza.corpus.models import Collection, Document, DocumentType, \
 from geniza.footnotes.admin import FootnoteInline
 
 
+class FragmentTextBlockInline(admin.TabularInline):
+    '''The TextBlockInline class for the Fragment admin'''
+    model = TextBlock
+    fields = ('document', 'side', 'extent_label') # document_link
+    readonly_fields = ('document', )  # 'document__description')
+    extra = 0
+
+    def document_link(self, obj):
+        document_path = reverse('admin:corpus_document_change', args=[obj.id])
+        return format_html(
+            f'<a href="{document_path}">{str(obj)}</a>'
+        )
+
+
 @admin.register(Collection)
 class CollectionAdmin(admin.ModelAdmin):
     list_display = ('library', 'name', 'lib_abbrev', 'abbrev', 'location')
@@ -58,7 +72,8 @@ class LanguageScriptAdmin(admin.ModelAdmin):
     probable_documents.admin_order_field = 'probable_document__count'
 
 
-class TextBlockInline(admin.TabularInline):
+class DocumentTextBlockInline(admin.TabularInline):
+    '''The TextBlockInline class for the Document admin'''
     model = TextBlock
     autocomplete_fields = ['fragment']
     readonly_fields = ('thumbnail', )
@@ -128,7 +143,7 @@ class DocumentAdmin(admin.ModelAdmin):
     autocomplete_fields = ['languages', 'probable_languages']
     # NOTE: autocomplete does not honor limit_choices_to in model
     inlines = [
-        TextBlockInline,
+        DocumentTextBlockInline,
         FootnoteInline
     ]
 
@@ -178,6 +193,7 @@ class FragmentAdmin(admin.ModelAdmin):
         ('url', admin.EmptyFieldListFilter),
         ('needs_review', admin.EmptyFieldListFilter)
     )
+    inlines = [FragmentTextBlockInline]
     list_editable = ('url',)
     fields = (
         ('shelfmark', 'old_shelfmarks'),

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -16,14 +16,14 @@ from geniza.footnotes.admin import FootnoteInline
 class FragmentTextBlockInline(admin.TabularInline):
     '''The TextBlockInline class for the Fragment admin'''
     model = TextBlock
-    fields = ('document', 'side', 'extent_label') # document_link
-    readonly_fields = ('document', )  # 'document__description')
+    fields = ('document', 'side', 'extent_label', 'document_link') # document_link
+    readonly_fields = ('document', 'document_link')  # 'document__description')
     extra = 0
 
     def document_link(self, obj):
-        document_path = reverse('admin:corpus_document_change', args=[obj.id])
+        document_path = reverse('admin:corpus_document_change', args=[obj.document])
         return format_html(
-            f'<a href="{document_path}">{str(obj)}</a>'
+            f'<a href="{document_path}">{str(obj.document)}</a>'
         )
 
 


### PR DESCRIPTION
Problems so far: 
* Selecting `document__description` raises an error, but `document` doesn't. Why is that?
* I've created a method `document_link` so that the read-only field links to the change page for that document, but I can't reference it in the inline. Can you not define new methods for inlines?