### PR TITLE
#560 - Get attribution per fragment/shelfmark

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -6,6 +6,7 @@
 -   If not all languages should be enabled on the public site, edit `settings/local_settings.py` to add the **PUBLIC_SITE_LANGUAGES** variable from `settings/local_settings.py.sample`. As noted in the sample file, its value should be either a list of language codes that comprise the subset of **LANGUAGES** desired for the public site, or undefined.
 -   To enable Google Analytics for the production site, configure **GTAGS_ANALYTICS_ID** in local settings.
 -   Run `python manage.py update_translation_fields` to copy existing document descriptions to the description_en translated field.
+-   Run `python manage.py import_manifests --update` to update locally-cached manifests with the new attribution field.
 
 ## 4.0
 

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -243,6 +243,27 @@ class Fragment(TrackChangesModel):
             )
         )
 
+    @property
+    def attribution(self):
+        """Generate an attribution for this fragment"""
+        # if there is no iiif for this fragment, bail out
+        if not self.iiif_url:
+            return None
+        # try to use locally cached manifest
+        if self.manifest:
+            return strip_tags(self.manifest.extra_data.get("attribution", ""))
+        try:
+            # otherwise try to use remote manifest attribution attribute
+            remote_manifest = IIIFPresentation.from_url(self.iiif_url)
+            try:
+                return strip_tags(remote_manifest.attribution)
+            except AttributeError:
+                # attribution is optional, so ignore if not present
+                return None
+        except IIIFException:
+            logger.warning("Error loading IIIF manifest: %s" % self.iiif_url)
+        return None
+
     def save(self, *args, **kwargs):
         """Remember how shelfmarks have changed by keeping a semi-colon list
         in the old_shelfmarks field"""
@@ -632,6 +653,9 @@ class Document(ModelIndexable):
     def attribution(self):
         """Generate a tuple of three attribution components for use in IIIF manifests
         or wherever images/transcriptions need attribution."""
+
+        # NOTE: For individual fragment attribution, use :class:`Fragment` method instead.
+
         # keep track of unique attributions so we can include them all
         extra_attrs_set = set()
         for url in self.iiif_urls():

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -251,12 +251,12 @@ class Fragment(TrackChangesModel):
             return None
         # try to use locally cached manifest
         if self.manifest:
-            return strip_tags(self.manifest.extra_data.get("attribution", ""))
+            return mark_safe(self.manifest.extra_data.get("attribution", ""))
         try:
             # otherwise try to use remote manifest attribution attribute
             remote_manifest = IIIFPresentation.from_url(self.iiif_url)
             try:
-                return strip_tags(remote_manifest.attribution)
+                return mark_safe(remote_manifest.attribution)
             except AttributeError:
                 # attribution is optional, so ignore if not present
                 return None

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -34,6 +34,12 @@
                 <div>{{ document.digital_editions.0.content.html|safe }}</div>
             {% endif %}
         </div>
+        <div class="attribution">
+            {% for fragment in document.fragments.all %}
+                {% if fragment.attribution %}
+                    {{ fragment.shelfmark }}: {{ fragment.attribution }}
+                {% endif %}
+            {% endfor %}
+        </div>
     {% endif %}
-    {{ document.attribution|format_attribution|safe }}
 </section>

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -203,7 +203,7 @@ class TestFragment(TestCase):
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")
-    def test_iiif_images_iiifexception(self, mock_manifestimporter):
+    def test_iiifexception(self, mock_manifestimporter):
         # patch IIIFPresentation.from_url to always raise IIIFException
         with patch("geniza.corpus.models.IIIFPresentation") as mock_iiifpresentation:
             mock_iiifpresentation.from_url = Mock()
@@ -213,9 +213,47 @@ class TestFragment(TestCase):
             frag.save()
             # should raise the exception
             with self.assertRaises(IIIFException):
-                # should log at level WARN
+                # iiif_images should log at level WARN
                 with self.assertLogs(level="WARN"):
                     frag.iiif_images()
