### PR TITLE
#605 - Catch IIIFException during indexing

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -24,7 +24,7 @@ from djiffy.importer import ManifestImporter
 from djiffy.models import Manifest
 from parasolr.django.indexing import ModelIndexable
 from piffle.image import IIIFImageClient
-from piffle.presentation import IIIFPresentation
+from piffle.presentation import IIIFException, IIIFPresentation
 from taggit.models import Tag
 from taggit_selectize.managers import TaggableManager
 
@@ -212,12 +212,15 @@ class Fragment(TrackChangesModel):
 
         # if not cached, load from remote url
         else:
-            manifest = IIIFPresentation.from_url(self.iiif_url)
-            for canvas in manifest.sequences[0].canvases:
-                image_id = canvas.images[0].resource.id
-                images.append(IIIFImageClient(*image_id.rsplit("/", 1)))
-                # label provides library's recto/verso designation
-                labels.append(canvas.label)
+            try:
+                manifest = IIIFPresentation.from_url(self.iiif_url)
+                for canvas in manifest.sequences[0].canvases:
+                    image_id = canvas.images[0].resource.id
+                    images.append(IIIFImageClient(*image_id.rsplit("/", 1)))
+                    # label provides library's recto/verso designation
+                    labels.append(canvas.label)
+            except IIIFException:
+                pass
 
         return images, labels
 


### PR DESCRIPTION
## What this PR does
- Per #605:
  - Uses a try/except block to catch and ignore `IIIFExceptions` raised when calling `from_url` on IIIF manuscripts

## Questions
- This will fix the problem during indexing, but there are a couple of views where `from_url` is also called. Should those get try/except blocks as well?
- Should there be some kind of error logging when this occurs? I don't have a good idea for how to hook into stdout during indexing in a way that would make sense here.