### PR TITLE
#390 - Brief citations for digital editions

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -525,6 +525,23 @@ class Document(ModelIndexable):
             "content", "source"
         )
 
+    def digital_editions(self):
+        """All footnotes for this document where the document relation includes
+        edition AND the footnote has content."""
+        editions_with_content = (
+            self.footnotes.filter(doc_relation__contains=Footnote.EDITION)
+            .filter(content__isnull=False)
+            .order_by("content", "source")
+        )
+        display_strings = []
+        editions_with_unique_display = []
+        for f in editions_with_content:
+            if f.display() not in display_strings:
+                # Prevent redundant display of identical brief citations on detail page
+                editions_with_unique_display += [f.pk]
+                display_strings += [f.display()]
+        return editions_with_content.filter(pk__in=editions_with_unique_display)
+
     @classmethod
     def items_to_index(cls):
         """Custom logic for finding items to be indexed when indexing in

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -536,10 +536,7 @@ class Document(ModelIndexable):
 
     def editors(self):
         """All unique authors of digital editions for this document."""
-        editor_pks = []
-        for de in self.digital_editions():
-            editor_pks += [author.pk for author in de.source.authors.all()]
-        return Creator.objects.filter(pk__in=editor_pks)
+        return Creator.objects.filter(source__footnote__doc_relation__contains=Footnote.EDITION, content_isnull=False, source__footnote__document=self).distinct()
 
     @classmethod
     def items_to_index(cls):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -528,19 +528,11 @@ class Document(ModelIndexable):
     def digital_editions(self):
         """All footnotes for this document where the document relation includes
         edition AND the footnote has content."""
-        editions_with_content = (
+        return (
             self.footnotes.filter(doc_relation__contains=Footnote.EDITION)
             .filter(content__isnull=False)
             .order_by("content", "source")
         )
-        display_strings = []
-        editions_with_unique_display = []
-        for f in editions_with_content:
-            if f.display() not in display_strings:
-                # Prevent redundant display of identical brief citations on detail page
-                editions_with_unique_display += [f.pk]
-                display_strings += [f.display()]
-        return editions_with_content.filter(pk__in=editions_with_unique_display)
 
     @classmethod
     def items_to_index(cls):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -536,7 +536,11 @@ class Document(ModelIndexable):
 
     def editors(self):
         """All unique authors of digital editions for this document."""
-        return Creator.objects.filter(source__footnote__doc_relation__contains=Footnote.EDITION, content_isnull=False, source__footnote__document=self).distinct()
+        return Creator.objects.filter(
+            source__footnote__doc_relation__contains=Footnote.EDITION,
+            content_isnull=False,
+            source__footnote__document=self,
+        ).distinct()
 
     @classmethod
     def items_to_index(cls):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -23,7 +23,7 @@ from taggit_selectize.managers import TaggableManager
 
 from geniza.common.models import TrackChangesModel
 from geniza.common.utils import absolutize_url
-from geniza.footnotes.models import Footnote, Source
+from geniza.footnotes.models import Creator, Footnote
 
 logger = logging.getLogger(__name__)
 
@@ -533,6 +533,13 @@ class Document(ModelIndexable):
             .filter(content__isnull=False)
             .order_by("content", "source")
         )
+
+    def editors(self):
+        """All unique authors of digital editions for this document."""
+        editor_pks = []
+        for de in self.digital_editions():
+            editor_pks += [author.pk for author in de.source.authors.all()]
+        return Creator.objects.filter(pk__in=editor_pks)
 
     @classmethod
     def items_to_index(cls):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -538,7 +538,7 @@ class Document(ModelIndexable):
         """All unique authors of digital editions for this document."""
         return Creator.objects.filter(
             source__footnote__doc_relation__contains=Footnote.EDITION,
-            content_isnull=False,
+            source__footnote__content__isnull=False,
             source__footnote__document=self,
         ).distinct()
 

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -33,7 +33,7 @@
                 {% if document.digital_editions %}
                     <dt>
                         {# Translators: Editor label #}
-                        {% blocktranslate count counter=document.digital_editions.count trimmed %}
+                        {% blocktranslate count counter=document.editors.count trimmed %}
                             Editor
                         {% plural %}
                             Editors

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -31,8 +31,8 @@
             {# metadata #}
             <dl class="metadata">
                 {% if document.digital_editions %}
-                    {# Translators: Editor label #}
                     <dt>
+                        {# Translators: Editor label #}
                         {% blocktranslate count counter=document.digital_editions.count trimmed %}
                             Editor
                         {% plural %}
@@ -40,7 +40,9 @@
                         {% endblocktranslate %}
                     </dt>
                     {% for ed in document.digital_editions %}
-                        <dd>{{ ed.display|safe }}</dd>
+                        {% ifchanged %}
+                            <dd>{{ ed.display|safe }}</dd>
+                        {% endifchanged %}
                         {# link ? #}
                     {% endfor %}
                 {% endif %}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -30,10 +30,16 @@
             </h2>
             {# metadata #}
             <dl class="metadata">
-                {% if document.editions %}
+                {% if document.digital_editions %}
                     {# Translators: Editor label #}
-                    <dt>{% translate 'Editor' %}</dt>  {# optionally pluralize? #}
-                    {% for ed in document.editions %}
+                    <dt>
+                        {% blocktranslate count counter=document.digital_editions.count trimmed %}
+                            Editor
+                        {% plural %}
+                            Editors
+                        {% endblocktranslate %}
+                    </dt>
+                    {% for ed in document.digital_editions %}
                         <dd>{{ ed.display|safe }}</dd>
                         {# link ? #}
                     {% endfor %}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -40,6 +40,7 @@
                         {% endblocktranslate %}
                     </dt>
                     {% for ed in document.digital_editions %}
+                        {# ifchanged to avoid showing duplicate editions #}
                         {% ifchanged %}
                             <dd>{{ ed.display|safe }}</dd>
                         {% endifchanged %}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -596,6 +596,39 @@ class TestDocument:
         # Edition 2 should be alphabetically first based on its content
         assert edition2.pk == digital_edition_pks[0]
 
+    def test_editors(self, document, source, twoauthor_source):
+        # footnote with no content
+        Footnote.objects.create(
+            content_object=document, source=source, doc_relation=Footnote.EDITION
+        )
+        # No digital editions, so editors count should be 0
+        assert document.editors().count() == 0
+
+        # footnote with one author, content
+        Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation={Footnote.EDITION, Footnote.TRANSLATION},
+            content="A piece of text",
+        )
+
+        # Digital edition with one author, editor should be author of source
+        assert document.editors().count() == 1
+        assert document.editors().first() == source.authors.first()
+
+        # footnote with two authors, content
+        Footnote.objects.create(
+            content_object=document,
+            source=twoauthor_source,
+            doc_relation=Footnote.EDITION,
+            content="B other text",
+        )
+        # Should now be three editors, since this edition's source had two authors
+        assert document.editors().count() == 3
+        assert twoauthor_source.authors.first().pk in [
+            editor.pk for editor in document.editors().all()
+        ]
+
 
 def test_document_merge_with(document, join):
     doc_id = document.id

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -579,20 +579,12 @@ class TestDocument:
             doc_relation={Footnote.EDITION, Footnote.TRANSLATION},
             content="A piece of text",
         )
-        # footnote with same source
-        # (so will not be included in digital_editions as its brief citation is identical)
-        edition3 = Footnote.objects.create(
-            content_object=document,
-            source=source,
-            doc_relation=Footnote.EDITION,
-            content="B some other text",
-        )
         # footnote with different source
-        edition4 = Footnote.objects.create(
+        edition3 = Footnote.objects.create(
             content_object=document,
             source=twoauthor_source,
             doc_relation=Footnote.EDITION,
-            content="C other text",
+            content="B other text",
         )
         digital_edition_pks = [ed.pk for ed in document.digital_editions()]
 
@@ -600,10 +592,7 @@ class TestDocument:
         assert edition.pk not in digital_edition_pks
         # Has content, should appear in digital editions
         assert edition2.pk in digital_edition_pks
-        # Identical brief citation, should not appear in digital editions
-        assert edition3.pk not in digital_edition_pks
-        # New source, new brief citation, has content, should appear in digital editions
-        assert edition4.pk in digital_edition_pks
+        assert edition3.pk in digital_edition_pks
         # Edition 2 should be alphabetically first based on its content
         assert edition2.pk == digital_edition_pks[0]
 

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -91,6 +91,39 @@ class TestDocumentDetailTemplate:
         )
         assertNotContains(response, "p. 25")
 
+    def test_editors(self, client, document, source, twoauthor_source):
+        # footnote with no content
+        Footnote.objects.create(
+            content_object=document, source=source, doc_relation=Footnote.EDITION
+        )
+        # No digital editions, so no editors
+        response = client.get(document.get_absolute_url())
+        assertNotContains(response, "Editor")
+
+        # footnote with one author, content
+        Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation={Footnote.EDITION, Footnote.TRANSLATION},
+            content="A piece of text",
+        )
+
+        # Digital edition with one author, should have one editor but not multiple
+        response = client.get(document.get_absolute_url())
+        assertContains(response, "Editor")
+        assertNotContains(response, "Editors")
+
+        # footnote with two authors, content
+        Footnote.objects.create(
+            content_object=document,
+            source=twoauthor_source,
+            doc_relation=Footnote.EDITION,
+            content="B other text",
+        )
+        # Should now be "editors"
+        response = client.get(document.get_absolute_url())
+        assertContains(response, "Editors")
+
 
 class TestDocumentScholarshipTemplate:
     def test_source_title(self, client, document, twoauthor_source):

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -79,8 +79,11 @@ class TestDocumentDetailTemplate:
             doc_relation=Footnote.EDITION,
         )
         response = client.get(document.get_absolute_url())
-        print(response.content)
-        assertContains(response, "p. 25")
+        assertNotContains(response, "p. 25")  # should not show when no content
+        fn.content = "fake content"
+        fn.save()
+        response = client.get(document.get_absolute_url())
+        assertContains(response, "p. 25")  # should show when there is content
         fn.location = ""
         fn.save()
         response = client.get(

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -188,8 +188,12 @@ class Source(models.Model):
             # otherwise, just leave unformatted
             else:
                 work_title = self.title + ltr_mark
-        elif self.source_type and (extra_fields or not author):
+        elif self.source_type and (
+            extra_fields or not author or self.source_type.type == "Unpublished"
+        ):
             # Use type as descriptive title when no title available, per CMS
+            # Only when extra_fields enabled, or there is no author, or "unpublished" should appear
+            # in brief citation
             work_title = (
                 self.source_type.type if not author else self.source_type.type.lower()
             )
@@ -323,8 +327,12 @@ class Source(models.Model):
         #   L. B. Yarbrough (in Hebrew)             (no comma)
         #   Author (1964)                           (no comma)
         #   Author, Journal 6 (1964)                (comma)
+        #   Author, unpublished                     (comma)
         use_comma = (
-            extra_fields or self.title or (self.journal and not non_english_langs)
+            extra_fields
+            or self.title
+            or (self.journal and not non_english_langs)
+            or self.source_type.type == "Unpublished"
         )
         delimiter = ", " if use_comma else " "
 

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -435,15 +435,18 @@ class Footnote(TrackChangesModel):
     def display(self):
         """format footnote for display; used on document detail page
         and metdata export for old pgp site"""
-        # source, location. notes
-        # source. notes
+        # source, location. notes.
+        # source. notes.
         # source, location.
         parts = [str(self.source)]
         if self.location:
             parts.extend([", ", self.location])
         parts.append(".")
         if self.notes:
-            parts.extend([" ", self.notes])
+            # uppercase first letter of notes if not capitalized
+            notes = self.notes[0].upper() + self.notes[1:]
+            # append period to notes if not present
+            parts.extend([" ", notes.strip("."), "."])
         return "".join(parts)
 
     def has_url(self):

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -49,11 +49,13 @@ class TestSource:
             ordinal(twoauthor_source.edition),
         )
 
-        # four authors, no title
+        # four authors, no title, unpublished
         lastnames = [
             a.creator.last_name for a in multiauthor_untitledsource.authorship_set.all()
         ]
-        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s" % tuple(lastnames)
+        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s, %s" % (
+            tuple(lastnames) + (multiauthor_untitledsource.source_type.type.lower(),)
+        )
 
     @pytest.mark.django_db
     def test_str_article(self, article):

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-06 13:11-0500\n"
+"POT-Creation-Date: 2021-12-06 14:53-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -58,7 +58,7 @@ msgid "Document Type"
 msgstr "نوع المستند"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:569
+#: geniza/corpus/models.py:566
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -72,6 +72,7 @@ msgstr "المنزل"
 msgid "Metadata"
 msgstr ""
 
+#. Translators: Editor label
 #: geniza/corpus/templates/corpus/document_detail.html:36
 #, fuzzy
 #| msgid "Editor"
@@ -85,24 +86,24 @@ msgstr[4] "محرر"
 msgstr[5] "محرر"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:50
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:54
 msgid "Permalink"
 msgstr "رابط دائم"
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:64
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:75
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-01 12:48-0500\n"
+"POT-Creation-Date: 2021-12-06 13:11-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -58,7 +58,7 @@ msgid "Document Type"
 msgstr "نوع المستند"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:557
+#: geniza/corpus/models.py:569
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -72,30 +72,37 @@ msgstr "المنزل"
 msgid "Metadata"
 msgstr ""
 
-#. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:36
+#, fuzzy
+#| msgid "Editor"
 msgid "Editor"
-msgstr "محرر"
+msgid_plural "Editors"
+msgstr[0] "محرر"
+msgstr[1] "محرر"
+msgstr[2] "محرر"
+msgstr[3] "محرر"
+msgstr[4] "محرر"
+msgstr[5] "محرر"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:42
+#: geniza/corpus/templates/corpus/document_detail.html:48
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:46
+#: geniza/corpus/templates/corpus/document_detail.html:52
 msgid "Permalink"
 msgstr "رابط دائم"
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:56
+#: geniza/corpus/templates/corpus/document_detail.html:62
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:67
+#: geniza/corpus/templates/corpus/document_detail.html:73
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"
@@ -253,15 +260,15 @@ msgstr[3] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[4] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[5] "%(count)d سجل منح دراسية لـ %(doc)s"
 
-#: geniza/footnotes/models.py:340
+#: geniza/footnotes/models.py:388
 msgid "Edition"
 msgstr "الطبعة"
 
-#: geniza/footnotes/models.py:341
+#: geniza/footnotes/models.py:389
 msgid "Translation"
 msgstr "الترجمة"
 
-#: geniza/footnotes/models.py:342
+#: geniza/footnotes/models.py:390
 msgid "Discussion"
 msgstr "المناقشة"
 

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-06 13:11-0500\n"
+"POT-Creation-Date: 2021-12-06 14:53-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -53,7 +53,7 @@ msgid "Document Type"
 msgstr "Document Type"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:569
+#: geniza/corpus/models.py:566
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -67,6 +67,7 @@ msgstr "Home"
 msgid "Metadata"
 msgstr ""
 
+#. Translators: Editor label
 #: geniza/corpus/templates/corpus/document_detail.html:36
 #, fuzzy
 #| msgid "Editor"
@@ -76,24 +77,24 @@ msgstr[0] "Editor"
 msgstr[1] "Editor"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:50
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:54
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:64
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:75
 msgid "Description"
 msgstr ""
 

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-01 12:48-0500\n"
+"POT-Creation-Date: 2021-12-06 13:11-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -53,7 +53,7 @@ msgid "Document Type"
 msgstr "Document Type"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:557
+#: geniza/corpus/models.py:569
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -67,30 +67,33 @@ msgstr "Home"
 msgid "Metadata"
 msgstr ""
 
-#. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:36
+#, fuzzy
+#| msgid "Editor"
 msgid "Editor"
-msgstr "Editor"
+msgid_plural "Editors"
+msgstr[0] "Editor"
+msgstr[1] "Editor"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:42
+#: geniza/corpus/templates/corpus/document_detail.html:48
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:46
+#: geniza/corpus/templates/corpus/document_detail.html:52
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:56
+#: geniza/corpus/templates/corpus/document_detail.html:62
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:67
+#: geniza/corpus/templates/corpus/document_detail.html:73
 msgid "Description"
 msgstr ""
 
@@ -220,15 +223,15 @@ msgid_plural "%(count)d scholarship records for %(doc)s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: geniza/footnotes/models.py:340
+#: geniza/footnotes/models.py:388
 msgid "Edition"
 msgstr ""
 
-#: geniza/footnotes/models.py:341
+#: geniza/footnotes/models.py:389
 msgid "Translation"
 msgstr ""
 
-#: geniza/footnotes/models.py:342
+#: geniza/footnotes/models.py:390
 msgid "Discussion"
 msgstr ""
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-01 12:48-0500\n"
+"POT-Creation-Date: 2021-12-06 13:11-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -58,7 +58,7 @@ msgid "Document Type"
 msgstr "סוג המסמך"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:557
+#: geniza/corpus/models.py:569
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -72,30 +72,35 @@ msgstr "דף הבית"
 msgid "Metadata"
 msgstr ""
 
-#. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:35
+#: geniza/corpus/templates/corpus/document_detail.html:36
+#, fuzzy
+#| msgid "Editor"
 msgid "Editor"
-msgstr "עורך"
+msgid_plural "Editors"
+msgstr[0] "עורך"
+msgstr[1] "עורך"
+msgstr[2] "עורך"
+msgstr[3] "עורך"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:42
+#: geniza/corpus/templates/corpus/document_detail.html:48
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:46
+#: geniza/corpus/templates/corpus/document_detail.html:52
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:56
+#: geniza/corpus/templates/corpus/document_detail.html:62
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:67
+#: geniza/corpus/templates/corpus/document_detail.html:73
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"
@@ -243,15 +248,15 @@ msgstr[1] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[2] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[3] "%(count)d רשומות קשורות ל %(doc)s"
 
-#: geniza/footnotes/models.py:340
+#: geniza/footnotes/models.py:388
 msgid "Edition"
 msgstr "מהדורה"
 
-#: geniza/footnotes/models.py:341
+#: geniza/footnotes/models.py:389
 msgid "Translation"
 msgstr "תרגום"
 
-#: geniza/footnotes/models.py:342
+#: geniza/footnotes/models.py:390
 msgid "Discussion"
 msgstr "דיון"
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2021-12-06 13:11-0500\n"
+"POT-Creation-Date: 2021-12-06 14:53-0500\n"
 "PO-Revision-Date: 2021-11-02 18:38\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -58,7 +58,7 @@ msgid "Document Type"
 msgstr "סוג המסמך"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:569
+#: geniza/corpus/models.py:566
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -72,6 +72,7 @@ msgstr "דף הבית"
 msgid "Metadata"
 msgstr ""
 
+#. Translators: Editor label
 #: geniza/corpus/templates/corpus/document_detail.html:36
 #, fuzzy
 #| msgid "Editor"
@@ -83,24 +84,24 @@ msgstr[2] "עורך"
 msgstr[3] "עורך"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:48
+#: geniza/corpus/templates/corpus/document_detail.html:50
 #: geniza/corpus/templates/corpus/snippets/document_result.html:29
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:52
+#: geniza/corpus/templates/corpus/document_detail.html:54
 msgid "Permalink"
 msgstr ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:62
+#: geniza/corpus/templates/corpus/document_detail.html:64
 #: geniza/corpus/templates/corpus/snippets/document_result.html:19
 msgid "Tags"
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:73
+#: geniza/corpus/templates/corpus/document_detail.html:75
 #, fuzzy
 #| msgid "Transcription"
 msgid "Description"

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -58,6 +58,8 @@ body#document {
                 margin-top: spacing.$spacing-xs;
             }
             // hanging "info" phosphor icon before link
+            // disabled for MVP
+            /*
             dd a::before {
                 @include colors.apply-theme("on-background");
                 font-family: "Phosphor" !important;
@@ -67,6 +69,7 @@ body#document {
                 text-align: center;
                 margin-left: -#{spacing.$spacing-xl};
             }
+            */
         }
         // Document tags
         .tags {


### PR DESCRIPTION
## What this PR does

Per #390:
- Only shows brief citations relating to digital editions on Document Detail page
- Pluralizes "Editor" label when there is more than one editor of digital edition(s)
- Shows "unpublished" in brief citations when applicable
- Updates the display of brief citations with "notes" to always end in a period
- (Finally!) disables phosphor "i" icon next to permalink