### PR TITLE
#513 - Require message when taking Percy screenshots

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -19,6 +19,7 @@ jobs:
   # Get commit message, using HEAD if the event is "push", and HEAD^2 if the event is "pull_request".
   # From https://github.community/t/accessing-commit-message-in-pull-request-event/17158/15
   get_commit_msg:
+    name: Get commit message for key phrase
     runs-on: ubuntu-latest
     steps:
       - name: Checkout commits up to and including HEAD^2
@@ -34,7 +35,6 @@ jobs:
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
           fi
-
     outputs:
       commit_message: echo "${{ steps.get_commit_message.outputs.commit_message }}"
 

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -19,7 +19,9 @@ jobs:
   visual-tests:
     name: Visual regression tests
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || contains(github.event.head_commit.message, '[run percy]') }}
+    # on pull request: only run if the phrase "[run percy]" (including brackets) is present in the commit message
+    # on push to develop: run if the phrase "[skip percy]" (including brackets) is NOT present in the commit message
+    if: ${{ (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip percy]')) || contains(github.event.head_commit.message, '[run percy]') }}
     services:
       postgres:
         image: postgres:12

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -16,12 +16,35 @@ env:
   DJANGO_ENV: test
 
 jobs:
+  # Get commit message, using HEAD if the event is "push", and HEAD^2 if the event is "pull_request".
+  # From https://github.community/t/accessing-commit-message-in-pull-request-event/17158/15
+  get_commit_msg:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout commits up to and including HEAD^2
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Get commit message
+        id: get_commit_message
+        run: |
+          if   [[ '${{ github.event_name }}' == 'push' ]]; then
+            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
+          elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
+          fi
+
+    outputs:
+      commit_message: echo "${{ steps.get_commit_message.outputs.commit_message }}"
+
   visual-tests:
     name: Visual regression tests
     runs-on: ubuntu-latest
+    needs: get_commit_msg # grab the output from this job for the commit message
     # on pull request: only run if the phrase "[run percy]" (including brackets) is present in the commit message
     # on push to develop: run if the phrase "[skip percy]" (including brackets) is NOT present in the commit message
-    if: ${{ (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip percy]')) || contains(github.event.head_commit.message, '[run percy]') }}
+    if: ${{ (github.event_name == 'push' && !contains(needs.get_commit_msg.outputs.commit_message, '[skip percy]')) || contains(needs.get_commit_msg.outputs.commit_message, '[run percy]') }}
     services:
       postgres:
         image: postgres:12

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -19,6 +19,7 @@ jobs:
   visual-tests:
     name: Visual regression tests
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || contains(github.event.head_commit.message, '[run percy]') }}
     services:
       postgres:
         image: postgres:12

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,18 @@ Lighthouse runs several checks by visiting a list of URLs and averaging the resu
 
 If the Lighthouse build is generating errors that need to be temporarily or permanently ignored, the corresponding error code can be set to "off" or "warn" in `lighthouserc.js`.
 
+Visual Tests
+------------
+
+Visual regressions are monitored with `Percy <https://percy.io/>`_. Percy takes screenshots of the web application with different browsers and compares them to a set of base screenshots to find changes.
+
+In this repository, a GitHub Action is configured to take a set of Percy screenshots when one of the following conditions is met:
+
+#. A commit has been pushed to a pull request against the ``develop`` branch, and the phrase ``[run percy]`` is present in the commit message.
+#. A commit has been pushed to the ``develop`` branch, and the phrase ``[skip percy]`` is NOT present in the commit message.
+
+Otherwise, the Action will be skipped and Percy will not take a set of screenshots to check for visual regressions.
+
 Setup Black
 -----------
 


### PR DESCRIPTION
## What this PR does

- Per #513:
  - Updates the `visual_tests` workflow (aka Percy screenshots) to only run if the message `[run percy]` is present in the commit message, or if the trigger is a push to the `develop` branch