### PR TITLE
Automatically reindex documents when sources, footnotes, or creators change (#668)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -335,6 +335,7 @@ class DocumentSignalHandlers:
         "tag": "tags",
         "document type": "doctype",
         "Related Fragment": "textblock",  # textblock verbose name
+        "footnote": "footnotes",
     }
 
     @staticmethod
@@ -347,6 +348,7 @@ class DocumentSignalHandlers:
         # get related lookup for document filter
         model_name = instance._meta.verbose_name
         doc_attr = DocumentSignalHandlers.model_filter.get(model_name)
+
         # if handler fired on an model we don't care about, warn and exit
         if not doc_attr:
             logger.warning(
@@ -820,9 +822,15 @@ class Document(ModelIndexable):
         "textblock_set": {
             "post_save": DocumentSignalHandlers.related_save,
             "pre_delete": DocumentSignalHandlers.related_delete,
-        }
-        # footnotes and sources, when we include editors/translators
-        # script+language when/if included in index data
+        },
+        "footnotes.footnote": {
+            "post_save": DocumentSignalHandlers.related_save,
+            "pre_delete": DocumentSignalHandlers.related_delete,
+        },
+        # "footnotes__source__authors": { # "footnotes__source__authorship__creator",
+        #     "post_save": DocumentSignalHandlers.related_save,
+        #     "pre_delete": DocumentSignalHandlers.related_delete,
+        # },
     }
 
     def merge_with(self, merge_docs, rationale, user=None):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -336,6 +336,8 @@ class DocumentSignalHandlers:
         "document type": "doctype",
         "Related Fragment": "textblock",  # textblock verbose name
         "footnote": "footnotes",
+        "source": "footnotes__source",
+        "creator": "footnotes__source__authorship__creator",
     }
 
     @staticmethod
@@ -348,7 +350,6 @@ class DocumentSignalHandlers:
         # get related lookup for document filter
         model_name = instance._meta.verbose_name
         doc_attr = DocumentSignalHandlers.model_filter.get(model_name)
-
         # if handler fired on an model we don't care about, warn and exit
         if not doc_attr:
             logger.warning(
@@ -827,10 +828,14 @@ class Document(ModelIndexable):
             "post_save": DocumentSignalHandlers.related_save,
             "pre_delete": DocumentSignalHandlers.related_delete,
         },
-        # "footnotes__source__authors": { # "footnotes__source__authorship__creator",
-        #     "post_save": DocumentSignalHandlers.related_save,
-        #     "pre_delete": DocumentSignalHandlers.related_delete,
-        # },
+        "footnotes.source": {
+            "post_save": DocumentSignalHandlers.related_save,
+            "pre_delete": DocumentSignalHandlers.related_delete,
+        },
+        "footnotes.creator": {
+            "post_save": DocumentSignalHandlers.related_save,
+            "pre_delete": DocumentSignalHandlers.related_delete,
+        },
     }
 
     def merge_with(self, merge_docs, rationale, user=None):

--- a/geniza/corpus/tests/test_corpus_signals.py
+++ b/geniza/corpus/tests/test_corpus_signals.py
@@ -13,7 +13,7 @@ from geniza.corpus.models import (
 
 @pytest.mark.django_db
 @patch.object(ModelIndexable, "index_items")
-def test_related_save(mock_indexitems, document, join):
+def test_related_save(mock_indexitems, document, join, footnote):
     # unsaved fragment should be ignored
     frag = Fragment(shelfmark="T-S 123")
 
@@ -40,6 +40,26 @@ def test_related_save(mock_indexitems, document, join):
     assert mock_indexitems.call_count == 1
     assert document in mock_indexitems.call_args[0][0]
     assert join not in mock_indexitems.call_args[0][0]
+
+    # footnote
+    mock_indexitems.reset_mock()
+    DocumentSignalHandlers.related_save(DocumentType, document.footnotes.first())
+    assert mock_indexitems.call_count == 1
+    assert document in mock_indexitems.call_args[0][0]
+
+    # source
+    mock_indexitems.reset_mock()
+    DocumentSignalHandlers.related_save(DocumentType, document.footnotes.first().source)
+    assert mock_indexitems.call_count == 1
+    assert document in mock_indexitems.call_args[0][0]
+
+    # creator
+    mock_indexitems.reset_mock()
+    DocumentSignalHandlers.related_save(
+        DocumentType, document.footnotes.first().source.authorship_set.first().creator
+    )
+    assert mock_indexitems.call_count == 1
+    assert document in mock_indexitems.call_args[0][0]
 
     # unhandled model should be ignored, no error
     mock_indexitems.reset_mock()


### PR DESCRIPTION
@rlskoeser I got a bit caught up on the fact that parasolr can't handle foreign/generic keys. Throwing this together last minute, and tests need to be written, but just let me know if I'm missing something big!