### PR TITLE
Fix issue with mobile menus appearing from off-screen (#411)

### DIFF
--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
         browser.get("http://localhost:8000/en/documents/9469/#menu")
         # custom CSS to ensure that on mobile, the menu transition is disabled and the menu
         # is in the correct position
-        mobile_menu_css = "ul#menu { left: 0 !important; transition: none !important; }"
+        mobile_menu_css = "ul#menu { visibility: visible !important; width: 100% !important; height: 100vh !important; }"
         percy_snapshot(
             browser, "Mobile menu%s" % dark_mode_str, percy_css=mobile_menu_css
         )
@@ -113,7 +113,7 @@ class Command(BaseCommand):
         browser.find_element_by_id("open-about-menu").send_keys(Keys.ENTER)
         # custom CSS to ensure that on mobile, the about menu transition is disabled and the menu
         # is in the correct position; and that on desktop, that override does not impact its position
-        about_menu_css = "ul#about-menu { left: 0 !important; transition: none !important; } @media (min-width: 900px) { ul#about-menu { left: auto !important; } }"
+        about_menu_css = "ul#about-menu { visibility: visible !important; width: 100% !important; height: 100vh !important; } @media (min-width: 900px) { ul#about-menu { dispaly: flex !important; } }"
         percy_snapshot(
             browser, "About submenu%s" % dark_mode_str, percy_css=about_menu_css
         )

--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -100,8 +100,7 @@ class Command(BaseCommand):
 
         # mobile menu
         browser.get("http://localhost:8000/en/documents/9469/#menu")
-        # custom CSS to ensure that on mobile, the menu transition is disabled and the menu
-        # is in the correct position
+        # custom CSS to ensure that on mobile, the menu is in the correct position
         mobile_menu_css = "ul#menu { visibility: visible !important; width: 100% !important; height: 100vh !important; }"
         percy_snapshot(
             browser, "Mobile menu%s" % dark_mode_str, percy_css=mobile_menu_css
@@ -111,8 +110,8 @@ class Command(BaseCommand):
         browser.get("http://localhost:8000/en/documents/3504/#menu")
         # open about menu
         browser.find_element_by_id("open-about-menu").send_keys(Keys.ENTER)
-        # custom CSS to ensure that on mobile, the about menu transition is disabled and the menu
-        # is in the correct position; and that on desktop, that override does not impact its position
+        # custom CSS to ensure that on mobile, the about menu is in the correct position;
+        # and that on desktop, that override does not impact its position
         about_menu_css = "ul#about-menu { visibility: visible !important; width: 100% !important; height: 100vh !important; } @media (min-width: 900px) { ul#about-menu { dispaly: flex !important; width: auto !important; height: auto !important; } }"
         percy_snapshot(
             browser, "About submenu%s" % dark_mode_str, percy_css=about_menu_css

--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
         browser.find_element_by_id("open-about-menu").send_keys(Keys.ENTER)
         # custom CSS to ensure that on mobile, the about menu transition is disabled and the menu
         # is in the correct position; and that on desktop, that override does not impact its position
-        about_menu_css = "ul#about-menu { visibility: visible !important; width: 100% !important; height: 100vh !important; } @media (min-width: 900px) { ul#about-menu { dispaly: flex !important; } }"
+        about_menu_css = "ul#about-menu { visibility: visible !important; width: 100% !important; height: 100vh !important; } @media (min-width: 900px) { ul#about-menu { dispaly: flex !important; width: auto !important; height: auto !important; } }"
         percy_snapshot(
             browser, "About submenu%s" % dark_mode_str, percy_css=about_menu_css
         )

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -67,16 +67,16 @@ header {
     ul#menu {
         // Takes up full screen on mobile
         display: flex;
-        left: calc(-100vw);
-        transition: left 0.5s;
+        visibility: hidden;
+        width: 0;
+        height: 0;
+        margin: 0;
+        padding: 0;
         position: fixed;
         flex-flow: row wrap;
         align-items: center;
         justify-content: flex-end;
-        padding: 0;
         max-width: 100%;
-        width: 100%;
-        height: 100vh;
         z-index: 7;
         // Direct descendent menu buttons (mobile)
         & > li.menu-button {
@@ -105,25 +105,26 @@ header {
         }
         // Move into view on :target with link to #ID
         &:target {
-            left: 0;
+            visibility: visible;
+            width: 100%;
+            height: 100vh;
             pointer-events: all;
             @include breakpoints.for-tablet-landscape-up {
                 flex: 1 0 auto;
-                left: auto;
                 transition: none;
             }
         }
         // Positioning for desktop
         @include breakpoints.for-tablet-landscape-up {
-            display: flex;
+            visibility: visible;
+            width: auto;
             height: 100%;
+            display: flex;
             transition: none;
-            left: auto;
             position: relative;
             flex: 1 0 auto;
             flex-flow: row nowrap;
             justify-content: flex-end;
-            width: auto;
             margin: 0 spacing.$spacing-4xl 0 spacing.$spacing-xl;
             pointer-events: all;
             & > li.menu-item + li.menu-item {
@@ -249,7 +250,11 @@ header {
     ul.sub-menu {
         // Sub menu mobile view
         display: flex;
-        left: calc(100vw);
+        visibility: hidden;
+        width: 0;
+        height: 0;
+        margin: 0;
+        padding: 0;
         transition: left 0.5s;
         position: fixed;
         top: 0;
@@ -259,8 +264,6 @@ header {
         flex: 1 0 100%;
         padding: 0;
         max-width: 100%;
-        width: 100%;
-        height: 100vh;
         li.menu-button {
             display: inline-block;
             width: auto;
@@ -285,16 +288,18 @@ header {
             @include typography.mobile-menu;
         }
         &:target {
-            left: 0;
+            visibility: visible;
+            width: 100%;
+            height: 100vh;
             @include breakpoints.for-tablet-landscape-up {
-                transition: none;
-                left: auto;
+                width: auto;
+                height: auto;
             }
         }
         // Sub menu (floating) desktop view
         @include breakpoints.for-tablet-landscape-up {
+            visibility: visible;
             display: none;
-            left: auto;
             transition: none;
             flex: 1 0 auto;
             position: absolute;


### PR DESCRIPTION
## What this PR does

- Per #411:
  - Uses `visibility: hidden` to hide mobile menus when off screen