### PR TITLE
Revise old pgp csv metadata view; add prefetching, tweak output #107

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -329,7 +329,8 @@ class Document(ModelIndexable):
         return " + ".join(
             dict.fromkeys(
                 block.fragment.shelfmark
-                for block in self.textblock_set.filter(certain=True)
+                for block in self.textblock_set.all()
+                if block.certain  # filter locally instead of in the db
             )
         )
 

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -148,6 +148,8 @@ class Source(models.Model):
             parts.append(self.volume)
         if self.year:
             parts.append("(%d)" % self.year)
+        if self.other_info:
+            parts.append(self.other_info)
 
         # title, journal, etc should be joined by spaces only
         ref = " ".join(parts)
@@ -219,25 +221,23 @@ class Footnote(models.Model):
     has_transcription.boolean = True
     has_transcription.admin_order_field = "content"
 
-
     def display(self):
-        # TODO: Should source be a required field?
+        """format footnote for display; used on document detail page
+        and metdata export for old pgp site"""
         # source, location. notes
         # source. notes
         # source, location.
-        return_str = str(self.source)
+        parts = [str(self.source)]
         if self.location:
-            return_str += f", {self.location}"
-        return_str += "."
+            parts.extend([", ", self.location])
+        parts.append(".")
         if self.notes:
-            return_str += f" {self.notes}"
-        return return_str
+            parts.extend([" ", self.notes])
+        return "".join(parts)
 
-      
     def has_url(self):
         """Admin display field indicating if footnote has a url."""
         return bool(self.url)
 
     has_url.boolean = True
     has_url.admin_order_field = "url"
-

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -106,12 +106,12 @@ class TestFootnote:
         footnote = Footnote(source=source)
         assert footnote.display() == "Orwell, A Nice Cup of Tea."
 
-        footnote.location = "Cambridge"
-        assert footnote.display() == "Orwell, A Nice Cup of Tea, Cambridge."
+        footnote.location = "p. 55"
+        assert footnote.display() == "Orwell, A Nice Cup of Tea, p. 55."
 
-        footnote.notes = "Please review."
+        footnote.notes = "With minor edits."
         assert (
-            footnote.display() == "Orwell, A Nice Cup of Tea, Cambridge. Please review."
+            footnote.display() == "Orwell, A Nice Cup of Tea, p. 55. With minor edits."
         )
 
     @pytest.mark.django_db


### PR DESCRIPTION
- added prefetching to make the download generate faster
- renamed some of the methods to make the names more accurate/specific, and make it clearer they are associated with the old pgp metadata export
- adjusted the output of some of the fields to better match what I expected the content to be (my fault for not documenting more clearly and not catching in review)