### PR TITLE
#225 - Admin document merge tweaks

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -1,5 +1,7 @@
 from django import forms
+from django.forms import renderers
 from django.template.loader import get_template
+from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
@@ -183,6 +185,11 @@ class DocumentChoiceField(forms.ModelChoiceField):
 
 
 class DocumentMergeForm(forms.Form):
+    RATIONALE_CHOICES = [
+        ("duplicate", "Duplicate"),
+        ("join", "Join"),
+        ("other", "Other (please specify)"),
+    ]
     primary_document = DocumentChoiceField(
         label="Select primary document",
         queryset=None,
@@ -194,9 +201,16 @@ class DocumentMergeForm(forms.Form):
         empty_label=None,
         widget=forms.RadioSelect,
     )
-    rationale = forms.CharField(
+    rationale = forms.ChoiceField(
+        widget=forms.RadioSelect,
+        required=True,
         label="Rationale",
-        help_text="Briefly note why these documents are being merged; will be included in the document history.",
+        help_text="Choose the option that best explains why these documents are being merged; will be included in the document history.",
+        choices=RATIONALE_CHOICES,
+    )
+    rationale_notes = forms.CharField(
+        required=False,
+        label="Rationale notes",
         widget=forms.Textarea(),
     )
 
@@ -213,3 +227,13 @@ class DocumentMergeForm(forms.Form):
         self.fields["primary_document"].queryset = Document.objects.filter(
             id__in=document_ids
         )
+        self.initial["rationale"] = "duplicate"
+
+    def clean(self):
+        cleaned_data = super().clean()
+        rationale = cleaned_data.get("rationale")
+        rationale_notes = cleaned_data.get("rationale_notes")
+
+        if rationale == "other" and not rationale_notes:
+            msg = 'Additional information is required when selecting "Other".'
+            self.add_error("rationale", msg)

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -184,7 +184,7 @@ class DocumentChoiceField(forms.ModelChoiceField):
 
 class DocumentMergeForm(forms.Form):
     primary_document = DocumentChoiceField(
-        label="Primary document",
+        label="Select primary document",
         queryset=None,
         help_text=(
             "Select the primary document, which will be used as the merged document PGPID. "

--- a/geniza/corpus/templates/admin/corpus/document/merge.html
+++ b/geniza/corpus/templates/admin/corpus/document/merge.html
@@ -32,6 +32,11 @@
 {% block content %}
     <form method="post" class="merge-document">
         {% csrf_token %}
+        {% if form.errors|length > 0 %}
+            <p class="errornote">
+                Please correct the error below.
+            </p>
+        {% endif %}
         <fieldset class="module aligned">
             <div class="form-row">
                 {{ form.primary_document.label_tag }}
@@ -42,6 +47,8 @@
             <div class="form-row">
                 {{ form.rationale.label_tag }}
                 {{ form.rationale }}
+                {{ form.rationale.errors }}
+                {{ form.rationale_notes }}
                 <p class="help">{{ form.rationale.help_text|safe }}</p>
             </div>
             <div class="submit-row">

--- a/geniza/corpus/templates/corpus/snippets/document_option_label.html
+++ b/geniza/corpus/templates/corpus/snippets/document_option_label.html
@@ -33,8 +33,8 @@
         </div>
     {% endif %}
     {% if document.footnotes.count %}
-        <details class="form-row">
-            <summary>Scholarship Records</summary>
+        <div class="form-row">
+            <label>Scholarship Records</label>
             <ol>
                 {% regroup document.footnotes.all by source as source_list %}
                 {% for source in source_list %}
@@ -73,6 +73,6 @@
                     </li>
                 {% endfor %}
             </ol>
-        </details>
+        </div>
     {% endif %}
 </div>

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -141,3 +141,37 @@ class TestDocumentMergeForm:
         assert mergeform.fields["primary_document"].queryset.count() == docs.count() - 1
         # last document should not be an available choice
         assert docs.last() not in mergeform.fields["primary_document"].queryset
+
+    @pytest.mark.django_db
+    def test_clean(self):
+        """Should add an error if rationale is 'other' and rationale notes are empty"""
+        doc = Document.objects.create()
+
+        form = DocumentMergeForm()
+        form.cleaned_data = {
+            "primary_document": doc.id,
+            "rationale": "other",
+            "rationale_notes": "",
+        }
+        form.clean()
+        assert len(form.errors) == 1
+
+        # should not produce an error if rationale notes provided
+        form = DocumentSearchForm()
+        form.cleaned_data = {
+            "primary_document": doc.id,
+            "rationale": "other",
+            "rationale_notes": "test",
+        }
+        form.clean()
+        assert len(form.errors) == 0
+
+        # should not produce an error if rational is "duplicate" or "join"
+        form = DocumentSearchForm()
+        form.cleaned_data = {
+            "primary_document": doc.id,
+            "rationale": "duplicate",
+            "rationale_notes": "",
+        }
+        form.clean()
+        assert len(form.errors) == 0

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -477,7 +477,18 @@ class DocumentMerge(PermissionRequiredMixin, FormView):
         """Merge the selected documents into the primary document."""
         primary_doc = form.cleaned_data["primary_document"]
         self.primary_document = primary_doc
-        rationale = form.cleaned_data["rationale"]
+
+        # Include additional notes in rationale string if present
+        if form.cleaned_data["rationale"] == "other":
+            # Only use the additional notes if "other" is chosen
+            rationale = form.cleaned_data["rationale_notes"]
+        elif form.cleaned_data["rationale_notes"]:
+            rationale = "%s (%s)" % (
+                form.cleaned_data["rationale"],
+                form.cleaned_data["rationale_notes"],
+            )
+        else:
+            rationale = form.cleaned_data["rationale"]
 
         secondary_ids = [
             doc_id for doc_id in self.document_ids if doc_id != primary_doc.id

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -146,10 +146,6 @@ a#needsreview:target {
     justify-content: flex-start;
 }
 
-.merge-document h2 {
-    margin: 0 0 0 0.5rem;
-}
-
 .merge-document .submit-row {
     clear: left;
     padding: 12px 14px;
@@ -180,4 +176,11 @@ a#needsreview:target {
 
 .aligned .merge-document-label ol li {
     list-style: auto;
+}
+
+.merge-document input[type="radio"] {
+    margin-right: 0.5rem;
+}
+.merge-document textarea {
+    margin: 0 0 20px 180px;
 }

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -174,6 +174,10 @@ a#needsreview:target {
     word-wrap: break-word;
 }
 
+.merge-document-label label + ol {
+    clear: both;
+}
+
 .aligned .merge-document-label ol li {
     list-style: auto;
 }


### PR DESCRIPTION
## What this PR does

- Per #225:
  - Changes scholarship records from `details` back to `div` so that all are visible in document merge
  - Changes verbiage "primary document" to "select primary document"
  - For rationale: uses radio buttons with "other" and an optional notes field, which becomes required if "other" is selected
    - Sets "duplicate" as default choice
  
## review notes

- I didn't include labeling transcriptions in the admin, or expanding all trancsriptions on the front end, in this PR. I was thinking it's best to get this stuff reviewed first and do that separately, since it's a different concern.