### PR TITLE
Make transcription available for download as text

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -49,6 +49,9 @@
                         {% ifchanged %}
                             <dd>{{ ed.display|safe }}</dd>
                         {% endifchanged %}
+                        {% if ed.content.text %}
+                            <a style="text-align:right" href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">download as text</a>
+                        {% endif %}
                         {# link ? #}
                     {% endfor %}
                 {% endif %}

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="document-scholarship",
     ),
     path(
+        "documents/<int:pk>/transcription/<int:transcription_pk>/",
+        corpus_views.DocumentTranscriptionText.as_view(),
+        name="document-transcription-text",
+    ),
+    path(
         "documents/<int:pk>/iiif/manifest/",
         corpus_views.DocumentManifestView.as_view(),
         name="document-manifest",


### PR DESCRIPTION
proof-of-concept implementation to allow downloading transcription content as plain text, to see if this will satisfy the functionality needed for #434 