### PR TITLE
#310, #311 - Implement search box and button styles

### DIFF
--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -11,7 +11,9 @@
             {{ form.q }}
             {{ form.sort }}
             <label for="sort">{{ form.sort.label }}</label>
-            <button type="submit" aria-label="search">
+            {# Translators: Search submit button #}
+            {% translate 'Submit search' as search_label %}
+            <button type="submit" aria-label="{{ search_label }}">
                 <i class="ph-magnifying-glass"></i>
             </button>
         </fieldset>

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -11,7 +11,9 @@
             {{ form.q }}
             {{ form.sort }}
             <label for="sort">{{ form.sort.label }}</label>
-            <button type="submit"><i class="ph-magnifying-glass"></i></button>
+            <button type="submit" aria-label="search">
+                <i class="ph-magnifying-glass"></i>
+            </button>
         </fieldset>
         {% for field, errors in form.errors.items %}
             {# no clean way to get field labels here, so we just collapse the error lists #}

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -11,7 +11,7 @@
             {{ form.q }}
             {{ form.sort }}
             <label for="sort">{{ form.sort.label }}</label>
-            <input type="submit" value="search" />
+            <button type="submit"><i class="ph-magnifying-glass"></i></button>
         </fieldset>
         {% for field, errors in form.errors.items %}
             {# no clean way to get field labels here, so we just collapse the error lists #}

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-02 15:14-0400\n"
+"POT-Creation-Date: 2021-11-03 11:47-0400\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -72,8 +72,15 @@ msgstr "محرر"
 msgid "Permalink"
 msgstr "رابط دائم"
 
+#. Translators: Search submit button
+#: geniza/corpus/templates/corpus/document_list.html:15
+#, fuzzy
+#| msgid "Search"
+msgid "Submit search"
+msgstr "البحث"
+
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:26
+#: geniza/corpus/templates/corpus/document_list.html:30
 #, python-format
 msgid "1 result"
 msgid_plural "%(counter)s total results"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-02 15:14-0400\n"
+"POT-Creation-Date: 2021-11-03 11:47-0400\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -71,8 +71,13 @@ msgstr "Editor"
 msgid "Permalink"
 msgstr ""
 
+#. Translators: Search submit button
+#: geniza/corpus/templates/corpus/document_list.html:15
+msgid "Submit search"
+msgstr ""
+
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:26
+#: geniza/corpus/templates/corpus/document_list.html:30
 #, python-format
 msgid "1 result"
 msgid_plural "%(counter)s total results"

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-02 15:14-0400\n"
+"POT-Creation-Date: 2021-11-03 11:47-0400\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -72,8 +72,15 @@ msgstr "עורך"
 msgid "Permalink"
 msgstr ""
 
+#. Translators: Search submit button
+#: geniza/corpus/templates/corpus/document_list.html:15
+#, fuzzy
+#| msgid "Search"
+msgid "Submit search"
+msgstr "חיפוש"
+
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:26
+#: geniza/corpus/templates/corpus/document_list.html:30
 #, python-format
 msgid "1 result"
 msgid_plural "%(counter)s total results"

--- a/sitemedia/scss/base/_a11y.scss
+++ b/sitemedia/scss/base/_a11y.scss
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 
 // hide content for all but screen readers
-.sr-only {
+@mixin sr-only {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -14,7 +14,7 @@
 }
 
 // ensure only screen readers can focus. apply this with .sr-only
-.sr-only-focusable {
+@mixin sr-only-focusable {
     &:active,
     &:focus {
         position: static;
@@ -24,4 +24,12 @@
         clip: auto;
         white-space: normal;
     }
+}
+
+.sr-only {
+    @include sr-only;
+}
+
+.sr-only-focusable {
+    @include sr-only-focusable;
 }

--- a/sitemedia/scss/base/_a11y.scss
+++ b/sitemedia/scss/base/_a11y.scss
@@ -13,8 +13,9 @@
     white-space: nowrap;
 }
 
-// ensure only screen readers can focus. apply this with .sr-only
+// hide content for all but screen readers, and ensure only screen readers can focus
 @mixin sr-only-focusable {
+    @include sr-only;
     &:active,
     &:focus {
         position: static;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -67,7 +67,6 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            @include a11y.sr-only;
             @include a11y.sr-only-focusable;
             @include breakpoints.for-tablet-landscape-up {
                 width: auto;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -27,7 +27,9 @@
             order: 1;
             flex: 1 0 auto;
             border: 1px solid colors.$gray-50;
-            border-right: none;
+            @include breakpoints.for-tablet-landscape-up {
+                border-right: none;
+            }
             margin-right: 0;
             height: spacing.$spacing-xl;
             padding: spacing.$spacing-sm;

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -13,6 +13,10 @@
 #search form fieldset {
     @include container.two-column;
     max-width: 100%;
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: flex-start;
     input[type="search"] {
         max-width: 100%;
         order: 1;
@@ -76,15 +80,5 @@
                 height: spacing.$spacing-xl;
             }
         }
-    }
-    input[type="submit"] {
-        @include typography.button;
-        order: 2;
-        flex: 0 0 10%;
-        border-radius: 0;
-        margin-left: 0;
-        background-color: colors.$gray-30;
-        border: 1px solid colors.$gray-50;
-        height: spacing.$spacing-xl;
     }
 }

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -2,6 +2,7 @@
 // Document search form.
 // -----------------------------------------------------------------------------
 
+@use "../base/a11y";
 @use "../base/breakpoints";
 @use "../base/colors";
 @use "../base/container";
@@ -16,13 +17,13 @@
         margin-top: spacing.$spacing-2xl;
     }
     fieldset {
-        @include container.two-column;
+        max-width: 100%;
         display: flex;
         flex-flow: row wrap;
         align-items: center;
         justify-content: flex-start;
         input[type="search"] {
-            @include container.two-column;
+            max-width: 100%;
             order: 1;
             flex: 1 0 auto;
             border: 1px solid colors.$gray-50;
@@ -35,6 +36,7 @@
             }
         }
         select[name="sort"] {
+            max-width: 100%;
             font-size: typography.$text-size-sm;
             order: 4;
             flex: 1 1 auto;
@@ -47,20 +49,34 @@
             margin-top: spacing.$spacing-sm;
         }
         label[for="sort"] {
-            @include container.two-column;
+            max-width: 100%;
             order: 3;
             flex: 1 0 100%;
             margin-top: spacing.$spacing-lg;
         }
-        input[type="submit"] {
-            @include typography.button;
+        button[type="submit"] {
             order: 2;
-            flex: 0 0 10%;
+            flex: 0 0 40px;
             border-radius: 0;
             margin-left: 0;
             background-color: colors.$gray-30;
             border: 1px solid colors.$gray-50;
-            height: spacing.$spacing-xl;
+            font-size: typography.$text-size-xl;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            @include a11y.sr-only;
+            @include a11y.sr-only-focusable;
+            @include breakpoints.for-tablet-landscape-up {
+                width: auto;
+                height: spacing.$spacing-xl;
+                position: relative;
+                &:active,
+                &:focus {
+                    width: auto;
+                    height: spacing.$spacing-xl;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Might have made more sense to roll this in with #345, but I had already created a new feature branch for it!

### What this PR does
- Per #310:
  - The bulk of this was already accomplished in #336
  - Fixes some issues with form elements on different screen sizes via better use of `max-width`

- Per #311:
  - Changes the search submit button into an icon button using the Phosphor magnifying glass
  - Hides the search button on mobile, but leaves it accessible to screen readers

### Additional notes
- Question for @rlskoeser: Should `aria-label` names be translated?