### PR TITLE
#501 - Footnote location/URL revisions

### DIFF
--- a/geniza/corpus/templates/corpus/document_scholarship.html
+++ b/geniza/corpus/templates/corpus/document_scholarship.html
@@ -28,15 +28,29 @@
                                 {% endif %}
                             </dd>
                             <dt class="relation">
-                                <ul>
-                                    {% for fn in source.list|natsort:"location" %}
-                                        {% include "corpus/snippets/footnote_location.html" %}
-                                    {% endfor %}
-                                </ul>
+                                {# Translators: label for included document relations for a single footnote #}
+                                {% translate "includes" as includes_text %}
+                                {% if source.list|length > 1 or source.list.0.location or source.list.0.url %}
+                                    {# Translators: label for document relations in list of footnotes #}
+                                    {% blocktranslate with relation=source.list.0.doc_relation trimmed %}
+                                        for {{ relation }} see
+                                    {% endblocktranslate%}
+                                {% else %}
+                                    {# Translators: label for document relations for one footnote with no location or URL #}
+                                    {% blocktranslate with relation=source.list.0.doc_relation trimmed %}
+                                        includes {{ relation }}
+                                    {% endblocktranslate%}
+                                {% endif %}
                             </dt>
-                            <dd class="relation">
-                                {{ source.list.0.doc_relation }}
-                            </dd>
+                            {% if source.list|length > 1 or source.list.0.location or source.list.0.url %}
+                                <dd class="relation">
+                                    <ul>
+                                        {% for fn in source.list|natsort:"location" %}
+                                            {% include "corpus/snippets/footnote_location.html" %}
+                                        {% endfor %}
+                                    </ul>
+                                </dd>
+                            {% endif %}
                         </dl>
                     </li>
                 {% endspaceless %}

--- a/geniza/corpus/templates/corpus/snippets/footnote_location.html
+++ b/geniza/corpus/templates/corpus/snippets/footnote_location.html
@@ -2,33 +2,11 @@
 
 <li class="location">
     {% if fn.location and fn.url %}
-        {% if forloop.first %}
-            {# Translators: label for footnote location within source (with url) #}
-            {% blocktranslate with location=fn.location url=fn.url trimmed %}
-                see <a href="{{ url }}">{{ location }}</a> for
-            {% endblocktranslate %}
-        {% else %}
-            <a href="{{ fn.url }}">{{ fn.location }}</a>
-        {% endif %}
+        <a href="{{ fn.url }}">{{ fn.location }}</a>
     {% elif fn.location %}
-        {% if forloop.first %}
-            {# Translators: label for footnote location within source #}
-            {% blocktranslate with location=fn.location trimmed %}
-                see {{ location }} for
-            {% endblocktranslate %}
-        {% else %}
-            {{ fn.location }}
-        {% endif %}
+        {{ fn.location }}
     {% elif fn.url %}
-        {% if forloop.first %}
-            {# Translators: label for included document relations for a footnote #}
-            <a href="{{ fn.url }}">{% translate 'includes' %}</a>
-        {% else %}
-            {# Translators: label for a link in a list of footnote links #}
-            <a href="{{ fn.url }}">{% translate 'footnote' %}</a>
-        {% endif %}
-    {% elif forloop.first %}
-        {# Translators: label for included document relations for a footnote #}
-        {% translate "includes" %}
+        {# Translators: label for a link to a resource with no named location #}
+        <a href="{{ fn.url }}">{% translate "online resource" %}</a>
     {% endif %}
 </li>

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -245,7 +245,7 @@ class TestDocumentScholarshipTemplate:
             reverse("corpus:document-scholarship", args=[document.pk])
         )
         assertContains(
-            response, '<a href="https://example.com/">includes</a>', html=True
+            response, '<a href="https://example.com/">online resource</a>', html=True
         )
         fn.url = ""
         fn.save()
@@ -254,7 +254,7 @@ class TestDocumentScholarshipTemplate:
         )
         assertNotContains(response, '<a href="https://example.com/">')
 
-    def test_source_relation(self, client, document, source):
+    def test_source_relation(self, client, document, source, twoauthor_source):
         """Document scholarship template should show source relation to doc"""
         fn = Footnote.objects.create(
             content_object=document, source=source, doc_relation=Footnote.EDITION
@@ -262,14 +262,31 @@ class TestDocumentScholarshipTemplate:
         response = client.get(
             reverse("corpus:document-scholarship", args=[document.pk])
         )
-        assertContains(response, '<dd class="relation">Edition</dd>', html=True)
-        fn.doc_relation = [Footnote.EDITION, Footnote.TRANSLATION]
-        fn.save()
+        assertContains(
+            response, '<dt class="relation">includes Edition</dt>', html=True
+        )
+
+        fn2 = Footnote.objects.create(
+            content_object=document,
+            source=twoauthor_source,
+            doc_relation=Footnote.EDITION,
+            location="p. 25",
+        )
         response = client.get(
             reverse("corpus:document-scholarship", args=[document.pk])
         )
+        assertContains(response, '<dt class="relation">for Edition see</dt>', html=True)
+
+        fn2.doc_relation = [Footnote.EDITION, Footnote.TRANSLATION]
+        fn2.save()
+        response = client.get(
+            reverse("corpus:document-scholarship", args=[document.pk])
+        )
+        print(response.content)
         assertContains(
-            response, '<dd class="relation">Edition, Translation</dd>', html=True
+            response,
+            '<dt class="relation">for Edition, Translation see</dt>',
+            html=True,
         )
 
     def test_source_location(self, client, document, source):

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -4,6 +4,7 @@ from django.contrib.humanize.templatetags.humanize import ordinal
 from django.db import models
 from django.utils import html
 from django.utils.html import strip_tags
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from gfklookupwidget.fields import GfkLookupField
 from modeltranslation.manager import MultilingualManager
@@ -188,15 +189,12 @@ class Source(models.Model):
             # otherwise, just leave unformatted
             else:
                 work_title = self.title + ltr_mark
-        elif self.source_type and (
-            extra_fields or not author or self.source_type.type == "Unpublished"
-        ):
-            # Use type as descriptive title when no title available, per CMS
-            # Only when extra_fields enabled, or there is no author, or "unpublished" should appear
-            # in brief citation
-            work_title = (
-                self.source_type.type if not author else self.source_type.type.lower()
-            )
+        elif extra_fields or not author:
+            # Use [no title] as placeholder title when no title available;
+            # only when extra_fields enabled, or there is no author
+
+            # Translators: Placeholder for when a work has no title available
+            work_title = gettext("[no title]")
 
         # Wrap title in link to URL
         if self.url and work_title:
@@ -327,7 +325,7 @@ class Source(models.Model):
         #   L. B. Yarbrough (in Hebrew)             (no comma)
         #   Author (1964)                           (no comma)
         #   Author, Journal 6 (1964)                (comma)
-        #   Author, unpublished                     (comma)
+        #   Author, [no title]                      (comma)
         use_comma = (
             extra_fields
             or self.title

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -55,12 +55,12 @@ class TestSource:
             ordinal(twoauthor_source.edition),
         )
 
-        # four authors, no title, unpublished
+        # four authors, no title
         lastnames = [
             a.creator.last_name for a in multiauthor_untitledsource.authorship_set.all()
         ]
-        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s, %s." % (
-            tuple(lastnames) + (multiauthor_untitledsource.source_type.type.lower(),)
+        assert str(multiauthor_untitledsource) == "%s, %s, %s and %s." % tuple(
+            lastnames
         )
 
     @pytest.mark.django_db
@@ -180,6 +180,16 @@ class TestSource:
             phd_dissertation.place_published
             and phd_dissertation.place_published
             not in phd_dissertation.formatted_display()
+        )
+
+    def test_formatted_no_title(self, multiauthor_untitledsource):
+        # should include [no title]
+        lastnames = [
+            a.creator.last_name for a in multiauthor_untitledsource.authorship_set.all()
+        ]
+        assert (
+            multiauthor_untitledsource.formatted_display()
+            == "%s, %s, %s and %s, [no title]." % tuple(lastnames)
         )
 
     def test_get_volume_from_shelfmark(self):

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-02-02 12:39-0500\n"
+"POT-Creation-Date: 2022-02-02 12:54-0500\n"
 "PO-Revision-Date: 2022-01-12 17:31\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -329,15 +329,20 @@ msgstr[3] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[4] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[5] "%(count)d سجل منح دراسية لـ %(doc)s"
 
-#: geniza/footnotes/models.py:402
+#. Translators: Placeholder for when a work has no title available
+#: geniza/footnotes/models.py:197
+msgid "[no title]"
+msgstr ""
+
+#: geniza/footnotes/models.py:403
 msgid "Edition"
 msgstr "الطبعة"
 
-#: geniza/footnotes/models.py:403
+#: geniza/footnotes/models.py:404
 msgid "Translation"
 msgstr "الترجمة"
 
-#: geniza/footnotes/models.py:404
+#: geniza/footnotes/models.py:405
 msgid "Discussion"
 msgstr "المناقشة"
 

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-01-26 12:42-0500\n"
+"POT-Creation-Date: 2022-02-02 12:39-0500\n"
 "PO-Revision-Date: 2022-01-12 17:31\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -57,8 +57,29 @@ msgstr "نوع المستند"
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
+#: geniza/corpus/models.py:630
+msgid "Princeton Geniza Project"
+msgstr "مشروع برنستون جينيزا"
+
+#. Translators: attribution for local IIIF manifests
+#: geniza/corpus/models.py:632
+#, python-format
+msgid "Compilation by %(pgp)s."
+msgstr "تجميع بواسطة %(pgp)s."
+
+#. Translators: attribution for local IIIF manifests that include transcription
+#: geniza/corpus/models.py:635
+#, python-format
+msgid "Compilation and transcription by %(pgp)s."
+msgstr "التجميع والنسخ بواسطة %(pgp)s."
+
+#. Translators: manifest attribution note that content from other institutions may have restrictions
+#: geniza/corpus/models.py:637
+msgid "Additional restrictions may apply."
+msgstr "ويجوز تطبيق قيود إضافية."
+
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:629
+#: geniza/corpus/models.py:687
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr "نوع غير معروف"
@@ -143,6 +164,24 @@ msgstr "الاقتباس الببليوغرافي"
 msgid "unpublished"
 msgstr "غير منشورة"
 
+#. Translators: label for included document relations for a single footnote
+#: geniza/corpus/templates/corpus/document_scholarship.html:32
+msgid "includes"
+msgstr "يشمل"
+
+#. Translators: label for document relations in list of footnotes
+#: geniza/corpus/templates/corpus/document_scholarship.html:35
+#, fuzzy, python-format
+#| msgid "see %(location)s for"
+msgid "for %(relation)s see"
+msgstr "شاهد %(location)s ل"
+
+#. Translators: label for document relations for one footnote with no location or URL
+#: geniza/corpus/templates/corpus/document_scholarship.html:40
+#, python-format
+msgid "includes %(relation)s"
+msgstr ""
+
 #. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
@@ -192,7 +231,11 @@ msgstr[5] "%(counter)s مناقشات"
 msgid "No Scholarship Records"
 msgstr "لا توجد سجلات للمنح الدراسية"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:104
+#: geniza/corpus/templates/corpus/snippets/document_result.html:99
+msgid "more"
+msgstr ""
+
+#: geniza/corpus/templates/corpus/snippets/document_result.html:107
 msgid "View document details"
 msgstr "عرض تفاصيل المستند"
 
@@ -221,27 +264,24 @@ msgstr "الروابط الخارجية"
 msgid "External Links (%(n_links)s)"
 msgstr "الروابط الخارجية (%(n_links)s)"
 
-#. Translators: label for footnote location within source (with url)
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:7
-#, python-format
-msgid "see <a href=\"%(url)s\">%(location)s</a> for"
-msgstr "شاهد <a href=\"%(url)s\">%(location)s</a> ل"
+#. Translators: accessibility label for document images and transcription section
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:5
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Images and transcription"
+msgstr "%(counter)s النصوص"
 
-#. Translators: label for footnote location within source
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:16
-#, python-format
-msgid "see %(location)s for"
-msgstr "شاهد %(location)s ل"
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:24
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Transcription"
+msgstr "%(counter)s النصوص"
 
-#. Translators: label for included document relations for a footnote
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:25
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:32
-msgid "includes"
-msgstr "يشمل"
-
-#. Translators: label for a link in a list of footnote links
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:28
-msgid "footnote"
+#. Translators: label for a link to a resource with no named location
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:10
+msgid "online resource"
 msgstr ""
 
 #. Translators: Label for "previous page" button in search results
@@ -263,22 +303,22 @@ msgid "Next"
 msgstr ""
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:30
+#: geniza/corpus/views.py:31
 msgid "Search Documents"
 msgstr "البحث في المستندات"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:32
+#: geniza/corpus/views.py:33
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:223
+#: geniza/corpus/views.py:227
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "منحة في %(doc)s"
 
-#: geniza/corpus/views.py:230
+#: geniza/corpus/views.py:234
 #, python-format
 msgid "%(count)d scholarship record for %(doc)s"
 msgid_plural "%(count)d scholarship records for %(doc)s"
@@ -289,35 +329,15 @@ msgstr[3] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[4] "%(count)d سجل منح دراسية لـ %(doc)s"
 msgstr[5] "%(count)d سجل منح دراسية لـ %(doc)s"
 
-#. Translators: attribution for local IIIF manifests
-#: geniza/corpus/views.py:355
-msgid "Princeton Geniza Project"
-msgstr "مشروع برنستون جينيزا"
-
-#: geniza/corpus/views.py:356
-#, python-format
-msgid "Compilation by %(pgp)s."
-msgstr "تجميع بواسطة %(pgp)s."
-
-#: geniza/corpus/views.py:359
-#, python-format
-msgid "Compilation and transcription by %(pgp)s."
-msgstr "التجميع والنسخ بواسطة %(pgp)s."
-
-#. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/views.py:361
-msgid "Additional restrictions may apply."
-msgstr "ويجوز تطبيق قيود إضافية."
-
-#: geniza/footnotes/models.py:394
+#: geniza/footnotes/models.py:402
 msgid "Edition"
 msgstr "الطبعة"
 
-#: geniza/footnotes/models.py:395
+#: geniza/footnotes/models.py:403
 msgid "Translation"
 msgstr "الترجمة"
 
-#: geniza/footnotes/models.py:396
+#: geniza/footnotes/models.py:404
 msgid "Discussion"
 msgstr "المناقشة"
 
@@ -451,6 +471,10 @@ msgstr "العودة إلى القائمة الرئيسية"
 #: geniza/templates/snippets/theme_toggle.html:9
 msgid "Enable dark mode"
 msgstr "تمكين الوضع المظلم"
+
+#, python-format
+#~ msgid "see <a href=\"%(url)s\">%(location)s</a> for"
+#~ msgstr "شاهد <a href=\"%(url)s\">%(location)s</a> ل"
 
 #~ msgid "next page"
 #~ msgstr "الصفحة التالية"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-01-26 12:42-0500\n"
+"POT-Creation-Date: 2022-02-02 12:39-0500\n"
 "PO-Revision-Date: 2022-01-12 17:32\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -56,8 +56,29 @@ msgstr ""
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
+#: geniza/corpus/models.py:630
+msgid "Princeton Geniza Project"
+msgstr ""
+
+#. Translators: attribution for local IIIF manifests
+#: geniza/corpus/models.py:632
+#, python-format
+msgid "Compilation by %(pgp)s."
+msgstr ""
+
+#. Translators: attribution for local IIIF manifests that include transcription
+#: geniza/corpus/models.py:635
+#, python-format
+msgid "Compilation and transcription by %(pgp)s."
+msgstr ""
+
+#. Translators: manifest attribution note that content from other institutions may have restrictions
+#: geniza/corpus/models.py:637
+msgid "Additional restrictions may apply."
+msgstr ""
+
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:629
+#: geniza/corpus/models.py:687
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr ""
@@ -134,6 +155,23 @@ msgstr ""
 msgid "unpublished"
 msgstr ""
 
+#. Translators: label for included document relations for a single footnote
+#: geniza/corpus/templates/corpus/document_scholarship.html:32
+msgid "includes"
+msgstr ""
+
+#. Translators: label for document relations in list of footnotes
+#: geniza/corpus/templates/corpus/document_scholarship.html:35
+#, python-format
+msgid "for %(relation)s see"
+msgstr ""
+
+#. Translators: label for document relations for one footnote with no location or URL
+#: geniza/corpus/templates/corpus/document_scholarship.html:40
+#, python-format
+msgid "includes %(relation)s"
+msgstr ""
+
 #. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
@@ -171,7 +209,11 @@ msgstr[1] ""
 msgid "No Scholarship Records"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:104
+#: geniza/corpus/templates/corpus/snippets/document_result.html:99
+msgid "more"
+msgstr ""
+
+#: geniza/corpus/templates/corpus/snippets/document_result.html:107
 msgid "View document details"
 msgstr ""
 
@@ -200,27 +242,18 @@ msgstr ""
 msgid "External Links (%(n_links)s)"
 msgstr ""
 
-#. Translators: label for footnote location within source (with url)
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:7
-#, python-format
-msgid "see <a href=\"%(url)s\">%(location)s</a> for"
+#. Translators: accessibility label for document images and transcription section
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:5
+msgid "Images and transcription"
 msgstr ""
 
-#. Translators: label for footnote location within source
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:16
-#, python-format
-msgid "see %(location)s for"
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:24
+msgid "Transcription"
 msgstr ""
 
-#. Translators: label for included document relations for a footnote
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:25
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:32
-msgid "includes"
-msgstr ""
-
-#. Translators: label for a link in a list of footnote links
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:28
-msgid "footnote"
+#. Translators: label for a link to a resource with no named location
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:10
+msgid "online resource"
 msgstr ""
 
 #. Translators: Label for "previous page" button in search results
@@ -240,57 +273,37 @@ msgid "Next"
 msgstr ""
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:30
+#: geniza/corpus/views.py:31
 msgid "Search Documents"
 msgstr "Search Documents"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:32
+#: geniza/corpus/views.py:33
 msgid "Search and browse Geniza documents."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:223
+#: geniza/corpus/views.py:227
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr ""
 
-#: geniza/corpus/views.py:230
+#: geniza/corpus/views.py:234
 #, python-format
 msgid "%(count)d scholarship record for %(doc)s"
 msgid_plural "%(count)d scholarship records for %(doc)s"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: attribution for local IIIF manifests
-#: geniza/corpus/views.py:355
-msgid "Princeton Geniza Project"
-msgstr ""
-
-#: geniza/corpus/views.py:356
-#, python-format
-msgid "Compilation by %(pgp)s."
-msgstr ""
-
-#: geniza/corpus/views.py:359
-#, python-format
-msgid "Compilation and transcription by %(pgp)s."
-msgstr ""
-
-#. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/views.py:361
-msgid "Additional restrictions may apply."
-msgstr ""
-
-#: geniza/footnotes/models.py:394
+#: geniza/footnotes/models.py:402
 msgid "Edition"
 msgstr ""
 
-#: geniza/footnotes/models.py:395
+#: geniza/footnotes/models.py:403
 msgid "Translation"
 msgstr ""
 
-#: geniza/footnotes/models.py:396
+#: geniza/footnotes/models.py:404
 msgid "Discussion"
 msgstr ""
 

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-02-02 12:39-0500\n"
+"POT-Creation-Date: 2022-02-02 12:54-0500\n"
 "PO-Revision-Date: 2022-01-12 17:32\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -295,15 +295,20 @@ msgid_plural "%(count)d scholarship records for %(doc)s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: geniza/footnotes/models.py:402
-msgid "Edition"
+#. Translators: Placeholder for when a work has no title available
+#: geniza/footnotes/models.py:197
+msgid "[no title]"
 msgstr ""
 
 #: geniza/footnotes/models.py:403
-msgid "Translation"
+msgid "Edition"
 msgstr ""
 
 #: geniza/footnotes/models.py:404
+msgid "Translation"
+msgstr ""
+
+#: geniza/footnotes/models.py:405
 msgid "Discussion"
 msgstr ""
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-02-02 12:39-0500\n"
+"POT-Creation-Date: 2022-02-02 12:54-0500\n"
 "PO-Revision-Date: 2022-01-12 17:31\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -316,15 +316,20 @@ msgstr[1] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[2] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[3] "%(count)d רשומות קשורות ל %(doc)s"
 
-#: geniza/footnotes/models.py:402
+#. Translators: Placeholder for when a work has no title available
+#: geniza/footnotes/models.py:197
+msgid "[no title]"
+msgstr ""
+
+#: geniza/footnotes/models.py:403
 msgid "Edition"
 msgstr "מהדורה"
 
-#: geniza/footnotes/models.py:403
+#: geniza/footnotes/models.py:404
 msgid "Translation"
 msgstr "תרגום"
 
-#: geniza/footnotes/models.py:404
+#: geniza/footnotes/models.py:405
 msgid "Discussion"
 msgstr "דיון"
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-01-26 12:42-0500\n"
+"POT-Creation-Date: 2022-02-02 12:39-0500\n"
 "PO-Revision-Date: 2022-01-12 17:31\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -57,8 +57,29 @@ msgstr "סוג המסמך"
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
+#: geniza/corpus/models.py:630
+msgid "Princeton Geniza Project"
+msgstr "פרוייקט הגניזה של פרינסטון"
+
+#. Translators: attribution for local IIIF manifests
+#: geniza/corpus/models.py:632
+#, python-format
+msgid "Compilation by %(pgp)s."
+msgstr "קובץ על-ידי %(pgp)s."
+
+#. Translators: attribution for local IIIF manifests that include transcription
+#: geniza/corpus/models.py:635
+#, python-format
+msgid "Compilation and transcription by %(pgp)s."
+msgstr "קובץ ותועתק על-ידי %(pgp)s."
+
+#. Translators: manifest attribution note that content from other institutions may have restrictions
+#: geniza/corpus/models.py:637
+msgid "Additional restrictions may apply."
+msgstr "קיימות מגבלות נוספות."
+
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/models.py:629
+#: geniza/corpus/models.py:687
 #: geniza/corpus/templates/corpus/snippets/document_header.html:17
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
@@ -139,6 +160,23 @@ msgstr "ציטוט"
 msgid "unpublished"
 msgstr "לא פורסם"
 
+#. Translators: label for included document relations for a single footnote
+#: geniza/corpus/templates/corpus/document_scholarship.html:32
+msgid "includes"
+msgstr "כלול"
+
+#. Translators: label for document relations in list of footnotes
+#: geniza/corpus/templates/corpus/document_scholarship.html:35
+#, python-format
+msgid "for %(relation)s see"
+msgstr ""
+
+#. Translators: label for document relations for one footnote with no location or URL
+#: geniza/corpus/templates/corpus/document_scholarship.html:40
+#, python-format
+msgid "includes %(relation)s"
+msgstr ""
+
 #. Translators: Document edit link for admins
 #: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
@@ -182,7 +220,11 @@ msgstr[3] "%(counter)s דיונים"
 msgid "No Scholarship Records"
 msgstr "אין רשומות קשורות"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:104
+#: geniza/corpus/templates/corpus/snippets/document_result.html:99
+msgid "more"
+msgstr ""
+
+#: geniza/corpus/templates/corpus/snippets/document_result.html:107
 msgid "View document details"
 msgstr "הצגת פרטי מסמך"
 
@@ -211,27 +253,24 @@ msgstr "קישורים חיצוניים"
 msgid "External Links (%(n_links)s)"
 msgstr "קישורים חיצוניים (%(n_links)s)"
 
-#. Translators: label for footnote location within source (with url)
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:7
-#, python-format
-msgid "see <a href=\"%(url)s\">%(location)s</a> for"
-msgstr ""
+#. Translators: accessibility label for document images and transcription section
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:5
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Images and transcription"
+msgstr "תעתוק אחד"
 
-#. Translators: label for footnote location within source
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:16
-#, python-format
-msgid "see %(location)s for"
-msgstr ""
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:24
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Transcription"
+msgstr "תעתוק אחד"
 
-#. Translators: label for included document relations for a footnote
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:25
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:32
-msgid "includes"
-msgstr "כלול"
-
-#. Translators: label for a link in a list of footnote links
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:28
-msgid "footnote"
+#. Translators: label for a link to a resource with no named location
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:10
+msgid "online resource"
 msgstr ""
 
 #. Translators: Label for "previous page" button in search results
@@ -253,22 +292,22 @@ msgid "Next"
 msgstr ""
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:30
+#: geniza/corpus/views.py:31
 msgid "Search Documents"
 msgstr "חיפוש מסמכים"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:32
+#: geniza/corpus/views.py:33
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:223
+#: geniza/corpus/views.py:227
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "רשומה קשורה ל-%(doc)s"
 
-#: geniza/corpus/views.py:230
+#: geniza/corpus/views.py:234
 #, python-format
 msgid "%(count)d scholarship record for %(doc)s"
 msgid_plural "%(count)d scholarship records for %(doc)s"
@@ -277,35 +316,15 @@ msgstr[1] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[2] "%(count)d רשומות קשורות ל %(doc)s"
 msgstr[3] "%(count)d רשומות קשורות ל %(doc)s"
 
-#. Translators: attribution for local IIIF manifests
-#: geniza/corpus/views.py:355
-msgid "Princeton Geniza Project"
-msgstr "פרוייקט הגניזה של פרינסטון"
-
-#: geniza/corpus/views.py:356
-#, python-format
-msgid "Compilation by %(pgp)s."
-msgstr "קובץ על-ידי %(pgp)s."
-
-#: geniza/corpus/views.py:359
-#, python-format
-msgid "Compilation and transcription by %(pgp)s."
-msgstr "קובץ ותועתק על-ידי %(pgp)s."
-
-#. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/views.py:361
-msgid "Additional restrictions may apply."
-msgstr "קיימות מגבלות נוספות."
-
-#: geniza/footnotes/models.py:394
+#: geniza/footnotes/models.py:402
 msgid "Edition"
 msgstr "מהדורה"
 
-#: geniza/footnotes/models.py:395
+#: geniza/footnotes/models.py:403
 msgid "Translation"
 msgstr "תרגום"
 
-#: geniza/footnotes/models.py:396
+#: geniza/footnotes/models.py:404
 msgid "Discussion"
 msgstr "דיון"
 

--- a/sitemedia/scss/components/_footnote.scss
+++ b/sitemedia/scss/components/_footnote.scss
@@ -44,9 +44,6 @@
             margin-bottom: spacing.$spacing-2xs;
             @include typography.meta;
         }
-        // span.location:not(:last-child)::after {
-        //     content: ", ";
-        // }
         li.location {
             word-break: break-all;
         }

--- a/sitemedia/scss/components/_footnote.scss
+++ b/sitemedia/scss/components/_footnote.scss
@@ -44,9 +44,11 @@
             margin-bottom: spacing.$spacing-2xs;
             @include typography.meta;
         }
-        // Indentation for footnote relation when more than one present
-        li.location:not(:first-child) {
-            margin-left: spacing.$spacing-lg;
+        // span.location:not(:last-child)::after {
+        //     content: ", ";
+        // }
+        li.location {
+            word-break: break-all;
         }
     }
     div.unpublished {


### PR DESCRIPTION
## What this PR does
- Per #501:
  - Rearranges footnote relations/locations to read "for Relations see," then a line break, then list of footnote locations
  - Uses "includes Relations" for footnotes with no locations or URL
  - Uses "online resource" placeholder for footnotes with a URL and no location
  - Uses [no title] placeholder in long-form citations for sources without titles