### PR TITLE
Setup djiffy and add basic script to import IIIF manifests

### DIFF
--- a/geniza/corpus/management/commands/import_manifests.py
+++ b/geniza/corpus/management/commands/import_manifests.py
@@ -1,0 +1,54 @@
+"""
+Importing IIIF manifests to be cached in the database.
+
+"""
+
+from django.core.management.base import BaseCommand
+from djiffy.importer import ManifestImporter
+from djiffy.models import Manifest
+
+from geniza.corpus.models import Fragment
+
+
+class Command(BaseCommand):
+    """Import IIIF manifests into the local database."""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "path",
+            nargs="*",
+            help="One or more IIIF Collections or Manifests as file or URL (optional)",
+        )
+        parser.add_argument(
+            "--update", action="store_true", help="Update previously imported manifests"
+        )
+
+    def handle(self, *args, **kwargs):
+        # use command-line urls if specified
+        iiif_urls = kwargs.get("path")
+        # otherwise, import all iiif manifests referenced by fragments in the db
+        if not iiif_urls:
+            iiif_urls = set(
+                Fragment.objects.exclude(iiif_url="").values_list("iiif_url", flat=True)
+            )
+            # if we're not updating, filter out the ones we already have
+            if not kwargs["update"]:
+                already_imported = set(Manifest.objects.values_list("uri", flat=True))
+                self.stdout.write(
+                    "Skipping %d previously imported IIIF manifests"
+                    % len(already_imported)
+                )
+                iiif_urls = iiif_urls - already_imported
+
+            self.stdout.write(
+                "%d IIIF urls associated with fragments to import" % len(iiif_urls)
+            )
+
+        ManifestImporter(
+            stdout=self.stdout,
+            stderr=self.stderr,
+            style=self.style,
+            update=kwargs["update"],
+        ).import_paths(iiif_urls)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -173,6 +173,9 @@ class Fragment(TrackChangesModel):
 
     objects = FragmentManager()
 
+    # NOTE: may want to add optional ForeignKey to djiffy Manifest here
+    # (or property to find by URI if not an actual FK)
+
     class Meta:
         ordering = ["shelfmark"]
 
@@ -223,6 +226,9 @@ class Fragment(TrackChangesModel):
                 self.old_shelfmarks = ";".join(old_shelfmarks - {self.shelfmark})
             else:
                 self.old_shelfmarks = self.initial_value("shelfmark")
+
+        # NOTE: consider triggering manifest import here when iiif url changes
+
         super(Fragment, self).save(*args, **kwargs)
 
 

--- a/geniza/corpus/tests/test_import_manifests.py
+++ b/geniza/corpus/tests/test_import_manifests.py
@@ -1,0 +1,48 @@
+from io import StringIO
+from unittest.mock import mock_open, patch
+
+import pytest
+from django.core.management import call_command
+from djiffy.models import Manifest
+
+from geniza.corpus.management.commands import add_fragment_urls, import_manifests
+
+
+@pytest.mark.django_db
+@patch("geniza.corpus.management.commands.import_manifests.ManifestImporter")
+def test_handle(mock_importer, fragment, multifragment):
+    # both fragment fixtures have iiif urls
+    stdout = StringIO()
+    command = import_manifests.Command(stdout=stdout)
+    command.handle(update=False)
+    assert mock_importer.return_value.import_paths.call_count == 1
+    args, kwargs = mock_importer.return_value.import_paths.call_args
+    # both should be imported
+    assert fragment.iiif_url in args[0]
+    assert multifragment.iiif_url in args[0]
+
+    # simulate one manifest already imported
+    Manifest.objects.create(uri=fragment.iiif_url)
+    command.handle(update=False)
+    args, kwargs = mock_importer.return_value.import_paths.call_args
+    # should not import if already exists and update is false
+    assert fragment.iiif_url not in args[0]
+    assert multifragment.iiif_url in args[0]
+
+    # when update is true, both should be imported
+    command.handle(update=True)
+    args, kwargs = mock_importer.return_value.import_paths.call_args
+    assert fragment.iiif_url in args[0]
+    assert multifragment.iiif_url in args[0]
+
+
+@pytest.mark.django_db
+@patch("geniza.corpus.management.commands.import_manifests.ManifestImporter")
+def test_call_command(mock_importer):
+    # test calling from command line; specified url should take precedence
+    uri = "http://my.iiif.uri"
+    call_command("import_manifests", uri)
+    assert mock_importer.return_value.import_paths.call_count == 1
+    args, kwargs = mock_importer.return_value.import_paths.call_args
+    # both should be imported
+    assert args[0] == [uri]

--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -255,7 +255,7 @@ CSP_EXCLUDE_URL_PREFIXES = ("/admin", "/cms")
 # use jpg instead of png since some providers only support jpg
 DJIFFY_THUMBNAIL_FORMAT = "jpg"
 # disable djiffy import check, since we are not using djiffy views
-DJIFFY_IMPORT_CHECK_SUPPORTED = False
+# DJIFFY_IMPORT_CHECK_SUPPORTED = False
 
 # URL for git repository of TEI transcriptions
 TEI_TRANSCRIPTIONS_GITREPO = (

--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -45,6 +45,7 @@ INSTALLED_APPS = [
     "admin_log_entries",
     "parasolr",
     "webpack_loader",
+    "djiffy",
     "geniza.common",
     "geniza.corpus.apps.CorpusAppConfig",
     "geniza.footnotes.apps.FootnotesConfig",
@@ -250,6 +251,11 @@ CSP_IMG_SRC = (
 
 # exclude admin and cms urls from csp directives since they're authenticated
 CSP_EXCLUDE_URL_PREFIXES = ("/admin", "/cms")
+
+# use jpg instead of png since some providers only support jpg
+DJIFFY_THUMBNAIL_FORMAT = "jpg"
+# disable djiffy import check, since we are not using djiffy views
+DJIFFY_IMPORT_CHECK_SUPPORTED = False
 
 # URL for git repository of TEI transcriptions
 TEI_TRANSCRIPTIONS_GITREPO = (

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -20,3 +20,5 @@ django-webpack-loader
 django-csp
 gitpython
 eulxml
+# require develop version of djiffy until 0.7 is released
+git+https://github.com/Princeton-CDH/djiffy@develop#egg=djiffy


### PR DESCRIPTION
I'm not certain this is the approach I want to use for the long-term, but for the MVP I'm going to go ahead with the approach I've used before. 

in this PR:
- add djiffy to requirements and installed apps
- local import manifest command to import iiif manifests based on urls associated with fragments
- notes about possible integration between manifest and fragment