### PR TITLE
#589 - Use appropriate modeltranslation fields for "typed texts" source migration

### DIFF
--- a/geniza/footnotes/migrations/0016_rename_typed_texts.py
+++ b/geniza/footnotes/migrations/0016_rename_typed_texts.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.contrib.admin.models import CHANGE
 from django.db import migrations
+from django.db.models import Q
 
 
 def rename_typed_texts(apps, schema_editor):
@@ -18,7 +19,9 @@ def rename_typed_texts(apps, schema_editor):
     )  # generic user for script execution (should already be created)
 
     # get all sources called "typed texts"
-    typed_texts = Source.objects.filter(title="typed texts")
+    typed_texts = Source.objects.filter(
+        Q(title_en="typed texts") | Q(title="typed texts")
+    )
     # preserve as a list so queryset doesn't erase our set of records
     update_pks = list(typed_texts.values_list("pk", flat=True))
     # do a bulk update to replace the titles


### PR DESCRIPTION
## review notes

- Should the migration query on and update just `title_en`, or `title` as well (as I currently have it)?
- I guess it wasn't caught by tests because I do set the `title` field directly when instantiating the Source records. I guess that doesn't automatically populate the `title_en` field as well. Should I be setting `title_en` there instead as well?
