### PR TITLE
#307 - Search results: Alignment, spacing, margins

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -5,7 +5,7 @@ snapshot:
     - 1440
   minHeight: 1024
 discovery:
-  allowedHostnames: []
+  allowedHostnames: ["unpkg.com"]
   networkIdleTimeout: 100
 static:
   baseUrl: /

--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -31,8 +31,8 @@ class Command(BaseCommand):
         # percy_snapshot(browser, "Content Page")
 
         # document search
-        # search term should match description of 3951
-        browser.get("http://localhost:8000/documents/?q=tujib")
+        # search term should match descriptions of 3951 and the fake letter document
+        browser.get("http://localhost:8000/documents/?q=tujib+description")
         percy_snapshot(browser, "Document Search")
 
         # document detail

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -45,7 +45,6 @@ class DocumentSearchForm(forms.Form):
                 "placeholder": "search by keyword",
                 "aria-label": "Keyword or Phrase",
                 "type": "search",
-                "class": "search-field",
             }
         ),
     )
@@ -61,10 +60,7 @@ class DocumentSearchForm(forms.Form):
     required_css_class = "required"
 
     sort = forms.ChoiceField(
-        label="Sort by",
-        choices=SORT_CHOICES,
-        required=False,
-        widget=SelectWithDisabled(attrs={"class": "sort-by"}),
+        label="Sort by", choices=SORT_CHOICES, required=False, widget=SelectWithDisabled
     )
 
     def __init__(self, data=None, *args, **kwargs):

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -45,6 +45,7 @@ class DocumentSearchForm(forms.Form):
                 "placeholder": "search by keyword",
                 "aria-label": "Keyword or Phrase",
                 "type": "search",
+                "class": "search-field",
             }
         ),
     )
@@ -60,7 +61,10 @@ class DocumentSearchForm(forms.Form):
     required_css_class = "required"
 
     sort = forms.ChoiceField(
-        label="Sort by", choices=SORT_CHOICES, required=False, widget=SelectWithDisabled
+        label="Sort by",
+        choices=SORT_CHOICES,
+        required=False,
+        widget=SelectWithDisabled(attrs={"class": "sort-by"}),
     )
 
     def __init__(self, data=None, *args, **kwargs):

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -5,6 +5,7 @@
 {% block meta_description %}{{ page_description }}{% endblock meta_description %}
 
 {% block main %}
+    <h1 class="sr-only">{{ page_title }}</h1>
     <form>
         <fieldset>
             {{ form.q }}

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -5,11 +5,24 @@
 {% block meta_description %}{{ page_description }}{% endblock meta_description %}
 
 {% block main %}
