### PR TITLE
Add disabled attributes for empty scholarship tab

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_tabs.html
+++ b/geniza/corpus/templates/corpus/snippets/document_tabs.html
@@ -9,7 +9,7 @@
             {# Translators: n_records is number of scholarship records #}
             {% blocktranslate asvar srec_text %}Scholarship Records ({{ n_records }}){% endblocktranslate %}
             {% url 'corpus:document-scholarship' pk=document.pk as scholarship_url %}
-            <li>{% if n_records > 0 %}<a href="{{ scholarship_url }}"{% if request.path == scholarship_url %} aria-current="page"{% endif %}>{{ srec_text }}</a>{% else %}<span>{{ srec_text }}</span>{% endif %}</li>
+            <li>{% if n_records > 0 %}<a href="{{ scholarship_url }}"{% if request.path == scholarship_url %} aria-current="page"{% endif %}>{{ srec_text }}</a>{% else %}<span disabled aria-disabled="true">{{ srec_text }}</span>{% endif %}</li>
         {% endwith %}
 
         {# for MVP: external links is disabled; don't show a count #}

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -335,7 +335,11 @@ class TestDocumentTabsSnippet:
         """document nav should render inert scholarship tab if no footnotes"""
         response = client.get(document.get_absolute_url())
         # uses span, not link
-        assertContains(response, "<span>Scholarship Records (0)</span>", html=True)
+        assertContains(
+            response,
+            "<span disabled aria-disabled='true'>Scholarship Records (0)</span>",
+            html=True,
+        )
 
     def test_with_footnotes(self, client, document, source, twoauthor_source):
         """document nav should render scholarship link with footnote counter"""


### PR DESCRIPTION
@blms I think maybe this got missed when you fixed the lighthouse checks — please confirm