### PR TITLE
implement random document sort

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -122,6 +122,8 @@ class DocumentSearchForm(forms.Form):
     SORT_CHOICES = [
         # Translators: label for sort by relevance
         ("relevance", _("Relevance")),
+        # Translators: label for sort in random order
+        ("random", _("Random")),
         # ("input_date", "Input Date (Latest – Earliest)"),
         # Translators: label for descending sort by number of scholarship records
         ("scholarship_desc", _("Scholarship Records (Most–Least)")),

--- a/geniza/corpus/templates/corpus/snippets/pagination.html
+++ b/geniza/corpus/templates/corpus/snippets/pagination.html
@@ -4,7 +4,7 @@
         {# Translators: Label for "previous page" button in search results #}
         {% translate 'Previous' as previous_page %}
         {% if page_obj.has_previous %}
-            <a name="{{ previous_page }}" title="{{ previous_page }}" class="prev" rel="prev" href="?{% querystring_replace page=page_obj.previous_page_number %}">
+            <a name="{{ previous_page }}" title="{{ previous_page }}" class="prev" rel="prev" href="?{% querystring_replace page=page_obj.previous_page_number %}{{ random_seed }}">
                 {{ previous_page }}
             </a>
         {% else %}
@@ -24,23 +24,23 @@
 
             {% elif page_obj.number <= 2  and number <= 5 %}
                 {# for current page 1 or 2, display first 5 #}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
 
             {% elif page_obj.number|add:1 >= page_obj.paginator.num_pages and number >= page_obj.paginator.num_pages|add:-4 %}
                 {# for current page last or next to last, display last 5 pages #}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
 
             {% elif page_obj.number|add:2 >= number and page_obj.number|add:-2 <= number and number <= 100 %}
                 {# display the two numbers before and after the current page (up to 100) #}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
 
             {% elif page_obj.number|add:1 >= number and page_obj.number|add:-1 <= number and number > 100 %}
                 {# display the one numbers before and after the current page (after 100) #}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
 
             {% elif forloop.first %}
                 {# always display the first page (not current page) #}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
                 {# if there is a gap between 1 and group around current page #}
                 {% if page_obj.number > 4 and page_obj.paginator.num_pages > 6 %}
                     <span class="ellipsis">...</span>
@@ -52,14 +52,14 @@
                 {% if page_obj.number|add:3 < number and number > 6 %}
                     <span class="ellipsis">...</span>
                 {% endif %}
-                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}">{{ number }}</a>
+                <a title="{{ page_number_title }}" class="pagelink" href="?{% querystring_replace page=number %}{{ random_seed }}">{{ number }}</a>
             {% endif%}
         {% endfor %}
 
         {# Translators: Label for "next page" button in search results #}
         {% translate 'Next' as next_page %}
         {% if page_obj.has_next %}
-            <a name="{{ next_page }}" title="{{ next_page }}" class="next" rel="next" href="?{% querystring_replace page=page_obj.next_page_number %}">
+            <a name="{{ next_page }}" title="{{ next_page }}" class="next" rel="next" href="?{% querystring_replace page=page_obj.next_page_number %}{{ random_seed }}">
                 {{ next_page }}
             </a>
         {% else %}

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -1,4 +1,5 @@
 from ast import literal_eval
+from random import randint
 
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -36,7 +37,7 @@ class DocumentSearchView(ListView, FormMixin):
     # Translators: description of document search page, for search engines
     page_description = _("Search and browse Geniza documents.")
     paginate_by = 50
-    initial = {"sort": "scholarship_desc"}
+    initial = {"sort": "random"}
 
     # map form sort to solr sort field
     solr_sort = {
@@ -45,11 +46,27 @@ class DocumentSearchView(ListView, FormMixin):
         "scholarship_asc": "scholarship_count_i",
         #        'name': 'sort_name_isort'
     }
+    random_seed = None
+
+    def get_solr_sort(self, sort_option):
+        """Return solr sort field for user-seleted sort option;
+        generates random seed for random sort if requested and not set;
+        otherwise uses solr sort field from :attr:`solr_sort`"""
+        if sort_option == "random":
+            if self.random_seed is None:
+                self.random_seed = randint(1000, 9999)
+            return "random_%s" % self.random_seed
+        return self.solr_sort[sort_option]
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         # use GET instead of default POST/PUT for form data
         form_data = self.request.GET.copy()
+
+        # check for a random seed and save if set;
+        # used to preserve random list order when paginating
+        if "rnd" in form_data:
+            self.random_seed = form_data["rnd"]
 
         # sort by chosen sort
         if "sort" in form_data and bool(form_data.get("sort")):
@@ -112,7 +129,7 @@ class DocumentSearchView(ListView, FormMixin):
                 )  # include relevance score in results
 
             # order by sort option
-            documents = documents.order_by(self.solr_sort[search_opts["sort"]])
+            documents = documents.order_by(self.get_solr_sort(search_opts["sort"]))
 
             # filter by type if specified
             if search_opts["doctype"]:
@@ -158,6 +175,10 @@ class DocumentSearchView(ListView, FormMixin):
                 "highlighting": highlights,
             }
         )
+        # if random seed is set and not in current request queryset,
+        # add to context to preserve for pagination
+        if self.random_seed and "rnd" not in self.request.GET:
+            context_data["random_seed"] = "&rnd=%s" % self.random_seed
         return context_data
 
 

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -55,6 +55,7 @@ class DocumentSearchView(ListView, FormMixin):
         if sort_option == "random":
             if self.random_seed is None:
                 self.random_seed = randint(1000, 9999)
+            # use solr's random dynamic field to sort randomly
             return "random_%s" % self.random_seed
         return self.solr_sort[sort_option]
 

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
             (target) => target.value === "relevance"
         );
         this.defaultSortElement = this.sortTargets.find(
-            (target) => target.value === "scholarship_desc"
+            (target) => target.value === "random"
         );
         this.updateSort();
     }


### PR DESCRIPTION
- adds random sort option to document search form
- set random as default sort in view when there is no keyword search term
- update stimulus search controller to change non-relevance default sort to random 
- new method to get solr sort option based on submitted sort chosen in the search form; generates a random dynamic solr field to sort randomly
- adds a parameter to context & page links to preserve current random sort when paging with within results for a randomly sorted set of documents


notes:
- might make more sense for stimulus to remember and restore the previous sort option when disabling relevance
- don't love the random seed handling in the template (feels redundant), but didn't see an obvious alternate solution