### PR TITLE
improve IIIF handling so it works with PUL/JTS content

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -191,18 +191,29 @@ class Fragment(TrackChangesModel):
         return (self.shelfmark,)
 
     def iiif_images(self):
+        """IIIF image URLs for this fragment. Returns a list of
+        :class:`~piffle.image.IIIFImageClient` and corresponding list of labels,
+        or None if this fragement has no IIIF url associated."""
+
         # if there is no iiif for this fragment, bail out
         if not self.iiif_url:
             return None
-        # TODO: switch this to use locally cached version!
         images = []
         labels = []
-        manifest = IIIFPresentation.from_url(self.iiif_url)
-        for canvas in manifest.sequences[0].canvases:
-            image_id = canvas.images[0].resource.id
-            images.append(IIIFImageClient(*image_id.rsplit("/", 1)))
-            # label provides library's recto/verso designation
-            labels.append(canvas.label)
+        # use images from locally cached manifest if possible
+        if self.manifest:
+            for canvas in self.manifest.canvases.all():
+                images.append(canvas.image)
+                labels.append(canvas.label)
+
+        # if not cached, load from remote url
+        else:
+            manifest = IIIFPresentation.from_url(self.iiif_url)
+            for canvas in manifest.sequences[0].canvases:
+                image_id = canvas.images[0].resource.id
+                images.append(IIIFImageClient(*image_id.rsplit("/", 1)))
+                # label provides library's recto/verso designation
+                labels.append(canvas.label)
 
         return images, labels
 

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -12,7 +12,7 @@ from django.db.models.query import QuerySet
 from django.utils import timezone
 from django.utils.safestring import SafeString
 from django.utils.translation import activate, deactivate_all, get_language
-from djiffy.models import Manifest
+from djiffy.models import Canvas, IIIFImage, Manifest
 
 from geniza.common.utils import absolutize_url
 from geniza.corpus.models import (
@@ -178,6 +178,29 @@ class TestFragment:
         assert 'title="1r"' in thumbnails
         assert 'title="1v"' in thumbnails
         assert isinstance(thumbnails, SafeString)
+
+    @pytest.mark.django_db
+    @patch("geniza.corpus.models.ManifestImporter")
+    def test_iiif_images_locally_cached_manifest(self, mock_manifestimporter):
+        # fragment with a locally cached manifest
+        frag = Fragment(shelfmark="TS 1")
+        frag.iiif_url = "http://example.io/manifests/1"
+        frag.manifest = Manifest.objects.create(uri=frag.iiif_url, short_id="m")
+        # canvas with image and label
+        Canvas.objects.create(
+            manifest=frag.manifest,
+            label="fake image",
+            iiif_image_id="http://example.co/iiif/ts-1/00001",
+            short_id="c",
+            order=1,
+        )
+        frag.save()
+        # should return one IIIFImage and one label
+        (images, labels) = frag.iiif_images()
+        assert len(images) == 1
+        assert isinstance(images[0], IIIFImage)
+        assert len(labels) == 1
+        assert labels[0] == "fake image"
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -658,6 +658,19 @@ class TestDocumentManifestView:
             == "original source: %s" % mock_manifest.label
         )
 
+    def test_images_no_attribution(self, mockiifpres, client, document):
+        # manifest has no attribution
+        mock_manifest = mockiifpres.from_url.return_value
+        del mock_manifest.attribution  # remove attribution key
+
+        # should only have the default attribution content
+        response = client.get(reverse(self.view_name, args=[document.pk]))
+        result = response.json()
+        assert (
+            result["attribution"]
+            == "<div><p>Compilation by Princeton Geniza Project.</p><p>Additional restrictions may apply.</p></div>"
+        )
+
     def test_no_images_transcription(
         self, mockiifpres, client, document, source, fragment
     ):

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -319,7 +319,11 @@ class DocumentManifestView(DocumentDetailView):
             # CUDL attribution has some variation in tags;
             # would be nice to preserve tagged version,
             # for now, ignore tags so we can easily de-dupe
-            attributions.add(strip_tags(remote_manifest.attribution))
+            try:
+                attributions.add(strip_tags(remote_manifest.attribution))
+            except AttributeError:
+                # attribution is optional, so ignore if not present
+                pass
             for canvas in remote_manifest.sequences[0].canvases:
                 # do we want local canvas id, or rely on remote id?
                 local_canvas = dict(canvas)


### PR DESCRIPTION
- attribution is optional
- use images from cached manifest when available