-    <h1>{{ page_title }}</h1>
-    <div class="container">
-
-        <form>
-            {{ form }}
+    <div class="document-list">
+        <form class="search-form">
+            <div class="search-bar">
+                {{ form.q }}
+                <input type="submit" value="search" class="search-button">
+            </div>
+            <div class="results-count">
+                {% comment %}Translators: number of search results{% endcomment %}
+                {% blocktranslate count counter=total trimmed %}
+                    1 result
+                {% plural %}
+                    {{ counter }} total results
+                {% endblocktranslate %}
+            </div>
+            <div class="sort-by-container">
+                {{ form.sort.label }}
+                {{ form.sort }}
+            </div>
             {% for field, errors in form.errors.items %}
                 {# no clean way to get field labels here, so we just collapse the error lists #}
                 {% for error in errors %}
@@ -17,13 +30,6 @@
                 {% endfor %}
             {% endfor %}
         </form>
-
-        {% comment %}Translators: number of search results{% endcomment %}
-        {% blocktranslate count counter=total trimmed %}
-            1 result
-        {% plural %}
-            {{ counter }} total results
-        {% endblocktranslate %}
 
         <ol class="search-results">
             {% for document in documents %}

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -5,36 +5,33 @@
 {% block meta_description %}{{ page_description }}{% endblock meta_description %}
 
 {% block main %}
-    <div class="document-list">
-        <form class="search-form">
-            <div class="search-bar">
-                {{ form.q }}
-                <input type="submit" value="search" class="search-button">
-            </div>
-            <div class="results-count">
-                {% comment %}Translators: number of search results{% endcomment %}
-                {% blocktranslate count counter=total trimmed %}
-                    1 result
-                {% plural %}
-                    {{ counter }} total results
-                {% endblocktranslate %}
-            </div>
-            <div class="sort-by-container">
-                {{ form.sort.label }}
-                {{ form.sort }}
-            </div>
-            {% for field, errors in form.errors.items %}
-                {# no clean way to get field labels here, so we just collapse the error lists #}
-                {% for error in errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
+    <form>
+        <fieldset>
+            {{ form.q }}
+            {{ form.sort }}
+            <label for="sort">{{ form.sort.label }}</label>
+            <input type="submit" value="search" />
+        </fieldset>
+        {% for field, errors in form.errors.items %}
+            {# no clean way to get field labels here, so we just collapse the error lists #}
+            {% for error in errors %}
+                <li>{{ error }}</li>
             {% endfor %}
-        </form>
-
-        <ol class="search-results">
+        {% endfor %}
+    </form>
+    <section id="document-list">
+        <h1>
+            {% comment %}Translators: number of search results{% endcomment %}
+            {% blocktranslate count counter=total trimmed %}
+                1 result
+            {% plural %}
+                {{ counter }} total results
+            {% endblocktranslate %}
+        </h1>
+        <ol>
             {% for document in documents %}
                 {% include "corpus/snippets/document_result.html" %}
             {% endfor %}
         </ol>
-    </div>
+    </section>
 {% endblock main %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -11,7 +11,7 @@
             {# tags #}
             {% if document.tags %}
                 <ul class="tags">
-                    {% for tag in document.tags %}
+                    {% for tag in document.tags|alphabetize %}
                         <li>{{ tag }}</li>
                     {% endfor %}
                 </ul>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -1,46 +1,49 @@
 {% load i18n %}
 {% spaceless %}
     <li class="search-result">
-        {# tags #}
-        {% if document.tags %}
-            <ul class="tags">
-                {% for tag in document.tags %}
-                    <li>{{ tag }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
+        <div class="meta-container">
+            {# tags #}
+            {% if document.tags %}
+                <ul class="tags">
+                    {% for tag in document.tags %}
+                        <li>{{ tag }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+            {# title #}
+            <h2 class="title">
+                <span class="doctype">{{ document.type }}</span>
+                <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
+            </h2>
 
-        {# title #}
-        <h2 class="title">
-            <span class="doctype">{{ document.type }}</span>
-            <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
-        </h2>
+            {# metadata #}
+            <dl class="metadata">
+                <dt>{% translate 'Input date' %}</dt>
+                <dd>{{ document.input_year|default:'unknown' }}</dd>
+                <dt>{% translate 'PGP ID' %}</dt>
+                <dd>{{ document.pgpid }}</dd>
+            </dl>
 
-        {# metadata #}
-        <dl class="metadata">
-            <dt>{% translate 'Input date' %}</dt>
-            <dd>{{ document.input_year|default:'unknown' }}</dd>
-            <dt>{% translate 'PGP ID' %}</dt>
-            <dd>{{ document.pgpid }}</dd>
-        </dl>
+            {# description #}
+            <p class="description">{{ document.description.0|truncatewords:25 }}</p>
 
-        {# description #}
-        <p class="description">{{ document.description.0|truncatewords:25 }}</p>
+            {# scholarship records #}
+            {% if document.scholarship_count %}
+                <p class="scholarship">
+                    <i class="ph-check"></i>
+                    {% if document.num_editions %}{% translate 'Transcription' %}{% if document.num_editions > 1 %} ({{ document.num_editions }}){% endif %}{% endif %}
+                    {% if document.num_translations %}{% translate 'Translation' %}{% if document.num_translations > 1 %} ({{ document.num_translations }}){% endif %}{% endif %}
+                    {% if document.num_discussions %}{% translate 'Discussion' %}{% if document.num_discussions > 1 %} ({{ document.num_discussions }}){% endif %}{% endif %}
+                </p>
+            {% endif %}
+        </div>
 
-        {# scholarship records #}
-        {% if document.scholarship_count %}
-            <p class="scholarship">
-                <i class="ph-check"></i>
-                {% if document.num_editions %}{% translate 'Transcription' %}{% if document.num_editions > 1 %} ({{ document.num_editions }}){% endif %}{% endif %}
-                {% if document.num_translations %}{% translate 'Translation' %}{% if document.num_translations > 1 %} ({{ document.num_translations }}){% endif %}{% endif %}
-                {% if document.num_discussions %}{% translate 'Discussion' %}{% if document.num_discussions > 1 %} ({{ document.num_discussions }}){% endif %}{% endif %}
-            </p>
-        {% endif %}
-
-        {# view link #}
-        <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">
-            {% translate 'View document details' %}
-            <i class="ph-arrow-right"></i>
-        </a>
+        <div class="content-container">
+            {# view link #}
+            <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">
+                {% translate 'View document details' %}
+                <i class="ph-arrow-right"></i>
+            </a>
+        </div>
     </li>
 {% endspaceless %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -39,5 +39,12 @@
                 {% endif %}
             </p>
         </div>
+        <div class="content-container">
+            {# view link #}
+            <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">
+                {% translate 'View document details' %}
+                <i class="ph-arrow-right"></i>
+            </a>
+        </div>
     </li>
 {% endspaceless %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -1,7 +1,13 @@
-{% load i18n %}
+{% load i18n corpus_extras %}
 {% spaceless %}
     <li class="search-result">
-        <div class="meta-container">
+        <section>
+            {# title #}
+            <h2 class="title">
+                <span class="doctype">{{ document.type }}</span>
+                <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
+            </h2>
+
             {# tags #}
             {% if document.tags %}
                 <ul class="tags">
@@ -10,11 +16,6 @@
                     {% endfor %}
                 </ul>
             {% endif %}
-            {# title #}
-            <h2 class="title">
-                <span class="doctype">{{ document.type }}</span>
-                <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
-            </h2>
 
             {# metadata #}
             <dl class="metadata">
@@ -38,13 +39,11 @@
                     No Scholarship Records
                 {% endif %}
             </p>
-        </div>
-        <div class="content-container">
-            {# view link #}
-            <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">
-                {% translate 'View document details' %}
-                <i class="ph-arrow-right"></i>
-            </a>
-        </div>
+        </section>
+        {# view link #}
+        <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">
+            {% translate 'View document details' %}
+            <i class="ph-arrow-right"></i>
+        </a>
     </li>
 {% endspaceless %}

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -1,0 +1,12 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def alphabetize(value):
+    """Lowercases, then alphabetizes, a list of strings"""
+    if isinstance(value, list) and all(isinstance(s, str) for s in value):
+        return sorted([s.lower() for s in value])
+    else:
+        raise TypeError("Argument must be a list of strings")

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -1,0 +1,34 @@
+import pytest
+
+from geniza.corpus.templatetags import corpus_extras
+
+
+class TestCorpusExtrasTemplateTags:
+    def test_alphabetize(self):
+        """Should lowercase and alphabetize a list of strings"""
+        lst = ["Test", "hello", "abc", "Def"]
+        alphabetized = corpus_extras.alphabetize(lst)
+        assert alphabetized[0] == "abc"
+        assert alphabetized[1] == "def"
+        assert alphabetized[2] == "hello"
+        assert alphabetized[3] == "test"
+
+    def test_alphabetize_bad_list(self):
+        """Should throw TypeError when list contains non-strings"""
+        with pytest.raises(TypeError) as err:
+            bad_list = [1, 2, 3, "hi", ["test"]]
+            corpus_extras.alphabetize(bad_list)
+        assert "Argument must be a list of strings" in str(err)
+
+    def test_alphabetize_not_list(self):
+        """Should throw TypeError when argument is not a list"""
+        with pytest.raises(TypeError) as err:
+            not_list = -4
+            corpus_extras.alphabetize(not_list)
+        assert "Argument must be a list of strings" in str(err)
+
+    def test_alphabetize_empty_list(self):
+        """Should process empty list without raising exception"""
+        lst = []
+        alphabetized = corpus_extras.alphabetize(lst)
+        assert alphabetized == []

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -85,6 +85,7 @@ class DocumentSearchView(ListView, FormMixin):
                 "total": self.queryset.count(),
                 "page_title": self.page_title,
                 "page_description": self.page_description,
+                "id": "search",
             }
         )
         return context_data

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -29,7 +29,7 @@
         <script src="{{ main_js.0.url }}" nonce="{{ request.csp_nonce }}" defer></script>
         {% block extrascript %}{% endblock extrascript %}
     </head>
-    <body>
+    <body id="{{ id }}">
         {% if SHOW_TEST_WARNING %}
             {% include 'snippets/test_banner.html' %}
         {% endif %}

--- a/sitemedia/scss/base/_breakpoints.scss
+++ b/sitemedia/scss/base/_breakpoints.scss
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------------
+// Breakpoint map for various devices.
+// -----------------------------------------------------------------------------
+
+$breakpoints: (
+    "small": (
+        min-width: 767px,
+    ),
+    "medium": (
+        min-width: 992px,
+    ),
+    "large": (
+        min-width: 1200px,
+    ),
+);
+
+@mixin respond-to($name) {
+    // If the key exists in the map
+    @if map-has-key($breakpoints, $name) {
+        // Prints a media query based on the value
+        @media #{inspect(map-get($breakpoints, $name))} {
+            @content;
+        }
+    }
+
+    // If the key doesn't exist in the map
+    @else {
+        @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. "
+        + "Please make sure it is defined in `$breakpoints` map.";
+    }
+}

--- a/sitemedia/scss/base/_breakpoints.scss
+++ b/sitemedia/scss/base/_breakpoints.scss
@@ -1,31 +1,19 @@
 // -----------------------------------------------------------------------------
-// Breakpoint map for various devices.
+// Breakpoint mixins for various devices.
 // -----------------------------------------------------------------------------
 
-$breakpoints: (
-    "small": (
-        min-width: 767px,
-    ),
-    "medium": (
-        min-width: 992px,
-    ),
-    "large": (
-        min-width: 1200px,
-    ),
-);
-
-@mixin respond-to($name) {
-    // If the key exists in the map
-    @if map-has-key($breakpoints, $name) {
-        // Prints a media query based on the value
-        @media #{inspect(map-get($breakpoints, $name))} {
-            @content;
-        }
+@mixin for-phone-only {
+    @media (max-width: 599px) {
+        @content;
     }
-
-    // If the key doesn't exist in the map
-    @else {
-        @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. "
-        + "Please make sure it is defined in `$breakpoints` map.";
+}
+@mixin for-tablet-landscape-up {
+    @media (min-width: 900px) {
+        @content;
+    }
+}
+@mixin for-desktop-up {
+    @media (min-width: 1200px) {
+        @content;
     }
 }

--- a/sitemedia/scss/base/_container.scss
+++ b/sitemedia/scss/base/_container.scss
@@ -2,6 +2,7 @@
 // Utility classes for controlling the width of elements.
 // -----------------------------------------------------------------------------
 
+@use "../base/breakpoints";
 @use "spacing";
 
 // Maximum width of a line of text, in characters. This is based on standards
@@ -12,7 +13,12 @@ $measure: 60ch;
 // Maximum width of a two-column layout, whose columns should not exceed
 // width of $measure
 $two-column: 900px;
-
+@mixin two-column {
+    max-width: $measure;
+    @include breakpoints.respond_to(medium) {
+        max-width: $two-column;
+    }
+}
 // Minimum amount of space left on either side of the page to create a margin.
 $gutter: spacing.$spacing-sm;
 

--- a/sitemedia/scss/base/_container.scss
+++ b/sitemedia/scss/base/_container.scss
@@ -15,7 +15,7 @@ $measure: 60ch;
 $two-column: 900px;
 @mixin two-column {
     max-width: $measure;
-    @include breakpoints.respond_to(medium) {
+    @include breakpoints.for-tablet-landscape-up {
         max-width: $two-column;
     }
 }

--- a/sitemedia/scss/base/_container.scss
+++ b/sitemedia/scss/base/_container.scss
@@ -9,6 +9,10 @@
 // https://every-layout.dev/rudiments/axioms/#measure
 $measure: 60ch;
 
+// Maximum width of a two-column layout, whose columns should not exceed
+// width of $measure
+$two-column: 900px;
+
 // Minimum amount of space left on either side of the page to create a margin.
 $gutter: spacing.$spacing-sm;
 

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -11,6 +11,7 @@
 $text-size-xs: 0.64rem;
 $text-size-sm: 0.8rem;
 $text-size-md: 1rem;
+$text-size-2md: 1.15rem;
 $text-size-lg: 1.25rem;
 $text-size-xl: 1.56rem;
 $text-size-2xl: 1.95rem;
@@ -67,6 +68,12 @@ $text-size-5xl: 3.81rem;
     font-family: fonts.$secondary;
     font-size: $text-size-md;
     line-height: 1.5;
+}
+
+@mixin meta {
+    font-family: fonts.$secondary;
+    font-size: $text-size-2md;
+    line-height: 1.3;
 }
 
 @mixin button {

--- a/sitemedia/scss/components/_metadata.scss
+++ b/sitemedia/scss/components/_metadata.scss
@@ -2,12 +2,14 @@
 // Lists of detailed metadata about Geniza documents.
 // -----------------------------------------------------------------------------
 
+@use "../base/spacing";
+@use "../base/typography";
+
 .metadata {
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-column-gap: 1rem;
+    column-gap: 1rem;
+    row-gap: spacing.$spacing-xs;
 
-    dt {
-        font-weight: bold;
-    }
+    @include typography.meta;
 }

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -27,7 +27,7 @@
         padding: 0;
         flex: auto;
         display: none;
-        @include breakpoints.respond_to(medium) {
+        @include breakpoints.for-tablet-landscape-up {
             display: flex;
         }
         justify-content: flex-end;

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -2,9 +2,10 @@
 // Main site navigation that appears on every page.
 // -----------------------------------------------------------------------------
 
-@use "../base/typography";
+@use "../base/breakpoints";
 @use "../base/colors";
 @use "../base/spacing";
+@use "../base/typography";
 
 .site-nav {
     display: flex;
@@ -25,7 +26,10 @@
     .menu {
         padding: 0;
         flex: auto;
-        display: flex;
+        display: none;
+        @include breakpoints.respond_to(medium) {
+            display: flex;
+        }
         justify-content: flex-end;
         border: spacing.$spacing-4xs solid colors.$gray-40;
     }

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -2,23 +2,23 @@
 // Lists of search results for documents.
 // -----------------------------------------------------------------------------
 
-@use "../base/typography";
-@use "../base/spacing";
-@use "../base/container";
 @use "../base/breakpoints";
+@use "../base/container";
+@use "../base/spacing";
+@use "../base/typography";
 
 // list of results
 .search-results {
     list-style: none;
     counter-reset: search-counter;
-    max-width: container.$two-column;
+    @include container.two-column;
 }
 
 // single result
 .search-result {
     counter-increment: search-counter;
     margin-left: spacing.$spacing-xl;
-    max-width: container.$two-column;
+    @include container.two-column;
     display: flex;
     justify-content: space-between;
     flex-flow: column;

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -4,59 +4,82 @@
 
 @use "../base/typography";
 @use "../base/spacing";
+@use "../base/container";
+@use "../base/breakpoints";
 
 // list of results
 .search-results {
     list-style: none;
     counter-reset: search-counter;
+    max-width: container.$two-column;
 }
 
 // single result
 .search-result {
     counter-increment: search-counter;
+    margin-left: spacing.$spacing-xl;
+    max-width: container.$two-column;
+    display: flex;
+    justify-content: space-between;
+    flex-flow: column;
+    @include breakpoints.respond_to(medium) {
+        flex-flow: row;
+    }
 
     // spacing in between results
     & + .search-result {
         margin-top: spacing.$spacing-lg;
     }
 
-    // document titles
-    .title {
-        @include typography.subtitle;
+    // First row on mobile, left column on larger
+    .meta-container {
+        max-width: container.$measure;
+        // document titles
+        .title {
+            @include typography.subtitle;
 
-        position: relative;
+            position: relative;
+            margin-top: spacing.$spacing-sm;
+            margin-bottom: spacing.$spacing-xs;
 
-        // anchor counter to h2 instead of li, for alignment regardless of tags
-        &::before {
-            content: counter(search-counter);
-            margin-left: -#{spacing.$spacing-lg};
-            text-align: left;
-            float: left;
+            // anchor counter to h2 instead of li, for alignment regardless of tags
+            &::before {
+                content: counter(search-counter);
+                margin-left: -#{spacing.$spacing-xl};
+                text-align: left;
+                float: left;
+                font-weight: bold;
+            }
+        }
+
+        // document type, inside title
+        .doctype {
             font-weight: bold;
+
+            &::after {
+                font-weight: normal;
+                content: ", ";
+            }
+        }
+
+        // document description
+        .description {
+            margin: spacing.$spacing-md 0;
         }
     }
 
-    // document type, inside title
-    .doctype {
-        font-weight: bold;
+    // Second row on mobile, right column on larger
+    .content-container {
+        align-self: flex-end;
+        justify-self: flex-end;
+        max-width: container.$measure;
+        // "view more details" link
+        .view-link {
+            @include typography.link;
 
-        &::after {
-            font-weight: normal;
-            content: ", ";
+            display: block;
+            width: max-content;
+            margin-left: auto;
         }
-    }
-
-    // document description
-    .description {
-        margin: spacing.$spacing-sm 0;
-    }
-
-    // "view more details" link
-    .view-link {
-        @include typography.link;
-
-        display: block;
-        width: max-content;
-        margin-left: auto;
     }
 }

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -7,11 +7,20 @@
 @use "../base/spacing";
 @use "../base/typography";
 
-// list of results
-.search-results {
-    list-style: none;
-    counter-reset: search-counter;
-    @include container.two-column;
+section#document-list {
+    // count of results
+    h1 {
+        @include container.two-column;
+        @include typography.body;
+        text-align: center;
+        margin: spacing.$spacing-lg 0 spacing.$spacing-xl;
+    }
+    // list of results
+    ol {
+        list-style: none;
+        counter-reset: search-counter;
+        @include container.two-column;
+    }
 }
 
 // single result
@@ -22,9 +31,6 @@
     display: flex;
     justify-content: space-between;
     flex-flow: column;
-    @include breakpoints.respond_to(medium) {
-        flex-flow: row;
-    }
 
     // spacing in between results
     & + .search-result {
@@ -32,15 +38,26 @@
     }
 
     // First row on mobile, left column on larger
-    .meta-container {
+    section:first-of-type {
         max-width: container.$measure;
+        display: flex;
+        flex-flow: column;
+
+        // document tags
+        .tags {
+            order: 1;
+        }
+
         // document titles
         .title {
             @include typography.subtitle;
-
+            order: 2;
             position: relative;
-            margin-top: spacing.$spacing-sm;
-            margin-bottom: spacing.$spacing-xs;
+            margin-top: spacing.$spacing-md;
+            margin-bottom: spacing.$spacing-md;
+            @include breakpoints.for-tablet-landscape-up {
+                margin-bottom: spacing.$spacing-sm;
+            }
 
             // anchor counter to h2 instead of li, for alignment regardless of tags
             &::before {
@@ -50,36 +67,41 @@
                 float: left;
                 font-weight: bold;
             }
+
+            // document type, inside title
+            .doctype {
+                font-weight: bold;
+
+                &::after {
+                    font-weight: normal;
+                    content: ", ";
+                }
+            }
         }
 
-        // document type, inside title
-        .doctype {
-            font-weight: bold;
-
-            &::after {
-                font-weight: normal;
-                content: ", ";
-            }
+        // other document metadata
+        .metadata {
+            order: 3;
         }
 
         // document description
         .description {
+            order: 4;
             margin: spacing.$spacing-md 0;
+        }
+
+        // document scholarship records
+        .scholarship {
+            order: 5;
         }
     }
 
-    // Second row on mobile, right column on larger
-    .content-container {
-        align-self: flex-end;
-        justify-self: flex-end;
-        max-width: container.$measure;
-        // "view more details" link
-        .view-link {
-            @include typography.link;
+    .view-link {
+        @include typography.link;
 
-            display: block;
-            width: max-content;
-            margin-left: auto;
-        }
+        display: block;
+        width: max-content;
+        margin-left: auto;
+        margin-top: spacing.$spacing-md;
     }
 }

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -13,7 +13,7 @@ section#document-list {
         @include container.two-column;
         @include typography.body;
         text-align: center;
-        margin: spacing.$spacing-lg 0 spacing.$spacing-xl;
+        margin: spacing.$spacing-sm 0;
     }
     // list of results
     ol {

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -2,6 +2,7 @@
 // Document search form.
 // -----------------------------------------------------------------------------
 
+@use "../base/breakpoints";
 @use "../base/colors";
 @use "../base/container";
 @use "../base/spacing";
@@ -10,7 +11,10 @@
 // search form
 #search form {
     @include container.two-column;
-    margin-top: spacing.$spacing-xl;
+    margin-top: spacing.$spacing-lg;
+    @include breakpoints.for-tablet-landscape-up {
+        margin-top: spacing.$spacing-2xl;
+    }
     fieldset {
         @include container.two-column;
         display: flex;
@@ -33,7 +37,10 @@
         select[name="sort"] {
             font-size: typography.$text-size-sm;
             order: 4;
-            flex: 0 1 auto;
+            flex: 1 1 auto;
+            @include breakpoints.for-tablet-landscape-up {
+                flex: 0 1 auto;
+            }
             border-radius: 0;
             height: spacing.$spacing-xl;
             padding: spacing.$spacing-xs;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -1,0 +1,59 @@
+// -----------------------------------------------------------------------------
+// Document search form.
+// -----------------------------------------------------------------------------
+
+@use "../base/colors";
+@use "../base/container";
+@use "../base/spacing";
+@use "../base/typography";
+
+// search form
+.search-form {
+    margin-top: spacing.$spacing-xl;
+    margin-bottom: spacing.$spacing-xl;
+    max-width: container.$two-column;
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    .search-bar {
+        display: flex;
+        flex-flow: row nowrap;
+        .search-field {
+            border: 1px solid colors.$gray-50;
+            border-right: none;
+            margin-right: 0;
+            max-width: container.$two-column;
+            flex: 1 0 auto;
+            height: spacing.$spacing-xl;
+            padding: spacing.$spacing-sm;
+            &::placeholder {
+                font-size: typography.$text-size-md;
+            }
+        }
+        .search-button {
+            border-radius: 0;
+            margin-left: 0;
+            @include typography.button;
+            background-color: colors.$gray-30;
+            border: 1px solid colors.$gray-50;
+            height: spacing.$spacing-xl;
+        }
+    }
+    .results-count {
+        text-align: center;
+        margin-top: spacing.$spacing-md;
+        margin-bottom: spacing.$spacing-md;
+    }
+    .sort-by-container {
+        display: flex;
+        flex-flow: column;
+        align-items: flex-start;
+        .sort-by {
+            flex: 0 1 auto;
+            border-radius: 0;
+            height: spacing.$spacing-lg;
+            padding: spacing.$spacing-sm;
+            margin-top: spacing.$spacing-sm;
+        }
+    }
+}

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -11,7 +11,7 @@
 .search-form {
     margin-top: spacing.$spacing-xl;
     margin-bottom: spacing.$spacing-xl;
-    max-width: container.$two-column;
+    @include container.two-column;
     display: flex;
     flex-flow: column;
     justify-content: center;
@@ -22,7 +22,7 @@
             border: 1px solid colors.$gray-50;
             border-right: none;
             margin-right: 0;
-            max-width: container.$two-column;
+            @include container.two-column;
             flex: 1 0 auto;
             height: spacing.$spacing-xl;
             padding: spacing.$spacing-sm;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -8,52 +8,52 @@
 @use "../base/typography";
 
 // search form
-.search-form {
-    margin-top: spacing.$spacing-xl;
-    margin-bottom: spacing.$spacing-xl;
+#search form {
     @include container.two-column;
-    display: flex;
-    flex-flow: column;
-    justify-content: center;
-    .search-bar {
+    margin-top: spacing.$spacing-xl;
+    fieldset {
+        @include container.two-column;
         display: flex;
-        flex-flow: row nowrap;
-        .search-field {
+        flex-flow: row wrap;
+        align-items: center;
+        justify-content: flex-start;
+        input[type="search"] {
+            @include container.two-column;
+            order: 1;
+            flex: 1 0 auto;
             border: 1px solid colors.$gray-50;
             border-right: none;
             margin-right: 0;
-            @include container.two-column;
-            flex: 1 0 auto;
             height: spacing.$spacing-xl;
             padding: spacing.$spacing-sm;
             &::placeholder {
                 font-size: typography.$text-size-md;
             }
         }
-        .search-button {
+        select[name="sort"] {
+            font-size: typography.$text-size-sm;
+            order: 4;
+            flex: 0 1 auto;
+            border-radius: 0;
+            height: spacing.$spacing-xl;
+            padding: spacing.$spacing-xs;
+            margin-top: spacing.$spacing-sm;
+        }
+        label[for="sort"] {
+            @include container.two-column;
+            order: 3;
+            flex: 1 0 100%;
+            margin-top: spacing.$spacing-lg;
+        }
+        input[type="submit"] {
+            @include typography.button;
+            order: 2;
+            flex: 0 0 10%;
             border-radius: 0;
             margin-left: 0;
-            @include typography.button;
             background-color: colors.$gray-30;
             border: 1px solid colors.$gray-50;
             height: spacing.$spacing-xl;
-        }
-    }
-    .results-count {
-        text-align: center;
-        margin-top: spacing.$spacing-md;
-        margin-bottom: spacing.$spacing-md;
-    }
-    .sort-by-container {
-        display: flex;
-        flex-flow: column;
-        align-items: flex-start;
-        .sort-by {
-            flex: 0 1 auto;
-            border-radius: 0;
-            height: spacing.$spacing-lg;
-            padding: spacing.$spacing-sm;
-            margin-top: spacing.$spacing-sm;
         }
     }
 }

--- a/sitemedia/scss/main.scss
+++ b/sitemedia/scss/main.scss
@@ -9,6 +9,7 @@
 @use "components/metadata";
 @use "components/tag";
 @use "components/results";
+@use "components/searchform";
 @use "components/iiif";
 
 // Page-specific styles

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -2,6 +2,16 @@
 // Document search page.
 // -----------------------------------------------------------------------------
 
+@use "../base/spacing";
+@use "../base/container";
+
 #search {
-    // rules go here once body context ID is applied
+    // Overall page layout
+    .document-list {
+        width: 100%;
+        max-width: container.$two-column;
+        display: flex;
+        flex-direction: column;
+        padding: spacing.$spacing-lg;
+    }
 }

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -2,14 +2,14 @@
 // Document search page.
 // -----------------------------------------------------------------------------
 
-@use "../base/spacing";
 @use "../base/container";
+@use "../base/spacing";
 
 #search {
     // Overall page layout
     .document-list {
         width: 100%;
-        max-width: container.$two-column;
+        @include container.two-column;
         display: flex;
         flex-direction: column;
         padding: spacing.$spacing-lg;

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -7,11 +7,18 @@
 
 #search {
     // Overall page layout
-    .document-list {
+    form {
         width: 100%;
         @include container.two-column;
         display: flex;
         flex-direction: column;
-        padding: spacing.$spacing-lg;
+        padding: spacing.$spacing-md;
+    }
+    section#document-list {
+        width: 100%;
+        @include container.two-column;
+        display: flex;
+        flex-direction: column;
+        padding: 0 spacing.$spacing-md spacing.$spacing-md;
     }
 }


### PR DESCRIPTION
### What this PR does
- Per #307:
  - Implements alignment, spacing, and margin for search results page
    - Implements a minimal amount of typography for those to look right
    - Adds `breakpoints.respond_to` SASS mixin
  - Reorders `document_list.html ` template to match order of elements in the design
    - Uses individual form elements instead of `{% form %}` for finer control over layout
  - Separates `document_result.html` into two containers, which act as columns in desktop and rows in mobile

### Additional notes
- Because [element widths are defined in relation to character count](https://github.com/Princeton-CDH/geniza/blob/27c6f62c130c1a12a2d5a969ce13b79e3d9f4783/sitemedia/scss/base/_container.scss) and [spacing is defined in relation to 1rem](https://github.com/Princeton-CDH/geniza/blob/27c6f62c130c1a12a2d5a969ce13b79e3d9f4783/sitemedia/scss/base/_spacing.scss), it seemed to go against the code philosophy to define these things in terms of exact pixel count.
  - What I ended up doing is defining an exact-pixel container width for what I call a "two-column" layout, the children of which should not exceed 60 characters in width, thus still incorporating the philosophy that text containers should remain readable.
  - For all spacing, I used the closest existing value in `_spacing.scss` to approximate the pixel values used in the design.
- I used the view context to pass the id `"search"` to the base template `body` element based on the comment:
    ```css
    // rules go here once body context ID is applied
    ```
    I'm not sure if that is actually desirable or makes sense, and I may have completely misunderstood the comment, but for now I've tried to make a guess at what was intended.
- Document detail view was slightly touched by this PR but I'll leave fixes for that until #305.
