### PR TITLE
#596 - Show transcription source labels in admin

### DIFF
--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -17,20 +17,13 @@
             </div>
         </fieldset>
     {% endif %}
-    {% if original.has_transcription %}
+    {% if original.digital_editions %}
         <fieldset class="module aligned transcriptions-field">
             <div class="form-row">
-                <label>Transcription(s)</label>
-                {% regroup original.footnotes.all by source as source_list %}
-                {% for source in source_list %}
-                    {% if source_list|length > 1 %}<h3 class="source">{{ source.grouper|safe }}</h3>{% endif %}
-                    {% for footnote in source.list %}
-                        {% if footnote.content %}
-                            {% include "footnotes/transcription.html" with transcription=footnote.content %}
-                        {% else %}
-                            <div class="transcription">No transcription</div>
-                        {% endif %}
-                    {% endfor %}
+                <label>Transcription{{ original.digital_editions.count|pluralize }}</label>
+                {% for footnote in original.digital_editions %}
+                    {% if original.digital_editions|length > 1 %}<h3 class="source">{{ footnote.source|safe }}</h3>{% endif %}
+                    {% include "footnotes/transcription.html" with transcription=footnote.content %}
                 {% endfor %}
             </div>
         </fieldset>

--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -18,11 +18,21 @@
         </fieldset>
     {% endif %}
     {% if original.has_transcription %}
-        <h2>Transcription</h2>
-        {% for footnote in original.footnotes.all %}
-            {% if footnote.content %}
-                {% include "footnotes/transcription.html" with transcription=footnote.content %}
-            {% endif %}
-        {% endfor %}
+        <fieldset class="module aligned transcriptions-field">
+            <div class="form-row">
+                <label>Transcription(s)</label>
+                {% regroup original.footnotes.all by source as source_list %}
+                {% for source in source_list %}
+                    {% if source_list|length > 1 %}<h3 class="source">{{ source.grouper|safe }}</h3>{% endif %}
+                    {% for footnote in source.list %}
+                        {% if footnote.content %}
+                            {% include "footnotes/transcription.html" with transcription=footnote.content %}
+                        {% else %}
+                            <div class="transcription">No transcription</div>
+                        {% endif %}
+                    {% endfor %}
+                {% endfor %}
+            </div>
+        </fieldset>
     {% endif %}
 {% endblock %}

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -131,6 +131,18 @@ a#needsreview:target {
     direction: rtl;
 }
 
+/* styling transcriptions with labels in document admin change form */
+.transcriptions-field .transcription:first-of-type {
+    margin-left: 30px;
+}
+.transcriptions-field h3.source:not(:first-of-type) {
+    margin-left: 160px;
+    margin-top: 20px;
+}
+.transcriptions-field .transcription:not(:first-of-type) {
+    margin-left: 200px;
+}
+
 /* keep document relationship choices labels in line with checkboxes */
 .field-doc_relation {
     white-space: nowrap;


### PR DESCRIPTION
## What this PR does

- Per #596:
  - When displaying multiple transcriptions in the document admin: groups transcriptions by source, labels them each with source citation