### PR TITLE
Configure public site urls for i18n

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -12,6 +12,7 @@ from django.db.models.functions import Concat
 from django.db.models.query import Prefetch
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.translation import activate
 from django.utils.translation import gettext as _
 from parasolr.django.indexing import ModelIndexable
 from piffle.image import IIIFImageClient
@@ -455,7 +456,10 @@ class Document(ModelIndexable):
 
     @property
     def permalink(self):
-        return absolutize_url(self.get_absolute_url())
+        # generate permalink without language url so that all versions
+        # have the same link and users will be directed preferred language
+        activate("en")
+        return absolutize_url(self.get_absolute_url().replace("/en/", "/"))
 
     def iiif_urls(self):
         """List of IIIF urls for images of the Document's Fragments."""

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -315,14 +315,16 @@ class TestDocument:
 
     def test_get_absolute_url(self):
         doc = Document.objects.create(id=1)
-        assert doc.get_absolute_url() == "/documents/1/"
+        assert doc.get_absolute_url() == "/en/documents/1/"
 
     def test_permalink(self):
-        """permalink property should be constructed from base url and absolute url"""
+        """permalink property should be constructed from base url and absolute url, without any language code"""
         doc = Document.objects.create(id=1)
         site_domain = Site.objects.get_current().domain.rstrip("/")
         assert f"{site_domain}/documents/1/" in doc.permalink
-        assert doc.permalink == absolutize_url(doc.get_absolute_url())
+        assert doc.permalink == absolutize_url(doc.get_absolute_url()).replace(
+            "/en/", "/"
+        )
 
     def test_iiif_urls(self):
         # create example doc with two fragments with URLs

--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -144,7 +144,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "en"
 
 TIME_ZONE = "America/New_York"
 

--- a/geniza/urls.py
+++ b/geniza/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic.base import RedirectView
@@ -25,8 +26,12 @@ urlpatterns = [
     path("accounts/", include("pucas.cas_urls")),
     path("i18n/", include("django.conf.urls.i18n")),
     path("taggit/", include("taggit_selectize.urls")),
-    path("", include("geniza.corpus.urls", namespace="corpus")),
 ]
+
+# urls that should be available in multiple languages
+urlpatterns += i18n_patterns(
+    path("", include("geniza.corpus.urls", namespace="corpus")),
+)
 
 
 if settings.DEBUG:


### PR DESCRIPTION
When I went to test the form localization (#339) I discovered I'd missed a step with the i18n setup in the url configuration; this remedies that.

I revised the permalink url logic so it does _not_ include a language code: this way all versions of a document will show the same url for citation purposes, but it will resolve to the user's preferred language or the site default.

Note that this means there's now a difference between `get_absolute_url` and `permalink`; this is because I think the absolute urls we're generating elsewhere should be relative to the currently active language.

changes in this PR:
- adds `i18n_patterns` to main url config for public site urls (currently only `corpus`)
- revise document permalink behavior so it is language independent 
- adjust tests for the change to permalink
