### PR TITLE
Revisions for transcription download 

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -47,10 +47,6 @@
                         {% ifchanged %}
                             <dd>{{ ed.display|safe }}</dd>
                         {% endifchanged %}
-                        {% if ed.content.text %}
-                            <a style="text-align:right" href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">download as text</a>
-                        {% endif %}
-                        {# link ? #}
                     {% endfor %}
                 {% endif %}
                 {# Translators: Date document was first added to the PGP #}
@@ -83,6 +79,16 @@
             </h3>
             <p>{{ document.description }}</p>
         </section>
+        {# link to download transcription if available #}
+        {% if document.has_transcription %}
+            <section class="transcription-link">
+                {% for ed in document.digital_editions %}
+                    {% if ed.content.text %}
+                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% for auth in ed.source.authorship_set.all %}{{ auth.creator.last_name }}{% include "snippets/comma.html" %}{% endfor %}'s edition.</a></p>
+                    {% endif %}
+                {% endfor %}
+            </section>
+        {% endif %}
     </div>
 
     {# viewer #}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -84,7 +84,7 @@
             <section class="transcription-link">
                 {% for ed in document.digital_editions %}
                     {% if ed.content.text %}
-                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% for auth in ed.source.authorship_set.all %}{{ auth.creator.last_name }}{% include "snippets/comma.html" %}{% endfor %}'s edition.</a></p>
+                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% endfor %}'s edition.</a></p>
                     {% endif %}
                 {% endfor %}
             </section>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -45,7 +45,7 @@
                 {% elif document.transcription %}
                     {# otherwise, display truncated transcription #}
                     {# NOTE: might be nice to display N lines instead of using truncatechars #}
-                    <div class="transcription" lang="{{ lang }}">{{ document.transcription.0|linebreaks|truncatechars:150 }}</div>
+                    <div class="transcription" lang="{{ lang }}">{{ document.transcription.0|linebreaks|truncatechars_html:150 }}</div>
                 {% endif %}
             {% endwith %}
 

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -150,6 +150,59 @@ class TestDocumentDetailTemplate:
         assertContains(response, "<dt>Shelfmark</dt>", html=True)
         assertContains(response, join.shelfmark, html=True)
 
+    def test_download_transcription_link(self, client, document, typed_texts):
+        edition = Footnote.objects.create(
+            content_object=document,
+            source=typed_texts,
+            doc_relation=Footnote.EDITION,
+            content={
+                "html": "some transcription text",
+                "text": "some transcription text",
+            },
+        )
+        response = client.get(document.get_absolute_url())
+        # typed text fixture authored by Goitein
+        assertContains(response, "Download Goitein's edition")
+        assertContains(
+            response,
+            reverse(
+                "corpus:document-transcription-text",
+                kwargs={"pk": document.pk, "transcription_pk": edition.pk},
+            ),
+        )
+
+    def test_download_transcription_link_two_authors(
+        self, client, document, twoauthor_source
+    ):
+        edition = Footnote.objects.create(
+            content_object=document,
+            source=twoauthor_source,
+            doc_relation=Footnote.EDITION,
+            content={
+                "html": "some transcription text",
+                "text": "some transcription text",
+            },
+        )
+        response = client.get(document.get_absolute_url())
+        assertContains(response, "Download Kernighan and Ritchie's edition")
+
+    def test_download_transcription_link_many_authors(
+        self, client, document, multiauthor_untitledsource
+    ):
+        edition = Footnote.objects.create(
+            content_object=document,
+            source=multiauthor_untitledsource,
+            doc_relation=Footnote.EDITION,
+            content={
+                "html": "some transcription text",
+                "text": "some transcription text",
+            },
+        )
+        response = client.get(document.get_absolute_url())
+        assertContains(
+            response, "Download Khan, el-Leithy, Rustow and Vanthieghem's edition"
+        )
+
 
 class TestDocumentScholarshipTemplate:
     def test_source_title(self, client, document, twoauthor_source):

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -6,7 +6,7 @@ import pytest
 from django.db.models.fields import related
 from django.http.response import Http404
 from django.urls import reverse
-from django.utils.text import Truncator
+from django.utils.text import Truncator, slugify
 from parasolr.django import SolrClient
 from pytest_django.asserts import assertContains, assertNotContains
 
@@ -20,6 +20,7 @@ from geniza.corpus.views import (
     DocumentManifestView,
     DocumentScholarshipView,
     DocumentSearchView,
+    DocumentTranscriptionText,
     old_pgp_edition,
     old_pgp_tabulate_data,
     pgp_metadata_for_old_site,
@@ -766,3 +767,93 @@ class TestDocumentAnnotationListView:
 
         assertNotContains(response, "here is my transcription text")
         assertContains(response, "completely different transcription text")
+
+
+@pytest.mark.django_db
+class TestDocumentTranscriptionText:
+    view_name = DocumentTranscriptionText.viewname
+
+    def test_nonexesistent_pgpid(self, client):
+        # non-existent pgpid should 404
+        assert (
+            client.get(
+                reverse(self.view_name, kwargs={"pk": 123, "transcription_pk": 456})
+            ).status_code
+            == 404
+        )
+
+    def test_nonexesistent_footnote_id(self, client, document):
+        # valid pgpid but non-existent footnote id should 404
+        assert (
+            client.get(
+                reverse(
+                    self.view_name, kwargs={"pk": document.pk, "transcription_pk": 123}
+                )
+            ).status_code
+            == 404
+        )
+
+    def test_not_edition(self, client, document, source):
+        # valid pgpid, valid footnote, but not an edition should 404
+        discussion = Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation=Footnote.DISCUSSION,
+        )
+        assert (
+            client.get(
+                reverse(
+                    self.view_name,
+                    kwargs={"pk": document.pk, "transcription_pk": discussion.pk},
+                )
+            ).status_code
+            == 404
+        )
+
+    def test_no_content(self, client, document, source):
+        # valid pgpid, valid footnote, but not an edition should 404
+        edition = Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation=Footnote.EDITION,
+        )
+        assert (
+            client.get(
+                reverse(
+                    self.view_name,
+                    kwargs={"pk": document.pk, "transcription_pk": edition.pk},
+                )
+            ).status_code
+            == 404
+        )
+
+    def test_success(self, client, document, source):
+        # valid pgpid, valid footnote, but not an edition should 404
+        edition = Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation=Footnote.EDITION,
+            content={
+                "html": "some transcription text",
+                "text": "some transcription text",
+            },
+        )
+        response = client.get(
+            reverse(
+                self.view_name,
+                kwargs={"pk": document.pk, "transcription_pk": edition.pk},
+            )
+        )
+        assert response.status_code == 200
+        assert response.headers["Content-Type"] == "text/plain; charset=UTF-8"
+        content_disposition = response.headers["Content-Disposition"]
+        assert content_disposition.startswith("attachment; filename=")
+        assert content_disposition.endswith('.txt"')
+        # check filename format
+        filename = content_disposition.split("=")[1]
+        # filename is wrapped in quotes; includes pgpid, shelfmark, author last name
+        assert filename.startswith('"PGP%d' % document.pk)
+        assert slugify(document.shelfmark) in filename
+        assert slugify(source.authorship_set.first().creator.last_name) in filename
+
+        assert response.content == b"some transcription text"

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -266,14 +266,15 @@ class DocumentTranscriptionText(DocumentDetailView):
         document = self.get_object()
         try:
             edition = document.editions().get(pk=self.kwargs["transcription_pk"])
+            shelfmark = slugify(document.textblock_set.first().fragment.shelfmark)
             authors = [slugify(a.last_name) for a in edition.source.authors.all()]
-            filename = "PGP_%d_%s.txt" % (document.id, "_".join(authors))
+            filename = "PGP%d_%s_%s.txt" % (document.id, shelfmark, "_".join(authors))
 
             return HttpResponse(
                 edition.content["text"],
                 headers={
                     "Content-Type": "text/plain; charset=UTF-8",
-                    # prompt download with filename including pgpid & authors
+                    # prompt download with filename including pgpid, shelfmark, & authors
                     "Content-Disposition": 'attachment; filename="%s"' % filename,
                 },
             )

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -265,7 +265,9 @@ class DocumentTranscriptionText(DocumentDetailView):
     def get(self, request, *args, **kwargs):
         document = self.get_object()
         try:
-            edition = document.editions().get(pk=self.kwargs["transcription_pk"])
+            edition = document.digital_editions().get(
+                pk=self.kwargs["transcription_pk"]
+            )
             shelfmark = slugify(document.textblock_set.first().fragment.shelfmark)
             authors = [slugify(a.last_name) for a in edition.source.authors.all()]
             filename = "PGP%d_%s_%s.txt" % (document.id, shelfmark, "_".join(authors))

--- a/geniza/templates/snippets/comma.html
+++ b/geniza/templates/snippets/comma.html
@@ -1,0 +1,1 @@
+{# template for comma separated list; from https://stackoverflow.com/a/3649002 #}{% if not forloop.first %}{% if forloop.last %} and {% else %}, {% endif %}{% endif %}

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -94,5 +94,12 @@ body#document {
                 margin: spacing.$spacing-3xl 0 spacing.$spacing-md;
             }
         }
+
+        section.transcription-link {
+            margin-top: spacing.$spacing-md;
+            @include breakpoints.for-desktop-up {
+                margin-top: spacing.$spacing-xl;
+            }
+        }
     }
 }


### PR DESCRIPTION
revisions to transcription download feature:
- move the link to just above image/text viewer
- label download link to clarify what it is
- include shelfmark in download file name
- unit tests for view & template