### PR TITLE
Include old PGPIDs in solr index data and add to default search fields

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -445,7 +445,8 @@ class Document(ModelIndexable):
                 "needs_review_t": self.needs_review,
                 "shelfmark_ss": [f.shelfmark for f in self.fragments.all()],
                 "tags_ss": [t.name for t in self.tags.all()],
-                "status_s": self.get_status_display()
+                "status_s": self.get_status_display(),
+                "old_pgpids_is": self.old_pgpids,
                 # TODO: editors/translators/sources
             }
         )

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -18,7 +18,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "notes": "notes_t",
         "needs_review": "needs_review_t",
         "pgpid": "pgpid_i",
-        "old_pgpids": "old_pgpid_i",
+        "old_pgpids": "old_pgpid_is",
     }
 
     # (adapted from mep)

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -18,6 +18,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "notes": "notes_t",
         "needs_review": "needs_review_t",
         "pgpid": "pgpid_i",
+        "old_pgpids": "old_pgpid_i",
     }
 
     # (adapted from mep)

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -410,6 +410,7 @@ class TestDocument:
         for tag in document.tags.all():
             assert tag.name in index_data["tags_ss"]
         assert index_data["status_s"] == "Public"
+        assert not index_data["old_pgpids_is"]
 
         # suppressed documents are still indexed,
         # since they need to be searchable in admin
@@ -418,6 +419,11 @@ class TestDocument:
         assert index_data["id"] == document.index_id()
         assert "item_type_s" in index_data
         assert index_data["status_s"] == "Suppressed"
+
+        # add old pgpids
+        document.old_pgpids = [12345, 9876]
+        index_data = document.index_data()
+        assert index_data["old_pgpids_is"] == [12345, 9876]
 
 
 @pytest.mark.django_db

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -744,10 +744,10 @@
         editors_t
         translators_t
         transcription_t
+        old_pgpid_is
       </str>
       <str name="keyword_pf">
         description_t
-        pgpid_i
         type_s
         library_s
         shelfmark_t
@@ -770,6 +770,7 @@
         notes_t
         needs_review_t
         pgpid_i
+        old_pgpid_is
       </str>
       <str name="admin_doc_pf">
         shelfmark_t


### PR DESCRIPTION
I haven't tested locally by updating my configset and reindexing (and don't have any records with old pgpids yet to test with), but I think this should do what we need.