### PR TITLE
#309 - Search page type sizes

### DIFF
--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -2,8 +2,9 @@
 // Typographic styles (size, weight, etc.) used across the project.
 // -----------------------------------------------------------------------------
 
-@use "fonts";
+@use "breakpoints";
 @use "colors";
+@use "fonts";
 
 // Type scale: generate sizes according to harmonic ratio. This scale is based
 // on the "Major Third" scale, with a scale factor of 1.25. See:
@@ -60,7 +61,10 @@ $text-size-5xl: 3.81rem;
 
 @mixin subtitle {
     font-family: fonts.$secondary;
-    font-size: $text-size-lg;
+    font-size: $text-size-2md;
+    @include breakpoints.for-tablet-landscape-up {
+        font-size: $text-size-lg;
+    }
     line-height: 1.3;
 }
 
@@ -72,7 +76,10 @@ $text-size-5xl: 3.81rem;
 
 @mixin meta {
     font-family: fonts.$secondary;
-    font-size: $text-size-2md;
+    font-size: $text-size-md;
+    @include breakpoints.for-tablet-landscape-up {
+        font-size: $text-size-2md;
+    }
     line-height: 1.3;
 }
 

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -36,6 +36,7 @@
 
     // Individual menu items
     .menu-item {
+        font-size: typography.$text-size-2md;
         padding: spacing.$spacing-sm 0;
 
         & + .menu-item {
@@ -50,5 +51,6 @@
     // Currently active page
     a[aria-current="page"] {
         font-weight: bold;
+        font-size: typography.$text-size-2md;
     }
 }

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -13,7 +13,7 @@ section#document-list {
         @include container.two-column;
         @include typography.headline-6;
         text-align: center;
-        margin: spacing.$spacing-sm 0 spacing.$spacing-lg;
+        margin: spacing.$spacing-sm 0;
     }
     // list of results
     ol {

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -11,9 +11,9 @@ section#document-list {
     // count of results
     h1 {
         @include container.two-column;
-        @include typography.body;
+        @include typography.headline-6;
         text-align: center;
-        margin: spacing.$spacing-sm 0;
+        margin: spacing.$spacing-sm 0 spacing.$spacing-lg;
     }
     // list of results
     ol {
@@ -88,15 +88,27 @@ section#document-list {
         // document scholarship records
         .scholarship {
             order: 5;
+            @include typography.meta;
         }
     }
 
     .view-link {
-        @include typography.link;
-
-        display: block;
+        display: flex;
+        align-items: center;
         width: max-content;
         margin-left: auto;
         margin-top: spacing.$spacing-md;
+        font-size: typography.$text-size-md;
+        @include breakpoints.for-tablet-landscape-up {
+            font-size: typography.$text-size-lg;
+        }
+        i {
+            margin-left: spacing.$spacing-sm;
+            font-size: typography.$text-size-lg;
+            @include breakpoints.for-tablet-landscape-up {
+                margin-left: spacing.$spacing-lg;
+                font-size: typography.$text-size-2xl;
+            }
+        }
     }
 }

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -24,12 +24,12 @@
         margin-right: 0;
         height: spacing.$spacing-xl;
         padding: spacing.$spacing-sm;
