### PR TITLE
Correct document prefetch index type

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -855,6 +855,11 @@ class DocumentPrefetchableProxy(Document):
         # tell parasolr, nothing to index here
         return 0
 
+    @classmethod
+    def index_item_type(cls):
+        # when indexing in bulk with prefetching, index exactly like a document
+        return Document.index_item_type()
+
 
 class TextBlock(models.Model):
     """The portion of a document that appears on a particular fragment."""

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -930,3 +930,7 @@ class TestDocumentPrefetchableProxy:
 
     def test_items_to_index(self):
         assert DocumentPrefetchableProxy.items_to_index() == []
+
+    def test_index_data(self, document):
+        prefetch_doc = DocumentPrefetchableProxy.objects.get(pk=document.pk)
+        assert prefetch_doc.index_data() == document.index_data()


### PR DESCRIPTION
When indexing document via prefetch proxy,
index data should be the same when indexed as a document