### PR TITLE
Template filter for automatic PGPID links in descriptions (#578)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static i18n render_bundle_csp %}
+{% load static i18n render_bundle_csp corpus_extras %}
 
 {% block meta_title %}{{ page_title }}{% endblock meta_title %}
 {% block meta_description %}{{ page_description }}{% endblock meta_description %}
@@ -76,7 +76,7 @@
                 {# Translators: label for document description #}
                 {% translate 'Description' %}
             </h3>
-            <p>{{ document.description }}</p>
+            <p>{{ document.description|pgp_urlize }}</p>
         </section>
 
         {# link to download transcription if available; admin only for now since plain-text bidi is not great #}

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -127,20 +127,16 @@ def h1_to_h3(html):
 def pgp_urlize(text):
     """Find all instances of \"PGPID #\" in the passed text, and convert
     each to a link to the referenced document."""
-    # use an absolutized placeholder URL to use for each match, replacing the fake pgpid 000
-    placeholder_url = absolutize_url(reverse("corpus:document", args=["000"]))
+    # use an absolutized placeholder URL to use for each match, replacing the fake pgpid 000 with the regex
+    placeholder_url = absolutize_url(reverse("corpus:document", args=["000"])).replace(
+        "000", "\g<pgpid>"
+    )
+    placeholder_link = '<a href="%s">\g<text></a>' % placeholder_url
+    # match all instances of PGPID ### with a link to the document
     return mark_safe(
         re.sub(
-            # match all instances of PGPID ###
-            r"\bPGPID\b \b(?P<pgpid>\d+)\b",
-            # replace with a link
-            lambda match: '<a href="%s">%s</a>'
-            % (
-                # replace the fake pgpid in the placeholder URL with the matched real pgpid
-                re.sub("000", match.group("pgpid"), placeholder_url),
-                # use the original entire matched string as link text
-                match.group(0),
-            ),
+            r"\b(?P<text>PGPID\b \b(?P<pgpid>\d+))\b",
+            placeholder_link,
             text,
         )
     )


### PR DESCRIPTION
## What this PR does

- Per #578:
  - Adds a template filter to convert all instances of "PGPID ###" in a passed text into links to the canonical URL to the referenced document
  - Applies that template filter to the description in the document detail view