-        &::placeholder {
-            font-size: typography.$text-size-md;
+        font-size: typography.$text-size-md;
+        @include breakpoints.for-tablet-landscape-up {
+            font-size: typography.$text-size-2md;
         }
     }
     select[name="sort"] {
-        font-size: typography.$text-size-sm;
         order: 4;
         flex: 1 1 auto;
         @include breakpoints.for-tablet-landscape-up {
@@ -37,14 +37,22 @@
         }
         border-radius: 0;
         height: spacing.$spacing-xl;
-        padding: spacing.$spacing-xs;
+        padding: spacing.$spacing-2xs spacing.$spacing-xs;
         margin-top: spacing.$spacing-sm;
+        font-size: typography.$text-size-2md;
+        @include breakpoints.for-tablet-landscape-up {
+            font-size: typography.$text-size-lg;
+        }
     }
     label[for="sort"] {
         @include container.two-column;
         order: 3;
         flex: 1 0 100%;
         margin-top: spacing.$spacing-lg;
+        font-size: typography.$text-size-md;
+        @include breakpoints.for-tablet-landscape-up {
+            font-size: typography.$text-size-2md;
+        }
     }
     input[type="submit"] {
         @include typography.button;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -9,58 +9,51 @@
 @use "../base/typography";
 
 // search form
-#search form {
+#search form fieldset {
     @include container.two-column;
-    margin-top: spacing.$spacing-lg;
-    @include breakpoints.for-tablet-landscape-up {
-        margin-top: spacing.$spacing-2xl;
-    }
-    fieldset {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: flex-start;
+    input[type="search"] {
         @include container.two-column;
-        display: flex;
-        flex-flow: row wrap;
-        align-items: center;
-        justify-content: flex-start;
-        input[type="search"] {
-            @include container.two-column;
-            order: 1;
-            flex: 1 0 auto;
-            border: 1px solid colors.$gray-50;
-            border-right: none;
-            margin-right: 0;
-            height: spacing.$spacing-xl;
-            padding: spacing.$spacing-sm;
-            &::placeholder {
-                font-size: typography.$text-size-md;
-            }
+        order: 1;
+        flex: 1 0 auto;
+        border: 1px solid colors.$gray-50;
+        border-right: none;
+        margin-right: 0;
+        height: spacing.$spacing-xl;
+        padding: spacing.$spacing-sm;
+        &::placeholder {
+            font-size: typography.$text-size-md;
         }
-        select[name="sort"] {
-            font-size: typography.$text-size-sm;
-            order: 4;
-            flex: 1 1 auto;
-            @include breakpoints.for-tablet-landscape-up {
-                flex: 0 1 auto;
-            }
-            border-radius: 0;
-            height: spacing.$spacing-xl;
-            padding: spacing.$spacing-xs;
-            margin-top: spacing.$spacing-sm;
+    }
+    select[name="sort"] {
+        font-size: typography.$text-size-sm;
+        order: 4;
+        flex: 1 1 auto;
+        @include breakpoints.for-tablet-landscape-up {
+            flex: 0 1 auto;
         }
-        label[for="sort"] {
-            @include container.two-column;
-            order: 3;
-            flex: 1 0 100%;
-            margin-top: spacing.$spacing-lg;
-        }
-        input[type="submit"] {
-            @include typography.button;
-            order: 2;
-            flex: 0 0 10%;
-            border-radius: 0;
-            margin-left: 0;
-            background-color: colors.$gray-30;
-            border: 1px solid colors.$gray-50;
-            height: spacing.$spacing-xl;
-        }
+        border-radius: 0;
+        height: spacing.$spacing-xl;
+        padding: spacing.$spacing-xs;
+        margin-top: spacing.$spacing-sm;
+    }
+    label[for="sort"] {
+        @include container.two-column;
+        order: 3;
+        flex: 1 0 100%;
+        margin-top: spacing.$spacing-lg;
+    }
+    input[type="submit"] {
+        @include typography.button;
+        order: 2;
+        flex: 0 0 10%;
+        border-radius: 0;
+        margin-left: 0;
+        background-color: colors.$gray-30;
+        border: 1px solid colors.$gray-50;
+        height: spacing.$spacing-xl;
     }
 }

--- a/sitemedia/scss/components/_tag.scss
+++ b/sitemedia/scss/components/_tag.scss
@@ -5,8 +5,8 @@
 @use "../base/typography";
 
 .tags li {
-    @include typography.button;
-
+    @include typography.meta;
+    text-transform: lowercase;
     display: inline-block;
     &::before {
         content: "#";

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -2,6 +2,7 @@
 // Document search page.
 // -----------------------------------------------------------------------------
 
+@use "../base/breakpoints";
 @use "../base/container";
 @use "../base/spacing";
 
@@ -13,6 +14,10 @@
         display: flex;
         flex-direction: column;
         padding: spacing.$spacing-md;
+        margin-top: spacing.$spacing-lg;
+        @include breakpoints.for-tablet-landscape-up {
+            margin-top: spacing.$spacing-2xl;
+        }
     }
     section#document-list {
         width: 100%;


### PR DESCRIPTION
### What this PR does
- Per #309:
  - Implements type sizes for the search page according to the designs
  - Removes the underline from "View document details" link per designs
- Slightly reorganizes CSS to prevent the same selector from having two separate definitions

### Additional notes
- As I mentioned previously, the type sizes are defined relative to the page root—in terms of `rem`—rather than absolute `px` values. I went ahead and tried to match the values as closely as I could. I mapped it like this:
  - 16px --> `$text-size-md: 1rem;`
  - 18px --> `$text-size-2md: 1.15rem;`
  - 20px --> `$text-size-lg: 1.25rem;`
  I don't believe there are any font sizes besides those in the designs.
- I feel like the "View document details" type looks massive on desktop, but it's matching the design at 20px, the same size as the document title. It could be that the lack of an image is making it look larger than it should. On mobile it's smaller than the doc title, which makes it look nicer on mobile, in my opinion.
- I noticed that the description text is in "redacted script" but is size 20px on desktop/18px on mobile, in other words, the same size as the doc title. I wasn't sure if this was intended—I left it untouched at `text-size-md` (actually the "body" style mixin) but I can change it to match the doc title if need be.