### PR TITLE
#382 - Move tags below search result description

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -94,7 +94,7 @@
                 {# Translators: label for tags on a document #}
                 <h3 class="sr-only">{% translate 'Tags' %}</h3>
                 <ul class="tags">
-                    {% for tag in document.tags|alphabetize %}
+                    {% for tag in document.tags|alphabetize|slice:":5" %}
                         <li>{{ tag }}</li>
                     {% endfor %}
                 </ul>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -13,17 +13,6 @@
                 <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
             </h2>
 
-            {# tags #}
-            {% if document.tags %}
-                {# Translators: label for tags on a document #}
-                <h3 class="sr-only">{% translate 'Tags' %}</h3>
-                <ul class="tags">
-                    {% for tag in document.tags|alphabetize %}
-                        <li>{{ tag }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-
             {# metadata #}
             <dl class="metadata">
                 <dt>{% translate 'Input date' %}</dt>
@@ -99,6 +88,18 @@
                     {% translate 'No Scholarship Records' %}
                 {% endif %}
             </p>
+
+            {# tags #}
+            {% if document.tags %}
+                {# Translators: label for tags on a document #}
+                <h3 class="sr-only">{% translate 'Tags' %}</h3>
+                <ul class="tags">
+                    {% for tag in document.tags|alphabetize %}
+                        <li>{{ tag }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+
         </section>
         {# view link #}
         <a class="view-link" href="{% url 'corpus:document' document.pgpid %}">

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -52,15 +52,9 @@ section#document-list {
         display: flex;
         flex-flow: column;
 
-        // document tags
-        .tags {
-            order: 1;
-        }
-
         // document titles
         .title {
             @include typography.subtitle;
-            order: 2;
             position: relative;
             margin-top: spacing.$spacing-md;
             margin-bottom: spacing.$spacing-md;
@@ -84,7 +78,6 @@ section#document-list {
 
         // other document metadata
         .metadata {
-            order: 3;
             grid-template-columns: auto 1fr;
             column-gap: 1rem;
             row-gap: spacing.$spacing-xs;
@@ -93,7 +86,6 @@ section#document-list {
         // document description, transcription
         .description,
         .transcription {
-            order: 4;
             margin: spacing.$spacing-md 0;
 
             // keywords in context
@@ -118,7 +110,6 @@ section#document-list {
 
         // document scholarship records
         .scholarship {
-            order: 5;
             @include typography.meta;
 
             & span {

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -111,10 +111,19 @@ section#document-list {
         // document scholarship records
         .scholarship {
             @include typography.meta;
-
+            display: flex;
+            flex-flow: row wrap;
             & span {
                 padding-right: spacing.$spacing-md;
+                & + span {
+                    padding-right: 0;
+                }
             }
+        }
+
+        // document tags
+        ul.tags {
+            margin-top: spacing.$spacing-md;
         }
     }
 

--- a/sitemedia/scss/components/_tag.scss
+++ b/sitemedia/scss/components/_tag.scss
@@ -13,7 +13,8 @@
     }
 
     // spacing between tags
-    & + li {
-        margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    &:last-of-type {
+        margin-right: 0;
     }
 }


### PR DESCRIPTION
## Visual testing notes

[Percy build](https://percy.io/3201ecb4/geniza/builds/14498261)
- In scope: just checking that the tags look right on mobile and desktop search results pages
- Type sizes, etc. are still forthcoming in another PR

## What this PR does

- Limits the maximum number of tags displayed in search results to 5
- Per #382:
  - In search results, moves tags below scholarship records counts, above "View Document Details" link