### PR TITLE
Tweak language switcher

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -3,9 +3,10 @@
 ## 0.7
 
 -   Update settings to configure **TEI_TRANSCRIPTIONS_LOCAL_PATH** for the deploy environment.
--   Run `python manage.py bootstrap_content` to create stub pages for all site content needed for main site navigation.
--   After running the above, in the Wagtail CMS, go to "Settings" -> "Locales" and choose each non-English language. Enable
-    syncing to them from English. This should auto-populate each other locale with a new home page and set of subpages.
+-   Run `python manage.py bootstrap_content -h HOSTNAME -p PORt` to create stub pages for all site content needed for main site navigation.
+-   After running the boostrap content, in the Wagtail CMS, go to "Settings" -> "Locales" and choose each non-English language. Enable syncing to them from English. This should auto-populate each other locale with a new home page and set of subpages.
+-   Run `python manage.py add_links` with a csv file exported from PGP v3 links database.
+-   Run `python manage.py sync_transcriptions` to synchronize TEI transcription content to footnotes for search and display.
 
 ## 0.3.0
 

--- a/geniza/templates/snippets/language_switcher.html
+++ b/geniza/templates/snippets/language_switcher.html
@@ -9,10 +9,12 @@
                 {% get_language_info_list for LANGUAGES as languages %}
                 {% for language in languages %}
                     <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected{% endif %}>
-                        {# Translators: label for language choices in navigation #}
-                        {% blocktranslate with language_name=language.name_local language_code=language.code trimmed %}
-                            read this page in {{ language_name }} ({{ language_code }})
-                        {% endblocktranslate %}
+                        {% language language.code %} {# display label for language in that language! #}
+                            {# Translators: label for language choices in navigation #}
+                            {% blocktranslate with language_name=language.name_local language_code=language.code trimmed %}
+                                read this page in {{ language_name }} ({{ language_code }})
+                            {% endblocktranslate %}
+                        {% endlanguage %}
                     </option>
                 {% endfor %}
             </select>

--- a/sitemedia/scss/components/_langswitcher.scss
+++ b/sitemedia/scss/components/_langswitcher.scss
@@ -8,4 +8,9 @@ form#language {
     position: absolute;
     top: spacing.$spacing-xs;
     right: spacing.$spacing-sm;
+
+    option[value="he"],
+    option[value="ar"] {
+        direction: rtl;
+    }
 }


### PR DESCRIPTION
When I saw the language switcher in qa I immediately saw we didn't have it quite right! It is probably still not great and will benefit from Gissoo's design input when she is able to get to it, but wanted to make a quick adjustment for now:

- display "read this page in ..." in the language that will be switched _to_, so it's readable to a user who can't read the site text in the current language
- add dir=rtl in css for hebrew & arabic options