### PR TITLE
#354 - Replace semicolon with colon in doc titles

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -496,7 +496,7 @@ class Document(ModelIndexable):
     @property
     def title(self):
         """Short title for identifying the document, e.g. via search."""
-        return f"{self.doctype or _('Unknown type')}; {self.shelfmark_display or '??'}"
+        return f"{self.doctype or _('Unknown type')}: {self.shelfmark_display or '??'}"
 
     def editions(self):
         """All footnotes for this document where the document relation includes

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -370,14 +370,14 @@ class TestDocument:
 
     def test_title(self):
         doc = Document.objects.create()
-        assert doc.title == "Unknown type; ??"
+        assert doc.title == "Unknown type: ??"
         legal = DocumentType.objects.get_or_create(name="Legal")[0]
         doc.doctype = legal
         doc.save()
-        assert doc.title == "Legal document; ??"
+        assert doc.title == "Legal document: ??"
         frag = Fragment.objects.create(shelfmark="s1")
         TextBlock.objects.create(document=doc, fragment=frag, order=1)
-        assert doc.title == "Legal document; s1"
+        assert doc.title == "Legal document: s1"
 
     def test_shelfmark_display(self):
         # T-S 8J22.21 + T-S NS J193

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -113,6 +113,6 @@ $text-size-5xl: 3.81rem;
     font-weight: bold;
     &::after {
         font-weight: normal;
-        content: "; ";
+        content: ": ";
     }
 }


### PR DESCRIPTION
### What this PR does
- Per #354:
  - Updates `Document` model `title` property, which is used in document detail view head metadata 
  - Updates `_typography.scss`, which is used in search results page, and document detail view title header
  - Updates tests to use colon
