### PR TITLE
Override DocumentAdmin get_deleted_objects

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -306,6 +306,14 @@ class DocumentAdmin(admin.ModelAdmin):
         # return queryset, use distinct not needed
         return queryset, False
 
+    def get_deleted_objects(self, objs, request):
+        # override delete to use *Document* instead of the Document proxy object;
+        # this avoids the delete permission problem caused by the generic relation
+        # for log entries (which cannot be deleted) on the proxy model
+        return super().get_deleted_objects(
+            Document.objects.filter(pk__in=[obj.pk for obj in objs]), request
+        )
+
     def save_model(self, request, obj, form, change):
         """Customize this model's save_model function and then execute the
         existing admin.ModelAdmin save_model function"""

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -314,6 +314,16 @@ class TestDocumentAdmin:
         qs = doc_admin.get_queryset("rqst")
         assert qs.model == DocumentPrefetchableProxy
 
+    def test_get_deleted_objects(self, document):
+        # should use Document instead of DocumentPrefetchableProxy for deletion
+        doc_admin = DocumentAdmin(model=Document, admin_site=admin.site)
+        objs = DocumentPrefetchableProxy.objects.all()
+        (deleted_objects, _, _, _) = doc_admin.get_deleted_objects(objs, Mock())
+        # doesn't return the actual objects, but a list of items for display on the delete view
+        # check that the correct model was used based on the output of deleted_objects,
+        # which looks like Document: <a href="/admin/corpus/document/3951/change/">CUL Add.2586 (PGPID 3951)</a>
+        assert deleted_objects[0].startswith("Document: ")
+
 
 @pytest.mark.django_db
 class TestDocumentForm:


### PR DESCRIPTION
@blms when I went to deliver the document deletion bug fix I discovered that we still hadn't solved the problem! the deletion view used the custom queryset, so it still had the log entries relation with the permissions problem. However, I figured out that once that queryset customization was in place, I could override just the `get_deleted_objects` method to make sure _that_ one uses the non-proxy `Document` model without the generic relation causing all our permission problems.