### PR TITLE
Convert solr alias fields in keyword search terms

### DIFF
--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -13,8 +13,28 @@ class TestDocumentSolrQuerySet:
                 doc_query="deed of sale"
             )
 
+    def test_admin_search_shelfmark(self):
+        dqs = DocumentSolrQuerySet()
+        with patch.object(dqs, "search") as mocksearch:
             # ignore + when searching on joins
             dqs.admin_search("CUL Or.1080 3.41 + T-S 13J16.20 + T-S 13J8.14")
             mocksearch.return_value.raw_query_parameters.assert_called_with(
                 doc_query="CUL Or.1080 3.41 T-S 13J16.20 T-S 13J8.14"
+            )
+
+    def test_keyword_search_shelfmark(self):
+        dqs = DocumentSolrQuerySet()
+        with patch.object(dqs, "search") as mocksearch:
+            # ignore + when searching on joins
+            dqs.keyword_search("CUL Or.1080 3.41 + T-S 13J16.20 + T-S 13J8.14")
+            mocksearch.return_value.raw_query_parameters.assert_called_with(
+                keyword_query="CUL Or.1080 3.41 T-S 13J16.20 T-S 13J8.14"
+            )
+
+    def test_keyword_search_field_aliases(self):
+        dqs = DocumentSolrQuerySet()
+        with patch.object(dqs, "search") as mocksearch:
+            dqs.keyword_search("pgpid:950 shelfmark:ena")
+            mocksearch.return_value.raw_query_parameters.assert_called_with(
+                keyword_query="pgpid_i:950 shelfmark_t:ena"
             )


### PR DESCRIPTION
tweaks the keyword search to convert aliased solr field names into actual solr fields so that we can allow users to do more powerful searches within the existing keyword search field; specifics are documented on #494 

(note that this also makes it possible to easily support tag searching)