### PR TITLE
Improve inline editing UI for footnotes

### DIFF
--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -22,6 +22,18 @@ th.column-documents, th.column-probable_documents {
 	list-style-type: none;
 }
 
+/* align gfklookup magnifying glass with footnote field */
+.field-object_id {
+	position: relative;
+	padding-left: 24px;
+}
+.gfklookup {
+	position: absolute;
+	bottom: 16px;
+	left: 0;
+	cursor: pointer;
+}
+
 /* make first/last revision dates look like actual fields */
 .module + .module {
 	margin-top: -30px;


### PR DESCRIPTION
Some small changes to make the footnote inlines on both `Document` and `Source` a little easier to use.

- Remove `FootnoteInline` since it's been split into `SourceFootnoteInline` and `DocumentFootnoteInline`
- Re-add digitized transcription indicator to both inlines
- Tweak field sizing, order, and CSS so that inlines fit the screen width

Screenshot of source footnote inline:
<img width="1341" alt="Screen Shot 2021-05-14 at 3 21 01 PM" src="https://user-images.githubusercontent.com/4924494/118318908-07aa6b00-b4c8-11eb-894a-1bc3d0d09b5b.png">

Screenshot of document footnote inline:
<img width="1354" alt="Screen Shot 2021-05-14 at 3 22 09 PM" src="https://user-images.githubusercontent.com/4924494/118319010-2872c080-b4c8-11eb-8cd0-317d09ad4277.png">
