### PR TITLE
#486 - Add volume back to unpublished source string method

### DIFF
--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -132,8 +132,12 @@ class Source(models.Model):
         ordering = ["title", "year"]
 
     def __str__(self):
-        """strip HTML tags and trailing period from formatted display"""
-        return strip_tags(self.formatted_display(extra_fields=False))[:-1]
+        # Append volume for unpublished (e.g. typed texts)
+        if self.source_type.type == "Unpublished" and self.volume:
+            return self.formatted_stripped() + ", " + self.volume
+        # Otherwise return formatted display without html tags
+        else:
+            return self.formatted_stripped()
 
     def all_authors(self):
         """semi-colon delimited list of authors in order"""
@@ -335,6 +339,10 @@ class Source(models.Model):
     all_authors.short_description = "Authors"
     all_authors.admin_order_field = "first_author"  # set in admin queryset
 
+    def formatted_stripped(self):
+        """strip HTML tags and trailing period from formatted display"""
+        return strip_tags(self.formatted_display(extra_fields=False))[:-1]
+
     @classmethod
     def get_volume_from_shelfmark(cls, shelfmark):
         """Given a shelfmark, get our volume label. This logic was determined in
@@ -444,7 +452,7 @@ class Footnote(TrackChangesModel):
         # source, location. notes.
         # source. notes.
         # source, location.
-        parts = [str(self.source)]
+        parts = [self.source.formatted_stripped()]
         if self.location:
             parts.extend([", ", self.location])
         parts.append(".")

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -116,8 +116,12 @@ class TestSource:
         )
 
     def test_str_unpublished_vol(self, typed_texts):
+        # displays with volume
+        assert str(typed_texts) == "S. D. Goitein, typed texts, CUL"
+
+    def test_formatted_stripped(self, typed_texts):
         # displays without volume
-        assert str(typed_texts) == "S. D. Goitein, typed texts"
+        assert typed_texts.formatted_stripped() == "S. D. Goitein, typed texts"
 
     def test_formatted_display(self, book_section):
         # should display proper publisher info, page range for book section fixture

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -28,19 +28,19 @@ class TestSource:
     @pytest.mark.django_db
     def test_str(self, source, twoauthor_source, multiauthor_untitledsource):
         # source has no year; str should be creator lastname, title, (n.p., n.d.)
-        assert str(source) == "%s, %s" % (
+        assert str(source) == "%s, %s." % (
             source.authors.first().firstname_lastname(),
             source.title,
         )
         # set a year
         source.year = 1984
-        assert str(source) == "%s, %s (1984)" % (
+        assert str(source) == "%s, %s (1984)." % (
             source.authors.first().firstname_lastname(),
             source.title,
         )
 
         # two authors
-        assert str(twoauthor_source) == "%s and %s, %s" % (
+        assert str(twoauthor_source) == "%s and %s, %s." % (
             twoauthor_source.authors.first().firstname_lastname(),
             twoauthor_source.authors.all()[1].firstname_lastname(),
             twoauthor_source.title,
@@ -59,7 +59,7 @@ class TestSource:
         lastnames = [
             a.creator.last_name for a in multiauthor_untitledsource.authorship_set.all()
         ]
-        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s, %s" % (
+        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s, %s." % (
             tuple(lastnames) + (multiauthor_untitledsource.source_type.type.lower(),)
         )
 
@@ -67,7 +67,7 @@ class TestSource:
     def test_str_article(self, article):
 
         # article with title, journal title, volume, year
-        assert str(article) == '%s, "%s," %s %s, no. %d (%s)' % (
+        assert str(article) == '%s, "%s," %s %s, no. %d (%s).' % (
             article.authors.first().firstname_lastname(),
             article.title,
             article.journal,
@@ -77,7 +77,7 @@ class TestSource:
         )
         # article with no title
         article.title = ""
-        assert str(article) == "%s, %s %s, no. %d (%s)" % (
+        assert str(article) == "%s, %s %s, no. %d (%s)." % (
             article.authors.first().firstname_lastname(),
             article.journal,
             article.volume,
@@ -87,7 +87,7 @@ class TestSource:
         # no volume or issue
         article.volume = ""
         article.issue = None
-        assert str(article) == "%s, %s (%s)" % (
+        assert str(article) == "%s, %s (%s)." % (
             article.authors.first().firstname_lastname(),
             article.journal,
             article.year,
@@ -99,7 +99,7 @@ class TestSource:
 
     def test_str_book_section(self, book_section):
         # book section with authors, title, book title, edition, year, volume no.
-        assert str(book_section) == '%s, "%s," in %s, %s ed. (%s), vol. %s' % (
+        assert str(book_section) == '%s, "%s," in %s, %s ed. (%s), vol. %s.' % (
             book_section.authors.first().firstname_lastname(),
             book_section.title,
             book_section.journal,
@@ -117,11 +117,11 @@ class TestSource:
 
     def test_str_unpublished_vol(self, typed_texts):
         # displays with volume
-        assert str(typed_texts) == "S. D. Goitein, typed texts, CUL"
+        assert str(typed_texts) == "S. D. Goitein, typed texts. (CUL)"
 
-    def test_formatted_stripped(self, typed_texts):
+    def test_display(self, typed_texts):
         # displays without volume
-        assert typed_texts.formatted_stripped() == "S. D. Goitein, typed texts"
+        assert typed_texts.display() == "S. D. Goitein, typed texts."
 
     def test_formatted_display(self, book_section):
         # should display proper publisher info, page range for book section fixture
@@ -223,12 +223,12 @@ class TestFootnote:
         assert footnote.display() == "George Orwell, A Nice Cup of Tea."
 
         footnote.location = "p. 55"
-        assert footnote.display() == "George Orwell, A Nice Cup of Tea, p. 55."
+        assert footnote.display() == "George Orwell, A Nice Cup of Tea. p. 55."
 
         footnote.notes = "With minor edits."
         assert (
             footnote.display()
-            == "George Orwell, A Nice Cup of Tea, p. 55. With minor edits."
+            == "George Orwell, A Nice Cup of Tea. p. 55. With minor edits."
         )
 
     @pytest.mark.django_db


### PR DESCRIPTION
## What this PR does
- Per #486:
  - Adds source volume for unpublished sources back to the `__str__` method; adds a new method `formatted_stripped` to allow displaying without it

## dev notes
- I think the only other place the source string method was called, besides the admin interface, was `footnote.display()`. Otherwise the frontend uses `source.formatted_display()`. Running Percy just in case! (edit: confirmed in Percy)