### PR TITLE
Revise & correct scholarship counts for search

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -45,10 +45,36 @@
             {# scholarship records #}
             <p class="scholarship">
                 {% if document.scholarship_count %}
-                    <i class="ph-check"></i>
-                    {% if document.num_editions %}{% translate 'Transcription' %}{% if document.num_editions > 1 %} ({{ document.num_editions }}){% endif %}{% endif %}
-                    {% if document.num_translations %}{% translate 'Translation' %}{% if document.num_translations > 1 %} ({{ document.num_translations }}){% endif %}{% endif %}
-                    {% if document.num_discussions %}{% translate 'Discussion' %}{% if document.num_discussions > 1 %} ({{ document.num_discussions }}){% endif %}{% endif %}
+                    {% if document.num_editions %}
+                        <span>
+                            {% comment %}Translators: number of editions for this document{% endcomment %}
+                            {% blocktranslate count counter=document.num_editions trimmed %}
+                                1 Transcription
+                            {% plural %}
+                                {{ counter }} Transcriptions
+                            {% endblocktranslate %}
+                        </span>
+                    {% endif %}
+                    {% if document.num_translations %}
+                        <span>
+                            {% comment %}Translators: number of translations for this document{% endcomment %}
+                            {% blocktranslate count counter=document.num_translations trimmed %}
+                                1 Translation
+                            {% plural %}
+                                {{ counter }} Translations
+                            {% endblocktranslate %}
+                        </span>
+                    {% endif %}
+                    {% if document.num_discussions %}
+                        <span>
+                            {% comment %}Translators: number of sources that discuss this document{% endcomment %}
+                            {% blocktranslate count counter=document.num_discussions trimmed %}
+                                1 Discussion
+                            {% plural %}
+                                {{ counter }} Discussions
+                            {% endblocktranslate %}
+                        </span>
+                    {% endif %}
                 {% else %}
                     {% translate 'No Scholarship Records' %}
                 {% endif %}

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -244,7 +244,7 @@ class TestDocumentResult:
             }
         )
         assert "No Scholarship Records" not in result
-        assert "Transcription (15)" in result
+        assert "15 Transcriptions" in result
         assert "Translation" not in result
         assert "Discusion" not in result
 
@@ -255,16 +255,16 @@ class TestDocumentResult:
                     "pgpid": 1,
                     "id": "document.1",
                     "num_editions": 2,
-                    "num_translations": 3,
+                    "num_translations": 1,
                     "num_discussions": 2,
                     "scholarship_count": 10,
                 },
                 "highlighting": {},
             },
         )
-        assert "Transcription (2)" in result
-        assert "Translation (3)" in result
-        assert "Discussion (2)" in result
+        assert "2 Transcriptions" in result
+        assert "1 Translation" in result
+        assert "2 Discussions" in result
 
     def test_description(self, document):
         context = {

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -105,6 +105,10 @@ section#document-list {
         .scholarship {
             order: 5;
             @include typography.meta;
+
+            & span {
+                padding-right: spacing.$spacing-md;
+            }
         }
     }
 


### PR DESCRIPTION
updates the scholarship display on the public search
- fix a bug where 1-counts for scholarship records were not displayed
- revise layout to match the latest revisions in the design (#338) and update tests accordingly
- use `blocktranslate` to handle pluralization properly