### PR TITLE
keyword in context highlighting for search term matches in description

### DIFF
--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -10,6 +10,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
 
     #: map readable field names to actual solr fields
     field_aliases = {
+        "id": "id",  # needed to match results with highlighting
         "type": "type_s",
         "status": "status_s",
         "shelfmark": "shelfmark_ss",

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -26,7 +26,19 @@
             </dl>
 
             {# description #}
-            <p class="description">{{ document.description.0|truncatewords:25 }}</p>
+            <p class="description">
+                {# display keywords in context if any #}
+                {% if highlighting and document.id in highlighting %}
+                    {% with document_highlights=highlighting|dict_item:document.id %}
+                        {% for snippet in document_highlights.description_t %}
+                            {{ snippet|safe }}
+                        {% endfor %}
+                    {% endwith %}
+                {% else %}
+                    {# otherwise, display truncated description #}
+                    {{ document.description.0|truncatewords:25 }}
+                {% endif %}
+            </p>
 
             {# scholarship records #}
             <p class="scholarship">

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -10,3 +10,16 @@ def alphabetize(value):
         return sorted([s.lower() for s in value])
     else:
         raise TypeError("Argument must be a list of strings")
+
+
+# dict_item filter ported from ppa codebase
+
+
+@register.filter
+def dict_item(dictionary, key):
+    """'Template filter to allow accessing dictionary value by variable key.
+    Example use::
+
+        {{ mydict|dict_item:keyvar }}
+    """
+    return dictionary.get(key, None)

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -32,3 +32,14 @@ class TestCorpusExtrasTemplateTags:
         lst = []
         alphabetized = corpus_extras.alphabetize(lst)
         assert alphabetized == []
+
+
+def test_dict_item():
+    # no error on not found
+    assert corpus_extras.dict_item({}, "foo") is None
+    # string key
+    assert corpus_extras.dict_item({"foo": "bar"}, "foo") is "bar"
+    # integer key
+    assert corpus_extras.dict_item({13: "lucky"}, 13) is "lucky"
+    # integer value
+    assert corpus_extras.dict_item({13: 7}, 13) is 7

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -64,8 +64,10 @@ class DocumentSearchView(ListView, FormMixin):
             search_opts = form.cleaned_data
 
             if search_opts["q"]:
-                documents = documents.keyword_search(search_opts["q"]).also(
-                    "score"
+                documents = (
+                    documents.keyword_search(search_opts["q"])
+                    .highlight("description", snippets=3, method="unified")
+                    .also("score")
                 )  # include relevance score in results
 
             # sorting TODO; for now, order by relevance
@@ -86,6 +88,7 @@ class DocumentSearchView(ListView, FormMixin):
                 "page_title": self.page_title,
                 "page_description": self.page_description,
                 "page_type": "search",
+                "highlighting": self.queryset.get_highlighting(),
             }
         )
         return context_data

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,7 +11,9 @@ django-modeltranslation
 django-admin-sortable2
 python-dateutil>=2.8
 django-tabular-export
-parasolr>=0.7
+#parasolr>=0.7
+# require develop version of parasolr until 0.8 is released
+git+https://github.com/Princeton-CDH/parasolr@develop#egg=parasolr
 django-gfklookupwidget
 django-adminlogentries
 django-webpack-loader

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -6,6 +6,7 @@
 @use "../base/container";
 @use "../base/spacing";
 @use "../base/typography";
+@use "../base/colors";
 
 section#document-list {
     // count of results
@@ -83,6 +84,18 @@ section#document-list {
         .description {
             order: 4;
             margin: spacing.$spacing-md 0;
+
+            // keywords in context
+            em {
+                @include colors.apply-theme("primary");
+                font-weight: bold;
+            }
+            /* solr returns multiple matches in text without space between */
+            em + em {
+                &::before {
+                    content: " ";
+                }
+            }
         }
 
         // document scholarship records


### PR DESCRIPTION
- configure solr highlighting on search term in description text
- render highlighting in results if present, otherwise display description excerpt as usual

I ported a `dict_item` template from one of our other codebases for an easy way to get the highlighted content for a given document.

I made a slight update to a pytest fixture in `parasolr` (our locally developed python solr client) because it made testing the assertions on the solr queryset much easier and more readable — so tests will require the develop version of that package until I release a new version.