### PR TITLE
feature/scholarship records

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -451,6 +451,14 @@ class Document(ModelIndexable):
             )
         )
 
+    def fragment_urls(self):
+        """List of external URLs to view the Document's Fragments."""
+        return list(
+            dict.fromkeys(
+                filter(None, [b.fragment.url for b in self.textblock_set.all()])
+            )
+        )
+
     def has_transcription(self):
         """Admin display field indicating if document has a transcription."""
         return any(note.has_transcription() for note in self.footnotes.all())

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -9,8 +9,10 @@
 {% endblock extrahead %}
 
 {% block main %}
+<!-- document details -->
 <div class="container">
     <h1>{{ document.title }}</h1>
+    {% include "corpus/snippets/document_tabs.html" %}
     <dl>
         <dt class="sr-only">{% translate 'Shelfmark' %}</dt>
         <dd>{{ document.shelfmark }}</dd>
@@ -18,12 +20,11 @@
         <dt class="sr-only">{% translate 'Document Type' %}</dt>
         <dd>{{ document.doctype }}</dd>
         {% endif %}
-        {% comment %}Translators: Date document was first added to the PGP{% endcomment %}
+        {# Translators: Date document was first added to the PGP #}
         <dt class="inline">{% translate 'Input date' %}</dt>
         <dd>{{ document.log_entries.last.action_time.year }}</dd>
-
         {% if document.editions %}
-        {% comment %}Translators: Editor label{% endcomment %}
+        {# Translators: Editor label #}
         <dt>{% translate 'Editor' %}</dt>  {# optionally pluralize? #}
         {% for ed in document.editions %}
         <dd>{{ ed.display }}</dd>

--- a/geniza/corpus/templates/corpus/document_scholarship.html
+++ b/geniza/corpus/templates/corpus/document_scholarship.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% load static i18n %}
+
+{% block title %}{{ document.title }}{% endblock title %}
+
+{% block main %}
+<!-- document scholarship records -->
+<div class="container">
+    <h1>{{ document.title }}</h1>
+    {% include "corpus/snippets/document_tabs.html" %}
+    <ol>
+        {% for fn in document.footnotes.all %}
+        {% spaceless %}
+        <li><p class="footnote">
+        {% if fn.source.title %}<span class="title">{{ fn.source.title }}</span>{% endif %}
+        {% if fn.source.authors.exists %}<span class="author">{{ fn.source.all_authors }}</span>{% endif %}
+        {% if fn.source.year %}<span class="year">{{ fn.source.year }}</span>{% endif %}
+        <span class="relation">{{ fn.doc_relation }}</span>
+        {% if fn.location %}<span class="location">{{ fn.location }}</span>{% endif %}
+        {% if fn.url %}<a href="{{ fn.url }}">{% translate "Link to source" %}</a>{% endif %}
+        </p></li>
+        {% endspaceless %}
+        {% endfor %}
+    </ol>
+</div>
+{% endblock main %}

--- a/geniza/corpus/templates/corpus/snippets/document_tabs.html
+++ b/geniza/corpus/templates/corpus/snippets/document_tabs.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<!-- document detail page navigation -->
+<nav aria-label="tabs">
+    <ul>
+        <li><a href="{% url 'corpus:document' pk=document.pk %}">{% translate "Document Details" %}</a></li>
+        {% with n_records=document.footnotes.count %}
+        {# Translators: n_records is number of scholarship records #}
+        {% blocktranslate asvar srec_text %}Scholarship Records ({{ n_records }}){% endblocktranslate %}
+        <li>{% if n_records > 0 %}<a href="{% url 'corpus:document-scholarship' pk=document.pk %}">{{ srec_text }}</a>{% else %}<span>{{ srec_text }}</span>{% endif %}</li>
+        {% endwith %}
+        {% with n_links=document.fragment_urls|length %}
+        {# Translators: n_links is number of external links #}
+        {% blocktranslate asvar elink_text %}External Links ({{ n_links }}){% endblocktranslate %}
+        <li>{% if n_links > 0 %}<a>{{ elink_text }}</a>{% else %}<span>{{ elink_text }}</span>{% endif %}</li>
+        {% endwith %}
+    </ul>
+</nav>

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -329,6 +329,27 @@ class TestDocument:
         frag2.delete()
         assert doc.iiif_urls() == []
 
+    def test_fragment_urls(self):
+        # create example doc with two fragments with URLs
+        doc = Document.objects.create()
+        frag = Fragment.objects.create(shelfmark="s1", url="foo")
+        frag2 = Fragment.objects.create(shelfmark="s2", url="bar")
+        TextBlock.objects.create(document=doc, fragment=frag, order=1)
+        TextBlock.objects.create(document=doc, fragment=frag2, order=2)
+        assert doc.fragment_urls() == ["foo", "bar"]
+        # only one URL
+        frag2.url = ""
+        frag2.save()
+        assert doc.fragment_urls() == ["foo"]
+        # no URLs
+        frag.url = ""
+        frag.save()
+        assert doc.fragment_urls() == []
+        # no fragments
+        frag.delete()
+        frag2.delete()
+        assert doc.fragment_urls() == []
+
     def test_title(self):
         doc = Document.objects.create()
         assert doc.title == "Unknown: ??"

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -1,4 +1,8 @@
+from geniza.corpus.models import TextBlock
+from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
+
+from geniza.footnotes.models import Footnote
 
 
 class TestDocumentDetailTemplate:
@@ -52,3 +56,166 @@ class TestDocumentDetailTemplate:
         first_url = join.textblock_set.first().fragment.iiif_url
         second_url = join.textblock_set.last().fragment.iiif_url
         assertContains(response, f'data-iiif-urls="{first_url} {second_url}"')
+
+
+class TestDocumentScholarshipTemplate:
+    def test_source_title(self, client, document, source):
+        """Document scholarship template should show source titles if present"""
+        Footnote.objects.create(content_object=document, source=source)
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(
+            response, '<span class="title">A Nice Cup of Tea</span>', html=True
+        )
+        source.title = ""
+        source.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, '<span class="title">')
+
+    def test_source_authors(self, client, document, twoauthor_source):
+        """Document scholarship template should show source authors if present"""
+        Footnote.objects.create(content_object=document, source=twoauthor_source)
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(
+            response,
+            '<span class="author">Kernighan, Brian; Ritchie, Dennis</span>',
+            html=True,
+        )
+        for author in twoauthor_source.authors.all():
+            twoauthor_source.authors.remove(author)
+        twoauthor_source.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, '<span class="author">')
+
+    def test_source_date(self, client, document, article):
+        """Document scholarship template should show source pub. year if present"""
+        Footnote.objects.create(content_object=document, source=article)
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(response, '<span class="year">1963</span>', html=True)
+        article.year = None
+        article.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, '<span class="year">')
+
+    def test_source_location(self, client, document, source):
+        """Document scholarship template should show footnote location if present"""
+        fn = Footnote.objects.create(
+            content_object=document, source=source, location="p. 25"
+        )
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(response, '<span class="location">p. 25</span>', html=True)
+        fn.location = ""
+        fn.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, '<span class="location">')
+
+    def test_source_location(self, client, document, article):
+        """Document scholarship template should show source URL if present"""
+        fn = Footnote.objects.create(
+            content_object=document, source=article, url="https://example.com/"
+        )
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(
+            response, '<a href="https://example.com/">Link to source</a>', html=True
+        )
+        fn.url = ""
+        fn.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, '<a href="https://example.com/">')
+
+    def test_source_relation(self, client, document, source):
+        """Document scholarship template should show source relation to doc"""
+        fn = Footnote.objects.create(
+            content_object=document, source=source, doc_relation=Footnote.EDITION
+        )
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(response, '<span class="relation">Edition</span>', html=True)
+        fn.doc_relation = [Footnote.EDITION, Footnote.TRANSLATION]
+        fn.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(
+            response, '<span class="relation">Edition, Translation</span>', html=True
+        )
+
+
+class TestDocumentTabsSnippet:
+    def test_detail_link(self, client, document):
+        """document nav tabs should always include doc detail page link"""
+        response = client.get(document.get_absolute_url())
+        assertContains(response, document.get_absolute_url())
+
+    def test_no_footnotes(self, client, document):
+        """document nav should render inert scholarship tab if no footnotes"""
+        response = client.get(document.get_absolute_url())
+        # uses span, not link
+        assertContains(response, "<span>Scholarship Records (0)</span>", html=True)
+
+    def test_with_footnotes(self, client, document, source):
+        """document nav should render scholarship link with footnote counter"""
+        Footnote.objects.create(content_object=document, source=source)
+        response = client.get(document.get_absolute_url())
+
+        # renders link to scholarship records page
+        assertContains(
+            response, reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        # count should be 1
+        assertContains(response, "Scholarship Records (1)")
+
+        Footnote.objects.create(content_object=document, source=source)
+        response = client.get(document.get_absolute_url())
+
+        # count should be 2
+        assertContains(response, "Scholarship Records (2)")
+
+    def test_no_links(self, client, document, fragment):
+        """document nav should render inert links tab if no external links"""
+        # remove default URL from fragment
+        fragment.url = ""
+        fragment.save()
+        response = client.get(document.get_absolute_url())
+
+        # uses span, not link
+        assertContains(response, "<span>External Links (0)</span>", html=True)
+
+    def test_with_links(self, client, document, multifragment):
+        """document nav should render external links link with link counter"""
+        response = client.get(document.get_absolute_url())
+
+        # TODO renders link to external links page
+        # assertContains(
+        #     response, reverse("corpus:document-scholarship", args=[document.pk])
+        # )
+
+        # count should be 1
+        assertContains(response, "External Links (1)")
+
+        # associate to another fragment with a URL
+        TextBlock.objects.create(document=document, fragment=multifragment)
+        response = client.get(document.get_absolute_url())
+
+        # count should be 2
+        assertContains(response, "External Links (2)")

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1,18 +1,18 @@
 from unittest.mock import Mock, patch
 
-from django.contrib.contenttypes.models import ContentType
 import pytest
+from django.urls import reverse
 from pytest_django.asserts import assertContains
 
 from geniza.corpus.models import Document, DocumentType, Fragment, TextBlock
 from geniza.corpus.solr_queryset import DocumentSolrQuerySet
 from geniza.corpus.views import (
+    DocumentSearchView,
     old_pgp_edition,
     old_pgp_tabulate_data,
     pgp_metadata_for_old_site,
-    DocumentSearchView,
 )
-from geniza.footnotes.models import Footnote, Source, SourceType, Creator
+from geniza.footnotes.models import Creator, Footnote, Source, SourceType
 
 
 class TestDocumentDetailView:
@@ -188,3 +188,27 @@ class TestDocumentSearchView:
 
         context_data = docsearch_view.get_context_data()
         assert context_data["total"] == 22
+
+
+class TestDocumentScholarshipView:
+    def test_get_queryset(self, client, document, source):
+        # no footnotes; should 404
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assert response.status_code == 404
+
+        # add a footnote; should return document in context
+        Footnote.objects.create(content_object=document, source=source)
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assert response.context["document"] == document
+
+        # suppress document; should 404 again
+        document.status = Document.SUPPRESSED
+        document.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assert response.status_code == 404

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -3,14 +3,19 @@ from django.urls import path
 from geniza.corpus.views import (
     DocumentDetailView,
     DocumentSearchView,
+    DocumentScholarshipView,
     pgp_metadata_for_old_site,
 )
-
 
 app_name = "corpus"
 
 urlpatterns = [
     path("documents/", DocumentSearchView.as_view(), name="document-search"),
     path("documents/<int:pk>/", DocumentDetailView.as_view(), name="document"),
+    path(
+        "documents/<int:pk>/scholarship/",
+        DocumentScholarshipView.as_view(),
+        name="document-scholarship",
+    ),
     path("export/pgp-metadata-old/", pgp_metadata_for_old_site),
 ]

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -90,6 +90,24 @@ class DocumentDetailView(DetailView):
         return queryset.filter(status=Document.PUBLIC)
 
 
+class DocumentScholarshipView(DocumentDetailView):
+    """List of :class:`~geniza.footnotes.models.Footnote`s for a Document"""
+
+    template_name = "corpus/document_scholarship.html"
+
+    def get_queryset(self, *args, **kwargs):
+        """Prefetch footnotes, and don't show the page if there are none."""
+        # prefetch footnotes since we'll render all of them in the template
+        queryset = (
+            super()
+            .get_queryset(*args, **kwargs)
+            .prefetch_related("footnotes")
+            .distinct()     # prevent MultipleObjectsReturned if many footnotes
+        )
+
+        return queryset.filter(footnotes__isnull=False)
+
+
 # --------------- Publish CSV to sync with old PGP site --------------------- #
 
 

--- a/sitemedia/css/style.css
+++ b/sitemedia/css/style.css
@@ -13,15 +13,30 @@ main {
     flex-direction: column;
     align-items: center;
 }
+
+/* doc detail pages */
 dt, dd { margin: 0; }
 dt {margin-top: 20px;}
 dd ~ dd { margin-top: 5px; }
-
 dt.inline { display: inline; }
 dt.inline + dd { display: inline; }
 dt.inline::after { content: ':'; }
-
 dl.tags { text-align: right; }
+
+/* doc detail nav */
+nav[aria-label=tabs] > ul {
+    display: flex;
+    justify-content: space-between;
+    list-style: none;
+    padding: 0;
+}
+
+/* scholarship records */
+.footnote > * { display: block; }
+.footnote > * + * { margin-top: .5rem; }
+.footnote > .author,
+.footnote > .year { display: inline-block; }
+.footnote > .year::before { content: "/"; padding: 0 .5rem; }
 
 /* viewer */
 .wrapper {


### PR DESCRIPTION
this PR adds some new templates that have localizable content (for #188) and also implements a first-pass version of the scholarship records page (#119). the new `document_tabs.html` snippet handles rendering of the sub-page navigation for documents (details, scholarship records, external links).

no tests yet.