### PR TITLE
Feature/591 translation issues

### DIFF
--- a/geniza/context_processors.py
+++ b/geniza/context_processors.py
@@ -7,11 +7,12 @@ def template_globals(request):
     from django settings or site search form) for use on any page."""
 
     site = Site.find_for_request(request)
+    admin_language_codes = [lang[0] for lang in settings.LANGUAGES]
     context_extras = {
         "SHOW_TEST_WARNING": getattr(settings, "SHOW_TEST_WARNING", False),
         "FONT_URL_PREFIX": getattr(settings, "FONT_URL_PREFIX", ""),
         "PUBLIC_SITE_LANGUAGES": getattr(
-            settings, "PUBLIC_SITE_LANGUAGES", settings.LANGUAGES
+            settings, "PUBLIC_SITE_LANGUAGES", admin_language_codes
         ),
         "site": site,
         "GTAGS_ANALYTICS_ID": getattr(settings, "GTAGS_ANALYTICS_ID", None),

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -704,7 +704,8 @@ class Document(ModelIndexable):
             {
                 "pgpid_i": self.id,
                 "type_s": str(self.doctype) if self.doctype else _("Unknown type"),
-                "description_t": self.description,
+                # use english description for now
+                "description_t": self.description_en,
                 "notes_t": self.notes or None,
                 "needs_review_t": self.needs_review or None,
                 "shelfmark_ss": self.certain_join_shelfmarks,

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -19,7 +19,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "shelfmark": "shelfmark_t",
         "collection": "collection_ss",
         "tags": "tags_ss_lower",
-        "description": "description_txt_en",  # use stemmed version for field search & highlight
+        "description": "description_txt_ens",  # use stemmed version for field search & highlight
         "notes": "notes_t",
         "needs_review": "needs_review_t",
         "pgpid": "pgpid_i",

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -110,3 +110,10 @@ def format_attribution(attribution):
         additional_restrictions,
         extra_attrs,
     )
+
+
+@register.filter
+def h1_to_h3(html):
+    """Convert h1 headers to h3 to match other transcription formats,
+    used to avoid modeltranslation inserting elements into h1 headers"""
+    return html.replace("h1", "h3")

--- a/geniza/corpus/tests/conftest.py
+++ b/geniza/corpus/tests/conftest.py
@@ -47,7 +47,7 @@ def make_document(fragment):
     """A real legal document from the PGP."""
     doc = Document.objects.create(
         id=3951,
-        description="""Deed of sale in which a father sells to his son a quarter
+        description_en="""Deed of sale in which a father sells to his son a quarter
          of the apartment belonging to him in a house in the al- Mu'tamid
          passage of the Tujib quarter for seventeen dinars. Dated 1233.
          (Information from Mediterranean Society, IV, p. 281)""",
@@ -86,7 +86,7 @@ def make_document(fragment):
 def make_join(fragment, multifragment):
     """A fake letter document that occurs on two different fragments."""
     doc = Document.objects.create(
-        description="testing description",
+        description_en="testing description",
         doctype=DocumentType.objects.get_or_create(name="Letter")[0],
     )
     TextBlock.objects.create(document=doc, fragment=fragment, order=1)

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -230,7 +230,7 @@ class TestDocumentAdmin:
         doc.languages.add(arabic)
         doc.secondary_languages.add(french)
 
-        marina = Creator.objects.create(last_name="Rustow", first_name="Marina")
+        marina = Creator.objects.create(last_name_en="Rustow", first_name_en="Marina")
         book = SourceType.objects.create(type="Book")
         source = Source.objects.create(source_type=book)
         source.authors.add(marina)
@@ -385,7 +385,7 @@ class TestFragmentTextBlockInline:
     def test_document_description(self):
         fragment = Fragment.objects.create(shelfmark="CUL 123")
         test_description = "A medieval poem"
