### PR TITLE
Escape potential problem metadata fields (#386)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -9,7 +9,7 @@
     {# digital editions metadata for twitter, slack #}
     {% if document.digital_editions %}
         <meta name="twitter:label1" value="{% blocktranslate count counter=document.editors.count trimmed %}Editor{% plural %}Editors{% endblocktranslate %}">
-        <meta name="twitter:data1" value="{% for ed in document.digital_editions %}{% ifchanged %}{{ ed.display }}{% if not forloop.last %} {% endif %}{% endifchanged %}{% endfor %}">
+        <meta name="twitter:data1" value="{% for ed in document.digital_editions %}{% ifchanged %}{{ ed.display|escape }}{% if not forloop.last %} {% endif %}{% endifchanged %}{% endfor %}">
     {% endif %}
 
     {# preview card images for twitter and open graph #}

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -19,8 +19,8 @@
         {# open graph metadata #}
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="{% translate "Princeton Geniza Project" %}"/>
-        <meta property="og:title" content="{% firstof page_title page.title %}" />
-        <meta property="og:description" content="{% firstof page_description page.description %}" />
+        <meta property="og:title" content="{% firstof page_title|escape page.title|escape %}" />
+        <meta property="og:description" content="{% firstof page_description|escape page.description|escape %}" />
         <meta property="og:url" content="{{ request.build_absolute_uri }}" />
 
         {# twitter medatada #}


### PR DESCRIPTION
## What this PR does

- Per #386:
  - Escapes title, description, and editor metadata fields to avoid breaking on double quotes and other problem characters