### PR TITLE
#547 - Document detail view tweaks

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -688,7 +688,7 @@ class Document(ModelIndexable):
                 "description_t": self.description,
                 "notes_t": self.notes or None,
                 "needs_review_t": self.needs_review or None,
-                "shelfmark_ss": [f.shelfmark for f in fragments],
+                "shelfmark_ss": self.certain_join_shelfmarks,
                 # library/collection possibly redundant?
                 "collection_ss": [str(f.collection) for f in fragments],
                 "tags_ss_lower": [t.name for t in self.tags.all()],

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -461,18 +461,22 @@ class Document(ModelIndexable):
             )
         )
 
+    @property
+    def certain_join_shelfmarks(self):
+        return list(
+            dict.fromkeys(
+                block.fragment.shelfmark
+                for block in self.textblock_set.filter(certain=True)
+            ).keys()
+        )
+
     # NOTE: not currently used; remove or revise if this remains unused
     @property
     def shelfmark_display(self):
         """First shelfmark plus join indicator for shorter display."""
         # NOTE preliminary pending more discussion and implementation of #154:
         # https://github.com/Princeton-CDH/geniza/issues/154
-        certain = list(
-            dict.fromkeys(
-                block.fragment.shelfmark
-                for block in self.textblock_set.filter(certain=True)
-            ).keys()
-        )
+        certain = self.certain_join_shelfmarks
         if not certain:
             return None
         return certain[0] + (" + …" if len(certain) > 1 else "")

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -437,7 +437,7 @@ class Document(ModelIndexable):
         # ordering = [Least('textblock__fragment__shelfmark')]
 
     def __str__(self):
-        return f"{self.shelfmark_display or '??'} (PGPID {self.id or '??'})"
+        return f"{self.shelfmark or '??'} (PGPID {self.id or '??'})"
 
     @staticmethod
     def get_by_any_pgpid(pgpid):
@@ -458,21 +458,6 @@ class Document(ModelIndexable):
                 if block.certain  # filter locally instead of in the db
             )
         )
-
-    @property
-    def shelfmark_display(self):
-        """First shelfmark plus join indicator for shorter display."""
-        # NOTE preliminary pending more discussion and implementation of #154:
-        # https://github.com/Princeton-CDH/geniza/issues/154
-        certain = list(
-            dict.fromkeys(
-                block.fragment.shelfmark
-                for block in self.textblock_set.filter(certain=True)
-            ).keys()
-        )
-        if not certain:
-            return None
-        return certain[0] + (" + …" if len(certain) > 1 else "")
 
     @property
     def collection(self):
@@ -562,7 +547,7 @@ class Document(ModelIndexable):
     @property
     def title(self):
         """Short title for identifying the document, e.g. via search."""
