### PR TITLE
needs review alternate view for document admin list display

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -104,7 +104,7 @@ class LanguageScriptAdmin(admin.ModelAdmin):
 
     @admin.display(
         ordering="secondary_document__count",
-        description="# documents where this is a secondary langaug",
+        description="# documents where this is a secondary language",
     )
     def secondary_documents(self, obj):
         return format_html(
@@ -177,8 +177,11 @@ class HasTranscriptionListFilter(admin.SimpleListFilter):
 @admin.register(Document)
 class DocumentAdmin(admin.ModelAdmin):
     form = DocumentForm
+    # NOTE: columns display for default and needs review display
+    # are controlled via admin css; update the css if you change the order here
     list_display = (
         "id",
+        "needs_review",  # disabled by default with css
         "shelfmark",
         "description",
         "doctype",

--- a/geniza/corpus/templates/admin/corpus/document/change_list.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_list.html
@@ -4,3 +4,15 @@
     <li><a href="{% url 'admin:corpus_document_csv' %}" class="">Download all as CSV</a></li>
     {{ block.super }}
 {% endblock %}
+
+{% block search %}
+    {{ block.super }}
+    <p class="search-note">Search can use phrases, wildcards, booleans, and field-specific searches on : description, shelfmark, pgpid, old_pgpid, needs_review, tag</p>
+{% endblock %}
+
+
+{% block result_list %}
+    List display: <a href="#">default</a> | <a href="#needsreview" id="needsreview">needs review</a>.
+    {# NOTE: anchor link needs to not be nested so we can use sibling filter in css #}
+    {{ block.super }}
+{% endblock %}

--- a/geniza/corpus/templates/admin/corpus/review_list.html
+++ b/geniza/corpus/templates/admin/corpus/review_list.html
@@ -2,7 +2,7 @@
     <div class="module" id="awaiting-review-module">
         <h2>Awaiting review</h2>
         {% if perms.corpus.view_document %}
-            <h3><a href="{% url 'admin:corpus_document_changelist' %}?needs_review__isempty=0">Document{{ docs_review_count|pluralize }} ({{ docs_review_count }})</a></h3>
+            <h3><a href="{% url 'admin:corpus_document_changelist' %}?needs_review__isempty=0&q=needs_review:*#needsreview">Document{{ docs_review_count|pluralize }} ({{ docs_review_count }})</a></h3>
             <ul class="actionlist">
                 {% for doc in docs_need_review %}
                     <li class="changelink">

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -18,6 +18,10 @@ th.column-last_modified {
     max-width: 10em;
 }
 
+.search-note {
+    font-size: 90%;
+}
+
 .model-document th.column-has_transcription {
     max-width: 6em;
     overflow-wrap: break-word;
@@ -28,6 +32,32 @@ th.column-last_modified {
 .model-footnote th.column-has_transcription {
     max-width: 7em;
     overflow-wrap: break-word;
+}
+
+/* by default, hide needs review column */
+.model-document th.column-needs_review,
+.model-document .results td:nth-child(3) {
+    display: none;
+}
+/* adjust columns displayed when needs review mode is enabled
+  (mode based on anchor being targeted) */
+a#needsreview:target {
+    font-weight: bold;
+}
+/* adjust columns when needs review is enabled,  */
+/* show needs review column (second) */
+.model-document a#needsreview:target ~ .results th.column-needs_review,
+.model-document a#needsreview:target ~ .results td:nth-child(3) {
+    display: table-cell;
+}
+/* suppress: tags (7), has transcription (10), has image (11) */
+.model-document a#needsreview:target ~ .results th.column-all_tags,
+.model-document a#needsreview:target ~ .results th.column-has_transcription,
+.model-document a#needsreview:target ~ .results th.column-has_image,
+.model-document a#needsreview:target ~ .results td:nth-child(7),
+.model-document a#needsreview:target ~ .results td:nth-child(10),
+.model-document a#needsreview:target ~ .results td:nth-child(11) {
+    display: none;
 }
 
 #content-related {


### PR DESCRIPTION
Had an idea about a different way to solve the "needs review" queue display problem — add a toggle to the template and control the display with css. What do you think?