### PR TITLE
Pin Wagtail requirement at <2.16

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -19,7 +19,7 @@ django-csp
 gitpython
 eulxml
 rich
-wagtail
+wagtail>=2.15.3,<2.16
 wagtail-localize
 djiffy>=0.7
 natsort


### PR DESCRIPTION
Looks like this worked for now, maybe the new update to Wagtail (3 hours ago!) broke something with wagtail-localize—I'll keep an eye on it.