-        doc = Document.objects.create(description=test_description)
+        doc = Document.objects.create(description_en=test_description)
         textblock = TextBlock.objects.create(fragment=fragment, document=doc)
         inline = FragmentTextBlockInline(Fragment, admin_site=admin.site)
 

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -220,7 +220,7 @@ class TestDocumentScholarshipTemplate:
             reverse("corpus:document-scholarship", args=[document.pk])
         )
         assertContains(response, "<em>The C Programming Language</em>")
-        twoauthor_source.title = ""
+        twoauthor_source.title_en = ""
         twoauthor_source.save()
         response = client.get(
             reverse("corpus:document-scholarship", args=[document.pk])

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -135,3 +135,8 @@ def test_iiif_info_json():
     # should contain the same ids but with /info.json appended
     assert "http://image.server/path/myimgid/info.json" in json_ids
     assert "http://image.server/path/myimgid2/info.json" in json_ids
+
+
+def test_h1_to_h3():
+    html = "<div><h1>hi</h1><h3>hello</h3></div>"
+    assert corpus_extras.h1_to_h3(html) == "<div><h3>hi</h3><h3>hello</h3></div>"

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -134,7 +134,7 @@ def test_old_pgp_edition():
     doc = Document.objects.create()
     assert old_pgp_edition(doc.editions()) == ""
 
-    marina = Creator.objects.create(last_name="Rustow", first_name="Marina")
+    marina = Creator.objects.create(last_name_en="Rustow", first_name_en="Marina")
     book = SourceType.objects.create(type="Book")
     source = Source.objects.create(source_type=book)
     source.authors.add(marina)
@@ -148,7 +148,7 @@ def test_old_pgp_edition():
     edition_str = old_pgp_edition(doc.editions())
     assert edition_str == f"Ed. {fn.display()}"
 
-    source2 = Source.objects.create(title="Arabic dictionary", source_type=book)
+    source2 = Source.objects.create(title_en="Arabic dictionary", source_type=book)
     fn2 = Footnote.objects.create(
         doc_relation=[Footnote.EDITION],
         source=source2,
@@ -158,7 +158,7 @@ def test_old_pgp_edition():
     edition_str = old_pgp_edition(doc.editions())
     assert edition_str == f"Ed. Arabic dictionary; also ed. Marina Rustow."
 
-    source3 = Source.objects.create(title="Geniza Encyclopedia", source_type=book)
+    source3 = Source.objects.create(title_en="Geniza Encyclopedia", source_type=book)
     fn_trans = Footnote.objects.create(
         doc_relation=[Footnote.EDITION, Footnote.TRANSLATION],
         source=source3,

--- a/geniza/corpus/tests/test_merge_documents.py
+++ b/geniza/corpus/tests/test_merge_documents.py
@@ -126,14 +126,14 @@ def test_get_merge_candidates(fragment, multifragment, join):
     # join is a document associated with fragment & multifragment
     # create two other documents to be merged
     doc2 = Document.objects.create(
-        description="see other fragment", doctype=join.doctype
+        description_en="see other fragment", doctype=join.doctype
     )
     # associate in same order as join
     TextBlock.objects.create(document=doc2, fragment=fragment, order=1)
     TextBlock.objects.create(document=doc2, fragment=multifragment, order=2)
 
     doc3 = Document.objects.create(
-        description="see other fragment", doctype=join.doctype
+        description_en="see other fragment", doctype=join.doctype
     )
     # associate in different order as join doc
     TextBlock.objects.create(document=doc3, fragment=fragment, order=2)
@@ -141,7 +141,7 @@ def test_get_merge_candidates(fragment, multifragment, join):
 
     # doc on the same fragments with different type (unknown)
     unknown_doc = Document.objects.create(
-        description="something else",
+        description_en="something else",
     )
     # associate in same order as join doc
     TextBlock.objects.create(document=unknown_doc, fragment=fragment, order=1)
@@ -165,8 +165,8 @@ def test_get_merge_candidates(fragment, multifragment, join):
 def test_group_merge_candidates_same_desc():
     # merge based on same description
     command = merge_documents.Command()
-    doc1 = Document.objects.create(description="a marriage contract")
-    doc2 = Document.objects.create(description=doc1.description)
+    doc1 = Document.objects.create(description_en="a marriage contract")
+    doc2 = Document.objects.create(description_en=doc1.description_en)
     shelfmark_id = "shelfmark / letter"
     report_rows = command.group_merge_candidates(
         {
@@ -180,7 +180,7 @@ def test_group_merge_candidates_same_desc():
         "all descriptions match",
         "primary",
         doc1.pk,
-        doc1.description,
+        doc1.description_en,
     ]
     assert report_rows[1] == [
         shelfmark_id,
@@ -189,7 +189,7 @@ def test_group_merge_candidates_same_desc():
         "all descriptions match",
         "merge",
         doc2.pk,
-        doc2.description,
+        doc2.description_en,
     ]
 
 
@@ -197,7 +197,7 @@ def test_group_merge_candidates_same_desc():
 def test_group_merge_candidates_empty_description():
     # merge based on empty description text in secondary documents
     command = merge_documents.Command()
-    doc1 = Document.objects.create(description="a marriage contract")
+    doc1 = Document.objects.create(description_en="a marriage contract")
     doc2 = Document.objects.create()
     shelfmark_id = "shelfmark / letter"
     report_rows = command.group_merge_candidates(
@@ -208,14 +208,15 @@ def test_group_merge_candidates_empty_description():
     # status should be merge; rationale from empty description
     assert report_rows[0][2] == "MERGE"
     assert report_rows[0][3] == "one description, others empty"
+    assert report_rows[0][6] == "a marriage contract"
 
 
 @pytest.mark.django_db
 def test_group_merge_candidates_see_join():
     # merge based on "see join" text in secondary documents
     command = merge_documents.Command()
-    doc1 = Document.objects.create(description="a marriage contract")
-    doc2 = Document.objects.create(description="See join.")
+    doc1 = Document.objects.create(description_en="a marriage contract")
+    doc2 = Document.objects.create(description_en="See join.")
     shelfmark_id = "shelfmark / letter"
     report_rows = command.group_merge_candidates(
         {
@@ -233,8 +234,8 @@ def test_group_merge_candidates_see_join():
 def test_group_merge_candidates_see_pgpid():
     # merge based on "see pgpid" text in secondary documents
     command = merge_documents.Command()
-    doc1 = Document.objects.create(description="a marriage contract", pk=134552)
-    doc2 = Document.objects.create(description="See PGPID %d" % doc1.pk)
+    doc1 = Document.objects.create(description_en="a marriage contract", pk=134552)
+    doc2 = Document.objects.create(description_en="See PGPID %d" % doc1.pk)
     shelfmark_id = "shelfmark / unknown"
     report_rows = command.group_merge_candidates(
         {

--- a/geniza/footnotes/conftest.py
+++ b/geniza/footnotes/conftest.py
@@ -13,10 +13,10 @@ from geniza.footnotes.models import (
 @pytest.fixture
 def source(db):
     # fixture to create and return a source with one authors
-    orwell = Creator.objects.create(last_name="Orwell", first_name="George")
+    orwell = Creator.objects.create(last_name_en="Orwell", first_name_en="George")
     essay = SourceType.objects.create(type="Essay")
     english = SourceLanguage.objects.get(name="English")
-    cup_of_tea = Source.objects.create(title="A Nice Cup of Tea", source_type=essay)
+    cup_of_tea = Source.objects.create(title_en="A Nice Cup of Tea", source_type=essay)
     cup_of_tea.languages.add(english)
     cup_of_tea.authors.add(orwell)
     return cup_of_tea
@@ -25,10 +25,12 @@ def source(db):
 @pytest.fixture
 def twoauthor_source(db):
     # fixture to create and return a source with two authors
-    kernighan = Creator.objects.create(last_name="Kernighan", first_name="Brian")
-    ritchie = Creator.objects.create(last_name="Ritchie", first_name="Dennis")
+    kernighan = Creator.objects.create(last_name_en="Kernighan", first_name_en="Brian")
+    ritchie = Creator.objects.create(last_name_en="Ritchie", first_name_en="Dennis")
     book = SourceType.objects.get(type="Book")
-    cprog = Source.objects.create(title="The C Programming Language", source_type=book)
+    cprog = Source.objects.create(
+        title_en="The C Programming Language", source_type=book
+    )
     Authorship.objects.create(creator=kernighan, source=cprog)
     Authorship.objects.create(creator=ritchie, source=cprog, sort_order=2)
     return cprog
@@ -40,7 +42,7 @@ def multiauthor_untitledsource(db):
     unpub = SourceType.objects.get(type="Unpublished")
     source = Source.objects.create(source_type=unpub)
     for i, name in enumerate(["Khan", "el-Leithy", "Rustow", "Vanthieghem"]):
-        author = Creator.objects.create(last_name=name)
+        author = Creator.objects.create(last_name_en=name)
         Authorship.objects.create(creator=author, source=source, sort_order=i)
     return source
 
@@ -48,10 +50,10 @@ def multiauthor_untitledsource(db):
 @pytest.fixture
 def article(db):
     # fixture to create and return an article source
-    goitein = Creator.objects.create(last_name="Goitein", first_name="S. D.")
+    goitein = Creator.objects.create(last_name_en="Goitein", first_name_en="S. D.")
     article = SourceType.objects.get(type="Article")
     tarbiz = Source.objects.create(
-        title="Shemarya",
+        title_en="Shemarya",
         journal="Tarbiz",
         source_type=article,
         volume="32",
@@ -67,9 +69,9 @@ def unpublished_editions(db):
     # fixture for unpublished source
     unpub = SourceType.objects.get(type="Unpublished")
     source = Source.objects.create(
-        source_type=unpub, title="unpublished editions", volume="CUL"
+        source_type=unpub, title_en="unpublished editions", volume="CUL"
     )
-    author = Creator.objects.create(last_name="Goitein", first_name="S. D.")
+    author = Creator.objects.create(last_name_en="Goitein", first_name_en="S. D.")
     Authorship.objects.create(creator=author, source=source)
     return source
 
@@ -78,10 +80,12 @@ def unpublished_editions(db):
 def book_section(db):
     # fixture to create and return a book section source
     section_type = SourceType.objects.get(type="Book Section")
-    author = Creator.objects.create(last_name="Melammed", first_name="Renée Levine")
+    author = Creator.objects.create(
+        last_name_en="Melammed", first_name_en="Renée Levine"
+    )
     book_sect = Source.objects.create(
         source_type=section_type,
-        title="A Look at Women's Lives in Cairo Geniza Society",
+        title_en="A Look at Women's Lives in Cairo Geniza Society",
         journal="Festschrift Darkhei Noam: The Jews of Arab Lands",
         year=2015,
         publisher="Brill",
@@ -98,10 +102,10 @@ def book_section(db):
 def phd_dissertation(db):
     # fixture to create and return a PhD dissertation source
     diss_type = SourceType.objects.get(type="Dissertation")
-    author = Creator.objects.create(last_name="Zinger", first_name="Oded")
+    author = Creator.objects.create(last_name_en="Zinger", first_name_en="Oded")
     dissertation = Source.objects.create(
         source_type=diss_type,
-        title="Women, Gender and Law: Marital Disputes According to Documents of the Cairo Geniza",
+        title_en="Women, Gender and Law: Marital Disputes According to Documents of the Cairo Geniza",
         year=2014,
         place_published="Princeton, NJ",
         publisher="Princeton University",

--- a/geniza/footnotes/templates/footnotes/transcription.html
+++ b/geniza/footnotes/templates/footnotes/transcription.html
@@ -1,6 +1,8 @@
+{% load corpus_extras %}
+
 <div class="transcription" dir="rtl">
     {# provisional html format #}
-    {{ transcription.html|safe }}
+    {{ transcription.html|headers_to_h3|safe }}
     {# old format #}
     {% for block in transcription.blocks %}
         {% if block.label %}<h3>{{ block.label }}</h3>{% endif %}

--- a/geniza/footnotes/tests/test_footnote_admin.py
+++ b/geniza/footnotes/tests/test_footnote_admin.py
@@ -93,7 +93,7 @@ class TestSourceAdmin:
     def test_get_queryset(self, twoauthor_source):
         # source with no author
         book = SourceType.objects.get(type="Book")
-        source = Source.objects.create(title="Unknown", source_type=book)
+        source = Source.objects.create(title_en="Unknown", source_type=book)
 
         # confirm that first author is set correctly on annotated queryset
         qs = SourceAdmin(Source, admin.site).get_queryset("rqst")
@@ -124,7 +124,7 @@ class TestSourceAdmin:
     @pytest.mark.django_db
     def test_footnotes(self):
         book = SourceType.objects.get(type="Book")
-        source = Source.objects.create(title="Unknown", source_type=book)
+        source = Source.objects.create(title_en="Unknown", source_type=book)
 
         source_admin = SourceAdmin(Source, admin.site)
         # manually set footnote__count since it would usually be set in
@@ -195,7 +195,7 @@ class TestFootnoteAdmin:
     def test_doc_relation_list(self):
         fnoteadmin = FootnoteAdmin(Footnote, admin.site)
         book = SourceType.objects.get(type="Book")
-        source = Source.objects.create(title="Reader", source_type=book)
+        source = Source.objects.create(title_en="Reader", source_type=book)
 
         footnote = Footnote(source=source, doc_relation=["E", "D"])
         assert fnoteadmin.doc_relation_list(footnote) == str(footnote.doc_relation)
@@ -273,7 +273,7 @@ class TestSourceFootnoteInline:
     @pytest.mark.django_db
     def test_object_link(self):
         book = SourceType.objects.get(type="Book")
-        source = Source.objects.create(title="Unknown", source_type=book)
+        source = Source.objects.create(title_en="Unknown", source_type=book)
         footnote = Footnote.objects.create(
             doc_relation=["E"],
             source=source,

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -76,7 +76,7 @@ class TestSource:
             article.year,
         )
         # article with no title
-        article.title = ""
+        article.title_en = ""
         assert str(article) == "%s, %s %s, no. %d (%s)." % (
             article.authors.first().firstname_lastname(),
             article.journal,
@@ -352,27 +352,27 @@ class TestFootnoteQuerySet:
 
 class TestCreator:
     def test_str(self):
-        creator = Creator(last_name="Angelou", first_name="Maya")
+        creator = Creator(last_name_en="Angelou", first_name_en="Maya")
         str(creator) == "Angelou, Maya"
 
         # no firstname
-        assert str(Creator(last_name="Goitein")) == "Goitein"
+        assert str(Creator(last_name_en="Goitein")) == "Goitein"
 
     def test_natural_key(self):
-        creator = Creator(last_name="Angelou", first_name="Maya")
+        creator = Creator(last_name_en="Angelou", first_name_en="Maya")
         assert creator.natural_key() == ("Angelou", "Maya")
 
     @pytest.mark.django_db
     def test_get_by_natural_key(self):
-        creator = Creator.objects.create(last_name="Angelou", first_name="Maya")
+        creator = Creator.objects.create(last_name_en="Angelou", first_name_en="Maya")
         assert Creator.objects.get_by_natural_key("Angelou", "Maya") == creator
 
     def test_firstname_lastname(self):
-        creator = Creator(last_name="Angelou", first_name="Maya")
+        creator = Creator(last_name_en="Angelou", first_name_en="Maya")
         assert creator.firstname_lastname() == "Maya Angelou"
 
         # no firstname
-        assert Creator(last_name="Goitein").firstname_lastname() == "Goitein"
+        assert Creator(last_name_en="Goitein").firstname_lastname() == "Goitein"
 
 
 class TestAuthorship:

--- a/geniza/footnotes/tests/test_footnotes_migrations.py
+++ b/geniza/footnotes/tests/test_footnotes_migrations.py
@@ -44,21 +44,31 @@ class AlterSourceEdition(TestMigrations):
     migrate_from = "0013_add_fields_to_source"
     migrate_to = "0014_alter_source_edition"
 
+    src1 = None
+    src2 = None
+    src3 = None
+
     def setUpBeforeMigration(self, apps):
         Source = apps.get_model("footnotes", "Source")
         SourceType = apps.get_model("footnotes", "SourceType")
         source_type = SourceType.objects.create(type="Unknown")
-        Source.objects.create(
-            title="Book 1", edition="bad data", source_type=source_type
+        self.src1 = Source.objects.create(
+            title_en="Book 1", edition="bad data", source_type=source_type
         )
-        Source.objects.create(title="Book 2", edition="2", source_type=source_type)
-        Source.objects.create(title="Book 3", edition="", source_type=source_type)
+        self.src2 = Source.objects.create(
+            title_en="Book 2", edition="2", source_type=source_type
+        )
+        self.src3 = Source.objects.create(
+            title_en="Book 3", edition="", source_type=source_type
+        )
 
     def test_editions_converted_to_int(self):
-        Source = self.apps.get_model("footnotes", "Source")
-        assert not Source.objects.filter(title="Book 1").first().edition
-        assert Source.objects.filter(title="Book 2").first().edition == 2
-        assert not Source.objects.filter(title="Book 3").first().edition
+        self.src1.refresh_from_db()
+        assert not self.src1.edition
+        self.src2.refresh_from_db()
+        assert self.src2.edition == 2
+        self.src3.refresh_from_db()
+        assert not self.src3.edition
 
 
 @pytest.mark.last
@@ -68,17 +78,25 @@ class AlterSourceEditionReverse(TestMigrations):
     migrate_from = "0014_alter_source_edition"
     migrate_to = "0013_add_fields_to_source"
 
+    src1 = None
+    src2 = None
+
     def setUpBeforeMigration(self, apps):
         Source = apps.get_model("footnotes", "Source")
         SourceType = apps.get_model("footnotes", "SourceType")
         source_type = SourceType.objects.create(type="Unknown")
-        Source.objects.create(title="Book 1", edition=None, source_type=source_type)
-        Source.objects.create(title="Book 2", edition=2, source_type=source_type)
+        self.src1 = Source.objects.create(
+            title_en="Book 1", edition=None, source_type=source_type
+        )
+        self.src2 = Source.objects.create(
+            title_en="Book 2", edition=2, source_type=source_type
+        )
 
     def test_editions_converted_to_string(self):
-        Source = self.apps.get_model("footnotes", "Source")
-        assert Source.objects.filter(title="Book 1").first().edition == ""
-        assert Source.objects.filter(title="Book 2").first().edition == "2"
+        self.src1.refresh_from_db()
+        assert self.src1.edition == ""
+        self.src2.refresh_from_db()
+        assert self.src2.edition == "2"
 
 
 @pytest.mark.last
@@ -95,7 +113,7 @@ class TestFootnoteLocationPpMigration(TestMigrations):
         ContentType = apps.get_model("contenttypes", "ContentType")
 
         source_type = SourceType.objects.create(type="Unknown")
-        source = Source.objects.create(title="Book", source_type=source_type)
+        source = Source.objects.create(title_en="Book", source_type=source_type)
         source_ctype = ContentType.objects.get(
             app_label="footnotes", model="sourcetype"
         )
@@ -151,20 +169,20 @@ class TestRenameTypedTextsMigration(TestMigrations):
         SourceType = apps.get_model("footnotes", "SourceType")
         source_type = SourceType.objects.create(type="Unknown")
         typed_texts_source = Source.objects.create(
-            title="typed texts", source_type=source_type
+            title_en="typed texts", source_type=source_type
         )
         self.typed_texts_source = typed_texts_source
         other_source = Source.objects.create(
-            title="other title", source_type=source_type
+            title_en="other title", source_type=source_type
         )
         self.other_source = other_source
 
     def test_rename_typed_texts(self):
         # should rename "typed texts" (only) to "unpublished editions"
         self.typed_texts_source.refresh_from_db()
-        assert self.typed_texts_source.title == "unpublished editions"
+        assert self.typed_texts_source.title_en == "unpublished editions"
         self.other_source.refresh_from_db()
-        assert self.other_source.title == "other title"
+        assert self.other_source.title_en == "other title"
 
         LogEntry = self.apps.get_model("admin", "LogEntry")
         msg = 'changed title "typed texts" to "unpublished editions"'

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -86,7 +86,7 @@
          finally applies Porter's stemming.  The query time analyzer
          also applies synonyms from synonyms.txt. -->
     <dynamicField name="*_txt_en" type="text_en"  indexed="true"  stored="true"/>
-    <dynamicField name="*_txt_ens" type="text_en"  indexed="true"  stored="false" multiValued="true"/>
+    <dynamicField name="*_txt_ens" type="text_en"  indexed="true"  stored="true" multiValued="true"/>
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -154,7 +154,7 @@
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
   <copyField source="type_s" dest="type_t" maxChars="300" />
   <!-- copy description from general text to english text with stemming -->
-  <copyField source="description_t" dest="description_txt_en" />
+  <copyField source="description_t" dest="description_txt_ens" />
 
   <dynamicField name="*_descendent_path" type="descendent_path" indexed="true" stored="true"/>
   <dynamicField name="*_ancestor_path" type="ancestor_path" indexed="true" stored="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -734,7 +734,7 @@
       <!-- keyword search field for geniza prototype -->
       <str name="keyword_qf">
         description_t^50
-        description_txt_en
+        description_txt_ens
         pgpid_i
         type_s
         type_t
@@ -750,7 +750,7 @@
       </str>
       <str name="keyword_pf">
         description_t^50
-        description_txt_en^20
+        description_txt_ens^20
         shelfmark_t^100
         shelfmark_textnum^140
         tags_t
@@ -767,7 +767,7 @@
         tags_t
         tags_ss_lower
         description_t
-        description_txt_en
+        description_txt_ens
         notes_t
         needs_review_t
         pgpid_i
@@ -781,7 +781,7 @@
         shelfmark_textnum
         tags_t
         description_t
-        description_txt_en
+        description_txt_ens
         notes_t
         needs_review_t
         scholarship_t


### PR DESCRIPTION
## What this PR does

- Per #591:
  - Fixes issue with solr indexing of descriptions
  - Fixes issue with admin document change form by replacing all instances of h1 with h3 in transcriptions. This is more consistent with our other transcription formatting, and it prevents modeltranslation from automatically inserting its dropdown into any h1 on the page (annoying!)
  - Updates all tests to use the English `Source.title_en`, `Creator.first_name_en` and `last_name_en`, and `Document.description_en`
  
- Per #594:
  - Fixes issue with fallback to `settings.LANGUAGES` where it was using a list of tuples instead of the expected list of strings

## review notes

- The one test that I couldn't get to work with the `_en` version of a field is the test for the migration that merges India Books (`test_footnotes_migrations.MergeIndiaBookSources.test_sources_merged`). I guess those migrations only test the `title` field. But it's probably fine since it's an old migration.
- I noticed that the dropdown behavior seen by Rachel only happens when `PUBLIC_SITE_LANGUAGES` is not set properly in the settings. `PUBLIC_SITE_LANGUAGES` logic expects a list of language codes, not tuples, so we might want to make sure `PUBLIC_SITE_LANGUAGES` is set to just `["en"]` in the settings. If it's not set at all, it reverts back to `LANGUAGES`, which introduced a bug where it was reverting back to the list of tuples instead of the list of language codes (fixed here).
  - I could change this to make it accept tuples instead, but I thought it might be unnecessary to redefine "English", "Hebrew", and "Arabic" label strings when they're not being used.
