### PR TITLE
Position search filters absolutely on desktop (#663)

### DIFF
--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -68,7 +68,9 @@ class Command(BaseCommand):
         percy_snapshot(browser, "Content Page%s" % dark_mode_str)
 
         # document search with document type filter expanded
-        browser.get("http://localhost:8000/en/documents/?per_page=2#filters")
+        browser.get(
+            "http://localhost:8000/en/documents/?per_page=2&sort=scholarship_desc#filters"
+        )
         # open document type filter
         browser.find_element_by_css_selector(".doctype-filter summary").click()
         # click the first option
@@ -84,7 +86,7 @@ class Command(BaseCommand):
 
         # document search
         browser.get(
-            "http://localhost:8000/en/documents/?q=the+writer+Avraham+באנפנא&per_page=2"
+            "http://localhost:8000/en/documents/?q=the+writer+Avraham+באנפנא&sort=relevance&per_page=2"
         )
         percy_snapshot(browser, "Document Search%s" % dark_mode_str)
 

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -17,7 +17,7 @@
             {% translate 'Submit search' as search_label %}
             <button type="submit" aria-label="{{ search_label }}" />
         </fieldset>
-        <a href="#filters" role="button" id="filters-button">
+        <a href="#filters" role="button" id="filters-button" data-action="click->search#openFilters">
             <i class="ph-faders"></i>
             {% translate "Filters" %}
         </a>
@@ -42,16 +42,16 @@
             </details>
         </fieldset>
 
-        <fieldset id="filters" aria-expanded="false">
-            <a href="#" role="button" id="close-filters-modal">
+        <fieldset id="filters" aria-expanded="false" data-search-target="filterModal">
+            <a href="#" role="button" id="close-filters-modal" data-action="click->search#closeFilters">
                 {# Translators: label for 'filters' close button for mobile navigation #}
                 {% translate "Close filter options" as close_button %}
                 <span class="sr-only">{{ close_button }}</span>
             </a>
-            <span id="filters-label">
+            <a href="#" role="button" id="close-filters-button" data-action="click->search#closeFilters">
                 <i class="ph-faders"></i>
                 {% translate "Filters" %}
-            </span>
+            </a>
             <label for="{{ form.has_transcription.auto_id }}">
                 {{ form.has_transcription }}
                 {{ form.has_transcription.label }}

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -5,7 +5,7 @@ import { Controller } from "@hotwired/stimulus";
 // import { ApplicationController, useDebounce } from "stimulus-use";
 
 export default class extends Controller {
-    static targets = ["query", "sort", "sortlabel"];
+    static targets = ["query", "sort", "sortlabel", "filterModal"];
     // static debounces = ["submit"];
 
     connect() {
@@ -18,6 +18,18 @@ export default class extends Controller {
         // be set back to # in order for the "apply" button in the filter modal to close the modal.
         window.location.href = "#";
         this.element.submit();
+    }
+
+    // Open/close the filter modal using aria-expanded instead of targeting with a link, to prevent
+    // scroll jumping around the page. Will still work as a link when JS is disabled.
+    openFilters(e) {
+        e.preventDefault();
+        this.filterModalTarget.setAttribute("aria-expanded", "true");
+    }
+
+    closeFilters(e) {
+        e.preventDefault();
+        this.filterModalTarget.setAttribute("aria-expanded", "false");
     }
 
     sortTargetConnected() {

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -30,6 +30,10 @@ export default class extends Controller {
     closeFilters(e) {
         e.preventDefault();
         this.filterModalTarget.setAttribute("aria-expanded", "false");
+        if (window.location.href.includes("#filters")) {
+            // ensure filters modal can be closed if on #filters URL
+            window.location.href = "#";
+        }
     }
 
     sortTargetConnected() {

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -249,7 +249,7 @@
     }
 }
 #search main form a#filters-button,
-#search main form span#filters-label {
+#search main form a#close-filters-button {
     margin: spacing.$spacing-md 0 spacing.$spacing-lg;
     text-decoration: none;
     @include typography.body-bold;
@@ -281,12 +281,22 @@
     flex-flow: column;
     pointer-events: all;
     align-items: flex-start;
-    // width on desktop
+    // overlay on form on desktop
     @include breakpoints.for-tablet-landscape-up {
-        padding: 0 calc(calc(100vw - #{container.$two-column}) / 2);
+        position: absolute;
+        width: 900px;
+        max-width: container.$two-column;
+        overflow-y: auto;
+        padding: spacing.$spacing-sm 1.275rem spacing.$spacing-sm
+            spacing.$spacing-sm;
+        margin: 0 0 0 -#{spacing.$spacing-sm};
+        top: 19.45rem;
+        left: auto;
+        height: auto;
     }
     // show when targeted
-    &:target {
+    &:target,
+    &[aria-expanded="true"] {
         display: flex;
     }
     // close button
@@ -298,7 +308,7 @@
             content: "\f36d"; // phosphor X icon
         }
         @include breakpoints.for-tablet-landscape-up {
-            margin-top: spacing.$spacing-md;
+            display: none;
         }
     }
     // all filter form inputs that are not nested within a details
@@ -476,8 +486,7 @@
         margin: spacing.$spacing-2xl 0 spacing.$spacing-md;
         align-self: center;
         @include breakpoints.for-tablet-landscape-up {
-            align-self: flex-end;
-            margin: spacing.$spacing-3xl 0 spacing.$spacing-xl;
+            display: none;
         }
     }
 }


### PR DESCRIPTION
## What this PR does

- Ensures search sort is not random for Percy
- Per #663:
  - Positions filters absolutely and aligns with the "Filters" text in the search form, on desktop
  - Leaves mobile functionality the same as before