### PR TITLE
Position filters relatively on desktop (#663)

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -106,7 +106,7 @@ jobs:
         # NOTE: command line core creation does not seem to actually use the configset
 
       - name: Setup local_settings.py
-        run: python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4())" >> geniza/settings/local_settings.py
+        run: python -c "import uuid; print('SECRET_KEY = \'%s\'' % uuid.uuid4()); print('IS_PERCY = True')" >> geniza/settings/local_settings.py
 
       - name: Run webpack to process scss/js
         run: npm run build

--- a/.percy.yml
+++ b/.percy.yml
@@ -7,6 +7,7 @@ snapshot:
 discovery:
   allowedHostnames:
     [
+      "geniza.princeton.edu",
       "unpkg.com",
       "cdnjs.cloudflare.com",
       "princeton.edu",

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -21,26 +21,6 @@
             <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>
             {% translate "Filters" %}
         </a>
-        <fieldset id="sort">
-            <label for="{{ form.sort.html_name }}">
-                {{ form.sort.label }}
-            </label>
-            <details class="sort-select" aria-expanded="false">
-                <summary class="sort-select-trigger" data-search-target="sortlabel">
-                    {% for choice in form.sort.field.choices %}
-                        {% if form.sort.value == choice.0 %}
-                            {{ choice.1 }}
-                        {% endif %}
-                    {% endfor %}
-                    {# Translators: Button to open or close sort options menu #}
-                    {% translate 'Toggle sort options menu' as toggle_label %}
-                    <div role="button" tabindex="-1" aria-pressed="false" aria-expanded="false" aria-label="{{ toggle_label }}">
-                        <span class="sr-only" >{{ toggle_label }}</span>
-                    </div>
-                </summary>
-                {% render_field form.sort data-search-target="sort" %}
-            </details>
-        </fieldset>
 
         <fieldset id="filters" aria-expanded="false" data-search-target="filterModal">
             <a href="#" role="button" id="close-filters-modal" data-action="click->search#closeFilters">
@@ -73,6 +53,27 @@
             <button type="submit" class="primary">
                 {% translate "Apply" %}
             </button>
+        </fieldset>
+
+        <fieldset id="sort">
+            <label for="{{ form.sort.html_name }}">
+                {{ form.sort.label }}
+            </label>
+            <details class="sort-select" aria-expanded="false">
+                <summary class="sort-select-trigger" data-search-target="sortlabel">
+                    {% for choice in form.sort.field.choices %}
+                        {% if form.sort.value == choice.0 %}
+                            {{ choice.1 }}
+                        {% endif %}
+                    {% endfor %}
+                    {# Translators: Button to open or close sort options menu #}
+                    {% translate 'Toggle sort options menu' as toggle_label %}
+                    <div role="button" tabindex="-1" aria-pressed="false" aria-expanded="false" aria-label="{{ toggle_label }}">
+                        <span class="sr-only" >{{ toggle_label }}</span>
+                    </div>
+                </summary>
+                {% render_field form.sort data-search-target="sort" %}
+            </details>
         </fieldset>
 
         {% if form.errors %}

--- a/geniza/settings/environments/test.py
+++ b/geniza/settings/environments/test.py
@@ -1,5 +1,7 @@
 import os
 
+from django.conf import settings
+
 from geniza.settings.components.base import DATABASES, INSTALLED_APPS
 
 # These settings correspond to the service container settings in the
@@ -31,5 +33,5 @@ INSTALLED_APPS.append("django_dbml")
 
 # when running in CI, load fonts from production by overriding font base url
 # (needed for Percy and Lighthouse)
-if os.environ.get("CI"):
+if os.environ.get("CI") or settings.IS_PERCY:
     FONT_URL_PREFIX = "https://geniza.princeton.edu/static/fonts/"

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -119,7 +119,7 @@
     }
 }
 #search main form fieldset#sort {
-    order: 3;
+    order: 4;
     // sort options select (uses details/summary)
     details.sort-select {
         position: relative;
@@ -292,17 +292,16 @@
     flex-flow: column;
     pointer-events: all;
     align-items: flex-start;
-    // overlay on form on desktop
+    // expand form on desktop
     @include breakpoints.for-tablet-landscape-up {
-        position: absolute;
+        order: 3;
+        position: relative;
         width: 900px;
         max-width: container.$two-column;
         overflow-y: auto;
         padding: spacing.$spacing-sm 1.275rem spacing.$spacing-sm
             spacing.$spacing-sm;
-        margin: 0 0 0 -#{spacing.$spacing-sm};
-        top: 19.45rem;
-        left: auto;
+        margin: -4.2rem 0 0 -#{spacing.$spacing-sm};
         height: auto;
     }
     // show when targeted


### PR DESCRIPTION
## What this PR does

In order to move page content down, instead of overlaying the expanded filters on top of the form and results:
- Rearranges the search options so that filters sit between the filter toggle button and the sort options
- Uses relative positioning and negative margins to position the expanded filters