-        return f"{self.doctype or _('Unknown type')}: {self.shelfmark_display or '??'}"
+        return f"{self.doctype or _('Unknown type')}: {self.shelfmark or '??'}"
 
     def editions(self):
         """All footnotes for this document where the document relation includes

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -459,6 +459,22 @@ class Document(ModelIndexable):
             )
         )
 
+    # NOTE: not currently used; remove or revise if this remains unused
+    @property
+    def shelfmark_display(self):
+        """First shelfmark plus join indicator for shorter display."""
+        # NOTE preliminary pending more discussion and implementation of #154:
+        # https://github.com/Princeton-CDH/geniza/issues/154
+        certain = list(
+            dict.fromkeys(
+                block.fragment.shelfmark
+                for block in self.textblock_set.filter(certain=True)
+            ).keys()
+        )
+        if not certain:
+            return None
+        return certain[0] + (" + …" if len(certain) > 1 else "")
+
     @property
     def collection(self):
         """collection (abbreviation) for associated fragments"""

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -32,7 +32,7 @@
             {# metadata #}
             <dl class="metadata">
                 <dt>{% translate 'Shelfmark' %}</dt>
-                <dd>{{ document.shelfmark }}</dd>
+                <dd class="shelfmark">{% include "corpus/snippets/document_shelfmarks.html" %}</dd>
                 {% if document.digital_editions %}
                     <dt>
                         {# Translators: Editor label #}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -84,7 +84,7 @@
             <section class="transcription-link">
                 {% for ed in document.digital_editions %}
                     {% if ed.content.text %}
-                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% if ed.source.authorship_set.count > 0 %}{% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% endfor %}'s {% endif %}edition.</a></p>
+                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% empty %}[unknown]{% endfor %}'s edition.</a></p>
                     {% endif %}
                 {% endfor %}
             </section>

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -84,7 +84,7 @@
             <section class="transcription-link">
                 {% for ed in document.digital_editions %}
                     {% if ed.content.text %}
-                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% endfor %}'s edition.</a></p>
+                        <p><a href="{% url "corpus:document-transcription-text" document.pk ed.pk %}">Download {% if ed.source.authorship_set.count > 0 %}{% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% endfor %}'s {% endif %}edition.</a></p>
                     {% endif %}
                 {% endfor %}
             </section>

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,5 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark">{{ document.shelfmark_display }}</span>
+    <span class="shelfmark">{{ document.shelfmark }}</span>
 </span>

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,5 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark">{{ document.shelfmark }}</span>
+    <span class="shelfmark">{% include "corpus/snippets/document_shelfmarks.html" %}</span>
 </span>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -10,7 +10,7 @@
                 </span>
                 {# type and shelfmark #}
                 <span class="doctype">{{ document.type }}</span>
-                <span class="shelfmark">{{ document.shelfmark|join:" + " }}</span>
+                <span class="shelfmark">{% include "corpus/snippets/document_shelfmarks.html" %}</span>
             </h2>
 
             {# metadata #}

--- a/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
+++ b/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
@@ -1,0 +1,10 @@
+{% for block in document.textblock_set.all %}
+    {% if block.certain %}
+        <span>{{ block.fragment.shelfmark }}</span>
+    {% endif %}
+{% empty %}
+    {# search results page uses list "shelfmark" instead of textblocK_set #}
+    {% for shelfmark in document.shelfmark %}
+        <span>{{ shelfmark }}</span>
+    {% endfor %}
+{% endfor %}

--- a/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
+++ b/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
@@ -1,10 +1,10 @@
 {% for block in document.textblock_set.all %}
     {% if block.certain %}
-        <span>{{ block.fragment.shelfmark }}</span>
+        <span>{{ block.fragment.shelfmark }}{% if not forloop.last %} + {% endif %}</span>
     {% endif %}
 {% empty %}
     {# search results page uses list "shelfmark" instead of textblocK_set #}
     {% for shelfmark in document.shelfmark %}
-        <span>{{ shelfmark }}</span>
+        <span>{{ shelfmark }}{% if not forloop.last %} +&nbsp;{% endif %}</span>
     {% endfor %}
 {% endfor %}

--- a/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
+++ b/geniza/corpus/templates/corpus/snippets/document_shelfmarks.html
@@ -1,7 +1,5 @@
-{% for block in document.textblock_set.all %}
-    {% if block.certain %}
-        <span>{{ block.fragment.shelfmark }}{% if not forloop.last %} + {% endif %}</span>
-    {% endif %}
+{% for shelfmark in document.certain_join_shelfmarks %}
+    <span>{{ shelfmark }}{% if not forloop.last %} + {% endif %}</span>
 {% empty %}
     {# search results page uses list "shelfmark" instead of textblocK_set #}
     {% for shelfmark in document.shelfmark %}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -488,6 +488,41 @@ class TestDocument:
         TextBlock.objects.create(document=doc, fragment=frag, order=1)
         assert doc.title == "Legal document: s1"
 
+    # NOTE: not currently used; remove or revise if this remains unused
+    def test_shelfmark_display(self):
+        # T-S 8J22.21 + T-S NS J193
+        frag = Fragment.objects.create(shelfmark="T-S 8J22.21")
+        doc = Document.objects.create()
+        TextBlock.objects.create(document=doc, fragment=frag, order=1)
+        # single fragment
+        assert doc.shelfmark_display == frag.shelfmark
+
+        # add a second text block with the same fragment
+        TextBlock.objects.create(document=doc, fragment=frag)
+        # shelfmark should not repeat
+        assert doc.shelfmark_display == frag.shelfmark
+
+        frag2 = Fragment.objects.create(shelfmark="T-S NS J193")
+        TextBlock.objects.create(document=doc, fragment=frag2, order=2)
+        # multiple fragments: show first shelfmark + join indicator
+        assert doc.shelfmark_display == "%s + …" % frag.shelfmark
+
+        # ensure shelfmark honors order
+        doc2 = Document.objects.create()
+        TextBlock.objects.create(document=doc2, fragment=frag2, order=1)
+        TextBlock.objects.create(document=doc2, fragment=frag, order=2)
+        assert doc2.shelfmark_display == "%s + …" % frag2.shelfmark
+
+        # if no certain shelfmarks, don't return anything
+        doc3 = Document.objects.create()
+        frag3 = Fragment.objects.create(shelfmark="T-S NS J195")
+        TextBlock.objects.create(document=doc3, fragment=frag3, certain=False, order=1)
+        assert doc3.shelfmark_display == None
+
+        # use only the first certain shelfmark
+        TextBlock.objects.create(document=doc3, fragment=frag2, order=2)
+        assert doc3.shelfmark_display == frag2.shelfmark
+
     def test_has_transcription(self, document, source):
         # doc with no footnotes doesn't have transcription
         assert not document.has_transcription()

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -480,6 +480,26 @@ class TestDocument:
         TextBlock.objects.create(document=doc, fragment=frag, order=1)
         assert doc.title == "Legal document: s1"
 
+    def test_certain_join_shelfmarks(self):
+        # T-S 8J22.21 (+ T-S NS J193, uncertain)
+        frag = Fragment.objects.create(shelfmark="T-S 8J22.21")
+        doc = Document.objects.create()
+        TextBlock.objects.create(document=doc, fragment=frag, order=1, certain=True)
+        frag2 = Fragment.objects.create(shelfmark="T-S NS J193")
+        TextBlock.objects.create(document=doc, fragment=frag2, order=2, certain=False)
+        # should only be one shelfmark from certain join
+        assert len(doc.certain_join_shelfmarks) == 1
+        # should be the one with certain=True
+        assert doc.certain_join_shelfmarks[0] == "T-S 8J22.21"
+
+        # Add a third fragment
+        frag3 = Fragment.objects.create(shelfmark="T-S NS J195")
+        TextBlock.objects.create(document=doc, fragment=frag3, certain=True, order=3)
+        # should be length 2
+        assert len(doc.certain_join_shelfmarks) == 2
+        # should maintain order
+        assert doc.certain_join_shelfmarks[1] == "T-S NS J195"
+
     # NOTE: not currently used; remove or revise if this remains unused
     def test_shelfmark_display(self):
         # T-S 8J22.21 + T-S NS J193

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -488,40 +488,6 @@ class TestDocument:
         TextBlock.objects.create(document=doc, fragment=frag, order=1)
         assert doc.title == "Legal document: s1"
 
-    def test_shelfmark_display(self):
-        # T-S 8J22.21 + T-S NS J193
-        frag = Fragment.objects.create(shelfmark="T-S 8J22.21")
-        doc = Document.objects.create()
-        TextBlock.objects.create(document=doc, fragment=frag, order=1)
-        # single fragment
-        assert doc.shelfmark_display == frag.shelfmark
-
-        # add a second text block with the same fragment
-        TextBlock.objects.create(document=doc, fragment=frag)
-        # shelfmark should not repeat
-        assert doc.shelfmark_display == frag.shelfmark
-
-        frag2 = Fragment.objects.create(shelfmark="T-S NS J193")
-        TextBlock.objects.create(document=doc, fragment=frag2, order=2)
-        # multiple fragments: show first shelfmark + join indicator
-        assert doc.shelfmark_display == "%s + …" % frag.shelfmark
-
-        # ensure shelfmark honors order
-        doc2 = Document.objects.create()
-        TextBlock.objects.create(document=doc2, fragment=frag2, order=1)
-        TextBlock.objects.create(document=doc2, fragment=frag, order=2)
-        assert doc2.shelfmark_display == "%s + …" % frag2.shelfmark
-
-        # if no certain shelfmarks, don't return anything
-        doc3 = Document.objects.create()
-        frag3 = Fragment.objects.create(shelfmark="T-S NS J195")
-        TextBlock.objects.create(document=doc3, fragment=frag3, certain=False, order=1)
-        assert doc3.shelfmark_display == None
-
-        # use only the first certain shelfmark
-        TextBlock.objects.create(document=doc3, fragment=frag2, order=2)
-        assert doc3.shelfmark_display == frag2.shelfmark
-
     def test_has_transcription(self, document, source):
         # doc with no footnotes doesn't have transcription
         assert not document.has_transcription()

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -88,27 +88,6 @@ class TestDocumentDetailTemplate:
         response = admin_client.get(document.get_absolute_url())
         assertContains(response, edit_url)
 
-    def test_source_location(self, client, document, source):
-        """Document detail template should show footnote location if present"""
-        fn = Footnote.objects.create(
-            content_object=document,
-            source=source,
-            location="p. 25",
-            doc_relation=Footnote.EDITION,
-        )
-        response = client.get(document.get_absolute_url())
-        assertNotContains(response, "p. 25")  # should not show when no content
-        fn.content = "fake content"
-        fn.save()
-        response = client.get(document.get_absolute_url())
-        assertContains(response, "p. 25")  # should show when there is content
-        fn.location = ""
-        fn.save()
-        response = client.get(
-            reverse("corpus:document-scholarship", args=[document.pk])
-        )
-        assertNotContains(response, "p. 25")
-
     def test_editors(self, client, document, source, twoauthor_source):
         # footnote with no content
         Footnote.objects.create(
@@ -283,6 +262,25 @@ class TestDocumentScholarshipTemplate:
         assertContains(
             response, '<dd class="relation">Edition, Translation</dd>', html=True
         )
+
+    def test_source_location(self, client, document, source):
+        """Document scholarship template should show footnote location when present"""
+        fn = Footnote.objects.create(
+            content_object=document,
+            source=source,
+            location="p. 25",
+            doc_relation=Footnote.EDITION,
+        )
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertContains(response, "p. 25")
+        fn.location = ""
+        fn.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        assertNotContains(response, "p. 25")
 
 
 class TestDocumentTabsSnippet:

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -127,7 +127,16 @@ class TestDocumentDetailTemplate:
         assertContains(response, "<dt>Shelfmark</dt>", html=True)
         response = client.get(join.get_absolute_url())
         assertContains(response, "<dt>Shelfmark</dt>", html=True)
-        assertContains(response, join.shelfmark, html=True)
+        shelfmarks = list(
+            block.fragment.shelfmark
+            for block in join.textblock_set.all()
+            if block.certain
+        )
+        assertContains(
+            response,
+            "<span>%s</span><span>%s</span>" % (shelfmarks[0], shelfmarks[1]),
+            html=True,
+        )
 
     def test_download_transcription_link(self, client, document, typed_texts):
         edition = Footnote.objects.create(

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -280,7 +280,7 @@ class TestDocumentScholarshipTemplate:
         response = client.get(
             reverse("corpus:document-scholarship", args=[document.pk])
         )
-        assertNotContains(response, "p. 25")
+        assertNotContains(response, "p. 25")  # should not show when removed
 
 
 class TestDocumentTabsSnippet:

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -131,11 +131,7 @@ class TestDocumentDetailTemplate:
         multifragment.save()
         response = client.get(join.get_absolute_url())
         assertContains(response, "<dt>Shelfmark</dt>", html=True)
-        shelfmarks = list(
-            block.fragment.shelfmark
-            for block in join.textblock_set.all()
-            if block.certain
-        )
+        shelfmarks = join.certain_join_shelfmarks
         assertContains(
             response,
             "<span>%s + </span><span>%s</span>" % (shelfmarks[0], shelfmarks[1]),

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -134,7 +134,7 @@ class TestDocumentDetailTemplate:
         )
         assertContains(
             response,
-            "<span>%s</span><span>%s</span>" % (shelfmarks[0], shelfmarks[1]),
+            "<span>%s + </span><span>%s</span>" % (shelfmarks[0], shelfmarks[1]),
             html=True,
         )
 

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -445,8 +445,6 @@ class Footnote(TrackChangesModel):
         # source. notes.
         # source, location.
         parts = [str(self.source)]
-        if self.location:
-            parts.extend([", ", self.location])
         parts.append(".")
         if self.notes:
             # uppercase first letter of notes if not capitalized

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -218,13 +218,12 @@ class TestFootnote:
         footnote = Footnote(source=source)
         assert footnote.display() == "George Orwell, A Nice Cup of Tea."
 
-        footnote.location = "p. 55"
-        assert footnote.display() == "George Orwell, A Nice Cup of Tea, p. 55."
+        footnote.location = "p. 55"  # should not change display
+        assert footnote.display() == "George Orwell, A Nice Cup of Tea."
 
         footnote.notes = "With minor edits."
         assert (
-            footnote.display()
-            == "George Orwell, A Nice Cup of Tea, p. 55. With minor edits."
+            footnote.display() == "George Orwell, A Nice Cup of Tea. With minor edits."
         )
 
     @pytest.mark.django_db

--- a/sitemedia/scss/components/_docheader.scss
+++ b/sitemedia/scss/components/_docheader.scss
@@ -17,19 +17,23 @@ span#formatted-title {
     .shelfmark {
         @include typography.shelfmark;
     }
-    margin: spacing.$spacing-xl 0 spacing.$spacing-md;
+    margin: spacing.$spacing-xl spacing.$spacing-md spacing.$spacing-md;
     @include breakpoints.for-desktop-up {
-        margin: spacing.$spacing-3xl 0 spacing.$spacing-2xl;
+        margin: spacing.$spacing-3xl spacing.$spacing-md spacing.$spacing-2xl;
     }
 }
 
 // Edit link for admins
 .edit-link-container {
     @include container.measure;
+    top: spacing.$spacing-4xl;
     position: absolute;
     width: 100%;
     display: flex;
     justify-content: flex-end;
+    @include breakpoints.for-tablet-landscape-up {
+        top: auto;
+    }
     a.edit-link {
         span {
             @include typography.link;

--- a/sitemedia/scss/components/_shelfmark.scss
+++ b/sitemedia/scss/components/_shelfmark.scss
@@ -1,0 +1,13 @@
+// -----------------------------------------------------------------------------
+// Styling rules for document shelfmarks.
+// -----------------------------------------------------------------------------
+
+.shelfmark span {
+    // Never break in the middle of a shelfmark
+    white-space: nowrap;
+    display: inline-block;
+    // Add a plus indicator between shelfmarks
+    &:not(:last-child)::after {
+        content: " + ";
+    }
+}

--- a/sitemedia/scss/components/_shelfmark.scss
+++ b/sitemedia/scss/components/_shelfmark.scss
@@ -6,8 +6,4 @@
     // Never break in the middle of a shelfmark
     white-space: nowrap;
     display: inline-block;
-    // Add a plus indicator between shelfmarks
-    &:not(:last-child)::after {
-        content: " + ";
-    }
 }

--- a/sitemedia/scss/main.scss
+++ b/sitemedia/scss/main.scss
@@ -15,6 +15,7 @@
 @use "components/docheader";
 @use "components/controls";
 @use "components/footer";
+@use "components/shelfmark";
 
 // Page-specific styles
 @use "pages/content";


### PR DESCRIPTION
## What this PR does

- Per #547:
  - Removes `shelfmark_display` method, and instead just uses shelfmark string method to display all shelfmarks in document titles
  - Removes footnote location from detail view; moves test for footnote location presence to scholarship records template
  - Fixes "download edition" link for sources with no authorships