### PR TITLE
#313 - Use inline-block for tab links

### DIFF
--- a/sitemedia/scss/components/_tabs.scss
+++ b/sitemedia/scss/components/_tabs.scss
@@ -12,22 +12,13 @@
     text-align: center;
     font-size: typography.$text-size-md;
     margin: 0 auto;
-    @include breakpoints.for-tablet-landscape-up {
-        font-size: typography.$text-size-2md;
-        padding: spacing.$spacing-2xs;
-    }
     a {
-        flex: 0 1;
+        flex: 1 0 auto;
+        display: inline-block;
         font-size: typography.$text-size-md;
         @include breakpoints.for-tablet-landscape-up {
             font-size: typography.$text-size-2md;
-        }
-    }
-    li {
-        flex: 0 1;
-        padding: 0 spacing.$spacing-xs;
-        @include breakpoints.for-tablet-landscape-up {
-            padding: 0 spacing.$spacing-lg;
+            padding: spacing.$spacing-2xs spacing.$spacing-lg;
         }
     }
     a[aria-current="page"] {

--- a/sitemedia/scss/components/_tabs.scss
+++ b/sitemedia/scss/components/_tabs.scss
@@ -12,7 +12,8 @@
     text-align: center;
     font-size: typography.$text-size-md;
     margin: 0 auto;
-    a {
+    a,
+    span {
         flex: 1 0 auto;
         display: inline-block;
         font-size: typography.$text-size-md;

--- a/sitemedia/scss/components/_tabs.scss
+++ b/sitemedia/scss/components/_tabs.scss
@@ -22,6 +22,13 @@
             padding: spacing.$spacing-2xs spacing.$spacing-lg;
         }
     }
+    // Center tab padding boost
+    li:nth-child(2) a,
+    li:nth-child(2) span {
+        @include breakpoints.for-tablet-landscape-up {
+            padding: spacing.$spacing-2xs spacing.$spacing-2xl;
+        }
+    }
     a[aria-current="page"] {
         font-weight: bold;
     }


### PR DESCRIPTION
## What this PR does

Per https://github.com/Princeton-CDH/geniza/issues/313#issuecomment-985625133:
- Uses `display: inline-block` and padding for document tabs links, ensuring that the space around the text is clickable