### PR TITLE
Link tags to search documents by tag

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -71,7 +71,7 @@
                 <h3 class="sr-only">{% translate 'Tags' %}</h3>
                 <ul class="tags">
                     {% for tag in document.alphabetized_tags %}
-                        <li>{{ tag }}</li>
+                        <li><a href='{% url "corpus:document-search" %}?q=tag:"{{ tag }}"' rel="tag">{{ tag }}</a></li>
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -95,7 +95,7 @@
                 <h3 class="sr-only">{% translate 'Tags' %}</h3>
                 <ul class="tags">
                     {% for tag in document.tags|alphabetize|slice:":5" %}
-                        <li>{{ tag }}</li>
+                        <li><a href='{% url "corpus:document-search" %}?q=tag:"{{ tag }}"'>{{ tag }}</a></li>
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -32,8 +32,13 @@ class TestDocumentDetailTemplate:
     def test_tags(self, client, document):
         """Document detail template should include all document tags"""
         response = client.get(document.get_absolute_url())
-        assertContains(response, "<li>bill of sale</li>", html=True)
-        assertContains(response, "<li>real estate</li>", html=True)
+        for tag in ["bill of sale", "real estate"]:
+            assertContains(
+                response,
+                "<li><a href='/en/documents/?q=tag:\"%(tag)s\"' rel='tag'>%(tag)s</li>"
+                % {"tag": tag},
+                html=True,
+            )
 
     def test_description(self, client, document):
         """Document detail template should include document description"""
@@ -335,6 +340,22 @@ class TestDocumentResult:
         assert "15 Transcriptions" in result
         assert "Translation" not in result
         assert "Discusion" not in result
+
+    def test_tags(self):
+        tags = ["bill of sale", "real estate"]
+        result = self.template.render(
+            context={
+                "document": {"pgpid": 1, "id": "document.1", "tags": tags},
+                "highlighting": {},
+                "page_obj": self.page_obj,
+            }
+        )
+        for tag in tags:
+            assert (
+                "<li><a href='/en/documents/?q=tag:\"%(tag)s\"'>%(tag)s</a></li>"
+                % {"tag": tag}
+                in result
+            )
 
     def test_multiple_scholarship_types(self):
         result = self.template.render(


### PR DESCRIPTION
Turns tags in search results & document detail page into links to a tag search

This will change the percy build, but I can't tell from the designs on Figma if the default link style is what's intended for tags.
