### PR TITLE
Include footnote url in document and source inlines

### DIFF
--- a/geniza/footnotes/admin.py
+++ b/geniza/footnotes/admin.py
@@ -2,12 +2,12 @@ from adminsortable2.admin import SortableInlineAdminMixin
 from django import forms
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
-from django.contrib.contenttypes.admin import GenericTabularInline
+from django.contrib.contenttypes.admin import GenericTabularInline, GenericStackedInline
 from django.db import models
 from django.db.models import Count
-from django.db.models.fields import CharField, TextField
+from django.db.models.fields import CharField, TextField, URLField
 from django.db.models.functions import Concat
-from django.forms.widgets import TextInput, Textarea
+from django.forms.widgets import TextInput, Textarea, URLInput
 from django.urls import reverse
 from django.utils.html import format_html
 from modeltranslation.admin import TabbedTranslationAdmin
@@ -38,15 +38,16 @@ class SourceFootnoteInline(admin.TabularInline):
         "object_link",
         "content_type",
         "object_id",
-        "location",
         "doc_relation",
+        "location",
         "has_transcription",
         "notes",
+        "url",
     )
     readonly_fields = ("object_link", "has_transcription")
     formfield_overrides = {
         CharField: {"widget": TextInput(attrs={"size": "10"})},
-        TextField: {"widget": Textarea(attrs={"rows": 3})},
+        TextField: {"widget": Textarea(attrs={"rows": 4})},
     }
 
     def object_link(self, obj):
@@ -75,16 +76,17 @@ class DocumentFootnoteInline(GenericTabularInline):
     autocomplete_fields = ["source"]
     fields = (
         "source",
-        "location",
         "doc_relation",
-        "has_transcription",
+        "location",
         "notes",
+        "has_transcription",
+        "url",
     )
     readonly_fields = ("has_transcription",)
     extra = 1
     formfield_overrides = {
         CharField: {"widget": TextInput(attrs={"size": "10"})},
-        TextField: {"widget": Textarea(attrs={"rows": 3})},
+        TextField: {"widget": Textarea(attrs={"rows": 4})},
     }
 
 

--- a/geniza/footnotes/migrations/0009_add_source_journal_and_footnote_url.py
+++ b/geniza/footnotes/migrations/0009_add_source_journal_and_footnote_url.py
@@ -14,7 +14,10 @@ class Migration(migrations.Migration):
             model_name="footnote",
             name="url",
             field=models.URLField(
-                blank=True, help_text="Link to the source (optional)", max_length=300
+                "URL",
+                blank=True,
+                help_text="Link to the source (optional)",
+                max_length=300,
             ),
         ),
         migrations.AddField(

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -193,7 +193,7 @@ class Footnote(models.Model):
         blank=True, null=True, help_text="Transcription content (preliminary)"
     )
     url = models.URLField(
-        blank=True, max_length=300, help_text="Link to the source (optional)"
+        "URL", blank=True, max_length=300, help_text="Link to the source (optional)"
     )
 
     # Generic relationship

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -50,3 +50,9 @@ th.column-documents, th.column-probable_documents {
 	margin-right: auto;
 }
 .transcription h3 { text-align: left; }
+
+
+/* keep document relationship choices labels in line with checkboxes */
+.field-doc_relation {
+	white-space: nowrap;
+}


### PR DESCRIPTION
@richmanrachel I'm adding url as an editable field to the inlines on document and source pages

Here's how it looks on the document edit page:
![Screen Shot 2021-05-25 at 12 01 49 PM](https://user-images.githubusercontent.com/691231/119530609-2c68d300-bd51-11eb-8af2-d552d0f810ed.png)

And here's how it looks on the source edit page:
![Screen Shot 2021-05-25 at 12 01 41 PM](https://user-images.githubusercontent.com/691231/119530631-2ffc5a00-bd51-11eb-870a-bdcc5bce9395.png)

Do these look ok? 