### PR TITLE
Improve shelfmark indexing

### DIFF
--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -544,7 +544,7 @@ class TestDocumentSearchView:
         doc2 = Document.objects.create()
         TextBlock.objects.create(document=doc2, fragment=folder_fragment)
 
-        # ensure solr index is updated with all three test documents
+        # ensure solr index is updated with the two test documents
         SolrClient().update.index(
             [
                 doc1.index_data(),

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -532,6 +532,38 @@ class TestDocumentSearchView:
         ), "document with shelfmark in description returned second"
         # (document with similar shelfmark is third)
 
+    def test_shelfmark_partialmatch(self, empty_solr, multifragment):
+        # integration test for shelfmark indexing with partial matching
+        # - using empty solr fixture to ensure solr is empty when this test starts
+
+        # multifragment shelfmark can test for this problem: T-S 16.377
+        doc1 = Document.objects.create()
+        TextBlock.objects.create(document=doc1, fragment=multifragment)
+        # create an arbitrary fragment with similar numeric shelfmark
+        folder_fragment = Fragment.objects.create(shelfmark="T-S 16.378")
+        doc2 = Document.objects.create()
+        TextBlock.objects.create(document=doc2, fragment=folder_fragment)
+
+        # ensure solr index is updated with all three test documents
+        SolrClient().update.index(
+            [
+                doc1.index_data(),
+                doc2.index_data(),
+            ],
+            commit=True,
+        )
+
+        docsearch_view = DocumentSearchView()
+        docsearch_view.request = Mock()
+        # sort doesn't matter in this case
+        docsearch_view.request.GET = {"q": "T-S 16"}
+        qs = docsearch_view.get_queryset()
+        # should return both documents
+        assert qs.count() == 2
+        resulting_ids = [result["pgpid"] for result in qs]
+        assert doc1.id in resulting_ids
+        assert doc2.id in resulting_ids
+
 
 class TestDocumentScholarshipView:
     def test_page_title(self, document, client, source):

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -84,6 +84,12 @@
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>
     </analyzer>
   </fieldType>
+  <fieldType name="text_lettersnumbers" class="solr.TextField" positionIncrementGap="100">
+    <analyzer>
+      <!-- only capture letters and numbers -->
+      <tokenizer class="solr.PatternTokenizerFactory" pattern="[A-Za-z0-9]*" group="0"/>
+    </analyzer>
+  </fieldType>
   <fieldType name="tfloat" class="solr.TrieFloatField" positionIncrementGap="0" docValues="true" precisionStep="8"/>
   <fieldType name="tfloats" class="solr.TrieFloatField" positionIncrementGap="0" docValues="true" multiValued="true" precisionStep="8"/>
   <fieldType name="tint" class="solr.TrieIntField" positionIncrementGap="0" docValues="true" precisionStep="8"/>
@@ -98,6 +104,7 @@
   <field name="last_modified" type="pdate" multiValued="false" indexed="true" required="true" stored="true" default="NOW"/>
 
   <copyField source="shelfmark_ss" dest="shelfmark_t" maxChars="30000" />
+  <copyField source="shelfmark_ss" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
   <copyField source="type_s" dest="type_t" maxChars="300" />
 
@@ -140,6 +147,7 @@
   <dynamicField name="*_tf" type="tfloat" indexed="true" stored="true"/>
   <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
   <dynamicField name="*_ws" type="text_ws" indexed="true" stored="true"/>
+  <dynamicField name="*_textnum" type="text_lettersnumbers" indexed="true" stored="true" multiValued="true"/>
   <dynamicField name="*_i" type="int" indexed="true" stored="true"/>
   <dynamicField name="*_s" type="string" indexed="true" stored="true"/>
   <dynamicField name="*_l" type="long" indexed="true" stored="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -740,6 +740,7 @@
         collection_ss
         shelfmark_t^80
         shelfmark_ss^100
+        shelfmark_textnum^140
         tags_t
         tags_ss_lower
         scholarship_t
@@ -749,6 +750,7 @@
       <str name="keyword_pf">
         description_t^50
         shelfmark_t^100
+        shelfmark_textnum^140
         tags_t
         scholarship_t^80
         transcription_t^80
@@ -759,6 +761,7 @@
         type_s
         shelfmark_t
         shelfmark_ss
+        shelfmark_textnum
         tags_t
         tags_ss_lower
         description_t
@@ -771,6 +774,7 @@
       <str name="admin_doc_pf">
         type_s
         shelfmark_t
+        shelfmark_textnum
         tags_t
         description_t
         notes_t


### PR DESCRIPTION
ref #468

add another solr configuration and copy field for shelfmarks to index letters and numbers only, ignoring punctuation and so that portions of shelfmarks like `20.169` will be split apart and made available for partial matching.