### PR TITLE
View all admin actions

### DIFF
--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "pucas",
     "multiselectfield",
     "adminsortable2",
+    "admin_log_entries",
     "parasolr",
     "geniza.common",
     "geniza.corpus.apps.CorpusAppConfig",

--- a/geniza/templates/admin/index.html
+++ b/geniza/templates/admin/index.html
@@ -8,4 +8,8 @@
     {% include 'admin/corpus/review_list.html' %}
 </div>
 {{ block.super }}
+{# link to view all actions by this user, displayed under recent actions #}
+<div id="content-related"><p>
+    <a href="{% url "admin:admin_logentry_changelist" %}?user__id__exact={{ user.pk }}">View more actions</a>
+</p></div>
 {% endblock %}

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -13,3 +13,4 @@ python-dateutil>=2.8
 django-tabular-export
 parasolr>=0.7
 django-gfklookupwidget
+django-adminlogentries


### PR DESCRIPTION
- adds & enables `django-adminlogentries`, which provides & enables a model admin for the `LogEntry` model
- adds a link to admin index view under recent actions to log entry list for the logged in user