### PR TITLE
Implement django-taggit multi-word bugfix

### DIFF
--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -65,6 +65,7 @@ class TestCommonUtils(TestCase):
 
     def test_custom_tag_string(self):
         assert custom_tag_string("foo") == ["foo"]
+        assert custom_tag_string("multi-word tag") == ["multi-word tag"]
         assert custom_tag_string('"legal query", responsa') == [
             "legal query",
             "responsa",

--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -6,7 +6,7 @@ from django.contrib.sites.models import Site
 from django.test import TestCase, override_settings
 
 from geniza.common.admin import LocalUserAdmin, custom_empty_field_list_filter
-from geniza.common.utils import absolutize_url
+from geniza.common.utils import absolutize_url, custom_tag_string
 
 
 @pytest.mark.django_db
@@ -62,6 +62,17 @@ class TestCommonUtils(TestCase):
                 absolutize_url(local_path, mockrqst)
                 == "http://example.org/sub/foo/bar/"
             )
+
+    def test_custom_tag_string(self):
+        assert custom_tag_string("foo") == ["foo"]
+        assert custom_tag_string('"legal query", responsa') == [
+            "legal query",
+            "responsa",
+        ]
+        assert custom_tag_string("") == []
+        assert custom_tag_string(
+            '"Arabic script", "fiscal document",foods,Ḥalfon b. Menashshe'
+        ) == ["Arabic script", "fiscal document", "foods", "Ḥalfon b. Menashshe"]
 
 
 class TestCustomEmptyFieldListFilter:

--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -46,5 +46,6 @@ def custom_tag_string(tag_string):
     This is configured in settings with TAGGIT_TAGS_FROM_STRING.
     """
     # Stack overflow solution: https://stackoverflow.com/questions/30513783/django-taggit-how-to-allow-multi-word-tags
+    # Our github issue for taggit: https://github.com/jazzband/django-taggit/issues/783
 
     return [t.strip(' "') for t in tag_string.split(",") if t.strip(' "')]

--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -36,15 +36,12 @@ def absolutize_url(local_url, request=None):
 
 def custom_tag_string(tag_string):
     """
-    A custom tag string parser for taggit so that we can have multi-word
-    tags. Django-taggit allows for multi-word tags, but TaggableManager does not
-    encourage users to input them correctly.
+    Custom tag parsing for taggit to better support multi-word tags.
 
-    TaggableManager does not have an intuitive string output. If there are
-    no tags, it will return a comma-delimited string. It will wrap existing
-    tags in quotes. So if a user wants to add a tag "Arabic script" to a document
-    with the existing tag "fiscal document" it will send the value:
-    `"fiscal document", Arabic script` to be parsed.
+    Expected parsing:
+    - 'legal document' -> ["legal document"]
+    - '"fiscal document", Arabic script' -> ["fiscal document", "Arabic script"]
+    - '"fiscal document", "Arabic script"' -> ["fiscal document", "Arabic script"]
 
     This is configured in settings with TAGGIT_TAGS_FROM_STRING.
     """

--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -48,8 +48,6 @@ def custom_tag_string(tag_string: str) -> list:
 
     This is configured in settings with TAGGIT_TAGS_FROM_STRING.
     """
-    if not tag_string:
-        return []
-    elif "," not in tag_string:
-        return [tag_string.strip('"')]
-    return [t.strip(' "') for t in tag_string.split(",")]
+    # Stack overflow solution: https://stackoverflow.com/questions/30513783/django-taggit-how-to-allow-multi-word-tags
+
+    return [t.strip(' "') for t in tag_string.split(",") if t.strip(' "')]

--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -32,3 +32,24 @@ def absolutize_url(local_url, request=None):
         root = root.rstrip("/")
 
     return root + local_url
+
+
+def custom_tag_string(tag_string: str) -> list:
+    """
+    A custom tag string parser for taggit so that we can have multi-word
+    tags. Django-taggit allows for multi-word tags, but TaggableManager does not
+    encourage users to input them correctly.
+
+    TaggableManager does not have an intuitive string output. If there are
+    no tags, it will return a comma-delimited string. It will wrap existing
+    tags in quotes. So if a user wants to add a tag "Arabic script" to a document
+    with the existing tag "fiscal document" it will send the value:
+    `"fiscal document", Arabic script` to be parsed.
+
+    This is configured in settings with TAGGIT_TAGS_FROM_STRING.
+    """
+    if not tag_string:
+        return []
+    elif "," not in tag_string:
+        return [tag_string.strip('"')]
+    return [t.strip(' "') for t in tag_string.split(",")]

--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -34,7 +34,7 @@ def absolutize_url(local_url, request=None):
     return root + local_url
 
 
-def custom_tag_string(tag_string: str) -> list:
+def custom_tag_string(tag_string):
     """
     A custom tag string parser for taggit so that we can have multi-word
     tags. Django-taggit allows for multi-word tags, but TaggableManager does not

--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -294,3 +294,4 @@ FONT_URL_PREFIX = "/static/fonts/"
 
 # Taggit customization
 TAGGIT_TAGS_FROM_STRING = "geniza.common.utils.custom_tag_string"
+TAGGIT_CASE_INSENSITIVE = True 

--- a/geniza/settings/components/base.py
+++ b/geniza/settings/components/base.py
@@ -291,3 +291,6 @@ WAGTAIL_SITE_NAME = "GENIZA"
 
 # default font base url
 FONT_URL_PREFIX = "/static/fonts/"
+
+# Taggit customization
+TAGGIT_TAGS_FROM_STRING = "geniza.common.utils.custom_tag_string"


### PR DESCRIPTION
Django-taggit allows for multi-word tags, but `TaggableManager` does not encourage users to input them correctly 🥴 Should I open a ticket on https://github.com/jazzband/django-taggit? 