### PR TITLE
Include merged PGPIDs in reassociated log entries

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -661,7 +661,15 @@ class Document(ModelIndexable):
                 ):
                     # skip if it's a duplicate
                     continue
-                # otherwise, reassociate
+
+                # otherwise annotate and reassociate
+                # - modify change message to document which object this event applied to
+                log_entry.change_message = "%s [PGPID %d]" % (
+                    log_entry.change_message,
+                    doc.pk,
+                )
+                log_entry.save()
+                # - associate with the primary document
                 self.log_entries.add(log_entry)
 
         # combine text fields


### PR DESCRIPTION
ref #170

screenshot of merged document history page from running locally

![Screen Shot 2021-08-19 at 11 40 51 AM](https://user-images.githubusercontent.com/691231/130099120-3116e744-c910-45e4-9c31-20922c4609d3.png)
