### PR TITLE
#231 - Add "edit" link to document detail view for admins

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -17,6 +17,16 @@
 {% block main %}
     <!-- document details -->
 
+    {% if perms.corpus.change_document %}
+        <div class="edit-link-container">
+            <a class="edit-link" href="{% url 'admin:corpus_document_change' document.id %}">
+                <i class="ph-pencil"></i>
+                {# Translators: Document edit button for admins #}
+                <span>{% translate 'Edit' %}</span>
+            </a>
+        </div>
+    {% endif %}
+
     {# title #}
     <h1>
         {# Translators: Default label when document does not have a type #}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -21,7 +21,7 @@
         <div class="edit-link-container">
             <a class="edit-link" href="{% url 'admin:corpus_document_change' document.id %}">
                 <i class="ph-pencil"></i>
-                {# Translators: Document edit button for admins #}
+                {# Translators: Document edit link for admins #}
                 <span>{% translate 'Edit' %}</span>
             </a>
         </div>

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.template.loader import get_template, render_to_string
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
@@ -57,6 +58,18 @@ class TestDocumentDetailTemplate:
         first_url = join.textblock_set.first().fragment.iiif_url
         second_url = join.textblock_set.last().fragment.iiif_url
         assertContains(response, f'data-iiif-urls="{first_url} {second_url}"')
+
+    def test_edit_link(self, client, document):
+        """Edit link should appear if user is admin, otherwise it should not"""
+        edit_url = reverse("admin:corpus_document_change", args=[document.id])
+        response = client.get(document.get_absolute_url())
+        assertNotContains(response, f'<a class="edit-link" href="{edit_url}">')
+        user = User.objects.create_user(
+            "foo", "myemail@test.com", "bar", is_superuser=True
+        )
+        client.login(username="foo", password="bar")
+        response = client.get(document.get_absolute_url())
+        assertContains(response, f'<a class="edit-link" href="{edit_url}">')
 
 
 class TestDocumentScholarshipTemplate:

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -1,5 +1,4 @@
-from django.contrib.auth.models import User
-from django.template.loader import get_template, render_to_string
+from django.template.loader import get_template
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
 
@@ -59,17 +58,13 @@ class TestDocumentDetailTemplate:
         second_url = join.textblock_set.last().fragment.iiif_url
         assertContains(response, f'data-iiif-urls="{first_url} {second_url}"')
 
-    def test_edit_link(self, client, document):
+    def test_edit_link(self, client, admin_client, document):
         """Edit link should appear if user is admin, otherwise it should not"""
         edit_url = reverse("admin:corpus_document_change", args=[document.id])
         response = client.get(document.get_absolute_url())
-        assertNotContains(response, f'<a class="edit-link" href="{edit_url}">')
-        user = User.objects.create_user(
-            "foo", "myemail@test.com", "bar", is_superuser=True
-        )
-        client.login(username="foo", password="bar")
-        response = client.get(document.get_absolute_url())
-        assertContains(response, f'<a class="edit-link" href="{edit_url}">')
+        assertNotContains(response, edit_url)
+        response = admin_client.get(document.get_absolute_url())
+        assertContains(response, edit_url)
 
 
 class TestDocumentScholarshipTemplate:

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-16 14:52-0500\n"
+"POT-Creation-Date: 2021-11-16 14:56-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -62,7 +62,7 @@ msgstr ""
 msgid "Home"
 msgstr "المنزل"
 
-#. Translators: Document edit button for admins
+#. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/document_detail.html:25
 #, fuzzy
 #| msgid "Editor"

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-09 13:18-0500\n"
+"POT-Creation-Date: 2021-11-16 14:52-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -53,8 +53,8 @@ msgid "Sort by"
 msgstr "الترتيب حسب"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:541
-#: geniza/corpus/templates/corpus/document_detail.html:23
+#: geniza/corpus/models.py:551
+#: geniza/corpus/templates/corpus/document_detail.html:33
 msgid "Unknown type"
 msgstr ""
 
@@ -62,35 +62,42 @@ msgstr ""
 msgid "Home"
 msgstr "المنزل"
 
+#. Translators: Document edit button for admins
+#: geniza/corpus/templates/corpus/document_detail.html:25
+#, fuzzy
+#| msgid "Editor"
+msgid "Edit"
+msgstr "محرر"
+
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Metadata"
 msgstr ""
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:51
 msgid "Editor"
 msgstr "محرر"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:58
 #: geniza/corpus/templates/corpus/snippets/document_result.html:24
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:62
 msgid "Permalink"
 msgstr "رابط دائم"
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:72
 #: geniza/corpus/templates/corpus/snippets/document_result.html:14
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:83
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-16 14:52-0500\n"
+"POT-Creation-Date: 2021-11-16 14:56-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Home"
 msgstr "Home"
 
-#. Translators: Document edit button for admins
+#. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/document_detail.html:25
 #, fuzzy
 #| msgid "Editor"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-09 13:18-0500\n"
+"POT-Creation-Date: 2021-11-16 14:52-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -48,8 +48,8 @@ msgid "Sort by"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:541
-#: geniza/corpus/templates/corpus/document_detail.html:23
+#: geniza/corpus/models.py:551
+#: geniza/corpus/templates/corpus/document_detail.html:33
 msgid "Unknown type"
 msgstr ""
 
@@ -57,35 +57,42 @@ msgstr ""
 msgid "Home"
 msgstr "Home"
 
+#. Translators: Document edit button for admins
+#: geniza/corpus/templates/corpus/document_detail.html:25
+#, fuzzy
+#| msgid "Editor"
+msgid "Edit"
+msgstr "Editor"
+
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Metadata"
 msgstr ""
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:51
 msgid "Editor"
 msgstr "Editor"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:58
 #: geniza/corpus/templates/corpus/snippets/document_result.html:24
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:62
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:72
 #: geniza/corpus/templates/corpus/snippets/document_result.html:14
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:83
 msgid "Description"
 msgstr ""
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-09 13:18-0500\n"
+"POT-Creation-Date: 2021-11-16 14:52-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -53,8 +53,8 @@ msgid "Sort by"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:541
-#: geniza/corpus/templates/corpus/document_detail.html:23
+#: geniza/corpus/models.py:551
+#: geniza/corpus/templates/corpus/document_detail.html:33
 msgid "Unknown type"
 msgstr ""
 
@@ -62,35 +62,42 @@ msgstr ""
 msgid "Home"
 msgstr "דף הבית"
 
+#. Translators: Document edit button for admins
+#: geniza/corpus/templates/corpus/document_detail.html:25
+#, fuzzy
+#| msgid "Editor"
+msgid "Edit"
+msgstr "עורך"
+
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Metadata"
 msgstr ""
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:51
 msgid "Editor"
 msgstr "עורך"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:58
 #: geniza/corpus/templates/corpus/snippets/document_result.html:24
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:62
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:72
 #: geniza/corpus/templates/corpus/snippets/document_result.html:14
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:83
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-11-16 14:52-0500\n"
+"POT-Creation-Date: 2021-11-16 14:56-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -62,7 +62,7 @@ msgstr ""
 msgid "Home"
 msgstr "דף הבית"
 
-#. Translators: Document edit button for admins
+#. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/document_detail.html:25
 #, fuzzy
 #| msgid "Editor"

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -4,6 +4,7 @@
 
 @use "../base/breakpoints";
 @use "../base/colors";
+@use "../base/container";
 @use "../base/spacing";
 @use "../base/typography";
 
@@ -18,6 +19,25 @@ body#document {
         // document type, inside title
         .doctype {
             @include typography.doctype;
+        }
+    }
+    .edit-link-container {
+        @include container.measure;
+        position: absolute;
+        width: 100%;
+        display: flex;
+        justify-content: flex-end;
+        a.edit-link {
+            span {
+                @include typography.link;
+            }
+            i {
+                text-decoration: none;
+            }
+            margin-right: spacing.$spacing-xl;
+            @include breakpoints.for-desktop-up {
+                margin: spacing.$spacing-xl spacing.$spacing-md;
+            }
         }
     }
     // Primary container


### PR DESCRIPTION
### What this PR does

- Per #231:
  - Adds an "Edit" link (with Phosphor pencil icon) to the document detail view template for those with appropriate permissions
  - Adds template test for the above