### PR TITLE
#325 - Add links script revisions

### DIFF
--- a/geniza/corpus/management/commands/add_links.py
+++ b/geniza/corpus/management/commands/add_links.py
@@ -136,8 +136,16 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
 
         # generate CSV report of documents that could not be found
         if len(self.not_found_documents) > 0:
+            # basename without extension
+            original_csv = (
+                basename(csv_path)[: basename(csv_path).rindex(".")]
+                if "." in csv_path
+                else basename(csv_path)
+            )
             # save in same directory as original CSV
-            nf_report_path = dirname(csv_path) + "/not_found_report.csv"
+            nf_report_path = dirname(csv_path) + (
+                "/documents_not_found_in_%s.csv" % original_csv
+            )
             with open(nf_report_path, "w+") as f:
                 fieldnames = [
                     "linkID",
@@ -153,7 +161,7 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
                     csv_writer.writerow(not_found_row)
 
             self.stdout.write(
-                "Saved report of not found documents to %s." % nf_report_path
+                "Saved report of documents not found to %s." % nf_report_path
             )
 
     def log_action(self, obj, action=CHANGE):

--- a/geniza/corpus/management/commands/add_links.py
+++ b/geniza/corpus/management/commands/add_links.py
@@ -1,6 +1,5 @@
 import csv
-import re
-from collections import Counter
+from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
@@ -226,7 +225,8 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
     # base url target for each supported link type
     base_url = {
         "goitein_note": "https://commons.princeton.edu/media/geniza/",
-        "indexcard": "https://geniza.princeton.edu/indexcards/index.php?a=card&id=",
+        "indexcard": "https://geniza.princeton.edu/indexcards/"
+        + quote("index.php?a=card&id="),
         "jewish-traders": "https://s3.amazonaws.com/goitein-lmjt/",
         "india-traders": "https://s3.amazonaws.com/goitein-india-traders/",
     }
@@ -262,7 +262,7 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
             return
 
         # target url: combine base url for this link type with link target from csv
-        target_url = "".join([self.base_url[link_type], row["link_target"]])
+        target_url = "".join([self.base_url[link_type], quote(row["link_target"])])
         # get doc relation for this link type
         doc_relation = self.document_relation[link_type]
 

--- a/geniza/corpus/management/commands/add_links.py
+++ b/geniza/corpus/management/commands/add_links.py
@@ -242,8 +242,7 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
     # base url target for each supported link type
     base_url = {
         "goitein_note": "https://commons.princeton.edu/media/geniza/",
-        "indexcard": "https://geniza.princeton.edu/indexcards/"
-        + quote("index.php?a=card&id="),
+        "indexcard": "https://geniza.princeton.edu/indexcards/index.php?a=card&id=",
         "jewish-traders": "https://s3.amazonaws.com/goitein-lmjt/",
         "india-traders": "https://s3.amazonaws.com/goitein-india-traders/",
     }

--- a/geniza/corpus/management/commands/add_links.py
+++ b/geniza/corpus/management/commands/add_links.py
@@ -189,17 +189,13 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
         # return the footnote to indicate success
         return footnote
 
-    def get_goitein_source(self, doc, title, url=None):
-        volume = Source.get_volume_from_shelfmark(doc.shelfmark)
+    def get_goitein_source(self, doc, title):
         # common source options used to find or create our new source
         source_opts = {
             "title_en": title,
             "volume": Source.get_volume_from_shelfmark(doc.shelfmark),
             "source_type": self.unpublished,
         }
-        # set url if specified
-        if url:
-            source_opts["url"] = url
         # we can't filter by author on get_or_create, so check first
         source = Source.objects.filter(
             authors__last_name="Goitein", **source_opts
@@ -273,7 +269,6 @@ Created {footnotes_created:,} new footnotes; updated {footnotes_updated:,}.
             source = self.get_goitein_source(
                 doc=doc,
                 title="index cards",
-                url="https://geniza.princeton.edu/indexcards/",
             )
         elif link_type == "jewish-traders":
             source = self.jewish_traders

--- a/geniza/corpus/tests/test_add_links.py
+++ b/geniza/corpus/tests/test_add_links.py
@@ -1,12 +1,12 @@
 from collections import Counter, defaultdict
 from io import StringIO
 from unittest.mock import Mock, mock_open, patch
+from urllib.parse import quote
 
 import pytest
 from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.db.models.fields.related import ForeignKey
 
 from geniza.corpus.management.commands import add_links
 from geniza.corpus.models import Document
@@ -249,7 +249,8 @@ def test_add_link(mock_set_footnote, typed_texts, jewish_traders, india_book, do
     mock_set_footnote.assert_called_with(
         doc=document,
         source=indexcard_source,
-        url="https://geniza.princeton.edu/indexcards/index.php?a=card&id=abc123",
+        url="https://geniza.princeton.edu/indexcards/"
+        + quote("index.php?a=card&id=abc123"),
         doc_relation=Footnote.DISCUSSION,
     )
     test_row.update(

--- a/geniza/corpus/tests/test_add_links.py
+++ b/geniza/corpus/tests/test_add_links.py
@@ -301,8 +301,7 @@ def test_add_link(mock_set_footnote, typed_texts, jewish_traders, india_book, do
     mock_set_footnote.assert_called_with(
         doc=document,
         source=indexcard_source,
-        url="https://geniza.princeton.edu/indexcards/"
-        + quote("index.php?a=card&id=abc123"),
+        url="https://geniza.princeton.edu/indexcards/index.php?a=card&id=abc123",
         doc_relation=Footnote.DISCUSSION,
         location="card #abc123",
     )
@@ -318,8 +317,7 @@ def test_add_link(mock_set_footnote, typed_texts, jewish_traders, india_book, do
     mock_set_footnote.assert_called_with(
         doc=document,
         source=typed_texts,
-        url="https://commons.princeton.edu/media/geniza/"
-        + quote("abc123 (PGPID 1234).pdf"),
+        url="https://commons.princeton.edu/media/geniza/abc123%20%28PGPID%201234%29.pdf",
         doc_relation=Footnote.EDITION,
         location="abc123",
     )

--- a/geniza/corpus/tests/test_add_links.py
+++ b/geniza/corpus/tests/test_add_links.py
@@ -223,14 +223,14 @@ def test_set_footnote_location_update(
     cmd.stats = {"footnotes_created": 0, "footnotes_updated": 0}
 
     # create a typed text footnote on document with no location to update
+    test_url = "http://example.com/pgp/link/"
     existing_note = Footnote.objects.create(
         content_object=document,
         source=typed_texts,
-        url="http://example.com/pgp/link/",
+        url=test_url,
         doc_relation=Footnote.EDITION,
     )
 
-    test_url = "http://example.com/pgp/link/"
     footnote = cmd.set_footnote_url(
         document,
         typed_texts,

--- a/geniza/corpus/tests/test_add_links.py
+++ b/geniza/corpus/tests/test_add_links.py
@@ -344,3 +344,4 @@ def test_add_link_ignored():
 
 
 # TODO: add & test log entry handling
+# TODO: test report generation

--- a/geniza/corpus/tests/test_add_links.py
+++ b/geniza/corpus/tests/test_add_links.py
@@ -244,7 +244,6 @@ def test_add_link(mock_set_footnote, typed_texts, jewish_traders, india_book, do
     indexcard_source = cmd.get_goitein_source(
         doc=document,
         title="index cards",
-        url="https://geniza.princeton.edu/indexcards/",
     )
     mock_set_footnote.assert_called_with(
         doc=document,


### PR DESCRIPTION
## What this PR does
- Per #325, revises the add links script to add:
  - Escaped URLs to fix admin interface bugs
  - Footnote location generation / assignment
  - A report of documents not found

## notes
I just decided to save the "documents not found" report to the same directory as the original CSV. I also appended the original CSV's basename to the filename, in case multiple reports will be generated in the same directory for different CSVs.

Also, I reordered some of the logic in `test_add_link` to minimize the amount of times `link_target` is updated to reflect the kind of `link_target` that we expect from each document type.