+                # as should attirbution
+                with self.assertLogs(level="WARN"):
+                    frag.attribution
+
+    @pytest.mark.django_db
+    @patch("geniza.corpus.models.ManifestImporter")
+    def test_attribution(self, mock_manifestimporter):
+        # fragment with no manifest
+        frag = Fragment(shelfmark="TS 1")
+        assert not frag.attribution
+
+        # fragment with a locally cached manifest
+        frag = Fragment(shelfmark="TS 2")
+        frag.iiif_url = "http://example.io/manifests/2"
+        # manifest with an attribution
+        frag.manifest = Manifest.objects.create(
+            uri=frag.iiif_url,
+            short_id="m",
+            extra_data={"attribution": "Created by a person"},
+        )
+        frag.save()
+        assert frag.attribution == "Created by a person"
+
+        # fragment with remote manifest
+        frag_no_manifest = Fragment(shelfmark="TS 3")
+        frag_no_manifest.iiif_url = "http://example.io/manifests/3"
+        frag_no_manifest.save()
+        with patch("geniza.corpus.models.IIIFPresentation") as mock_iiifpresentation:
+            # no attribution, should return None via caught AttributeError
+            mock_iiifpresentation.from_url.return_value = AttrDict({})
+            assert not frag_no_manifest.attribution
+
+            # with attribution
+            mock_iiifpresentation.reset_mock()
+            mock_iiifpresentation.from_url.return_value = AttrDict(
+                {"attribution": "Created by a person"}
+            )
+            assert frag_no_manifest.attribution == "Created by a person"
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -203,7 +203,7 @@ class TestFragment(TestCase):
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")
-    def test_iiifexception(self, mock_manifestimporter):
+    def test_iiif_images_iiifexception(self, mock_manifestimporter):
         # patch IIIFPresentation.from_url to always raise IIIFException
         with patch("geniza.corpus.models.IIIFPresentation") as mock_iiifpresentation:
             mock_iiifpresentation.from_url = Mock()
@@ -213,12 +213,9 @@ class TestFragment(TestCase):
             frag.save()
             # should raise the exception
             with self.assertRaises(IIIFException):
-                # iiif_images should log at level WARN
+                # should log at level WARN
                 with self.assertLogs(level="WARN"):
                     frag.iiif_images()
-                # as should attirbution
-                with self.assertLogs(level="WARN"):
-                    frag.attribution
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")
@@ -254,6 +251,22 @@ class TestFragment(TestCase):
                 {"attribution": "Created by a person"}
             )
             assert frag_no_manifest.attribution == "Created by a person"
+
+    @pytest.mark.django_db
+    @patch("geniza.corpus.models.ManifestImporter")
+    def test_attribution_iiifexception(self, mock_manifestimporter):
+        # patch IIIFPresentation.from_url to always raise IIIFException
+        with patch("geniza.corpus.models.IIIFPresentation") as mock_iiifpresentation:
+            mock_iiifpresentation.from_url = Mock()
+            mock_iiifpresentation.from_url.side_effect = IIIFException
+            frag = Fragment(shelfmark="TS 1")
+            frag.iiif_url = "http://example.io/manifests/1"
+            frag.save()
+            # should raise the exception
+            with self.assertRaises(IIIFException):
+                # should log at level WARN
+                with self.assertLogs(level="WARN"):
+                    frag.attribution
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -21,5 +21,5 @@ eulxml
 rich
 wagtail>=2.15.3,<2.16
 wagtail-localize
-djiffy>=0.7.1
+djiffy>=0.7.2
 natsort


### PR DESCRIPTION
## What this PR does 

- Per #560:
  - Adds a function that gets a single Fragment's attribution; from local or remote manifest
  - Updates transcription template to show attribution per shelfmark
  - Updates djiffy to 0.7.2
  - Adds deploy notes

## review notes

- I left the old code present in case we still want to use it for serving our own IIIF manifests.