### PR TITLE
Right align transcriptions in admin (#688)

### DIFF
--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -100,11 +100,12 @@ a#needsreview:target {
     font-style: italic;
 }
 
-/* left-aligned transcriptions; rtl is controlled thru html "dir=" attribute */
+/* rtl is controlled thru html "dir=" attribute */
 .transcription {
     display: inline-block;
     margin-right: auto;
     direction: rtl;
+    text-align: right;
 }
 .transcription h3,
 .transcription section h1 {


### PR DESCRIPTION
## What this PR does

- Per #688:
  - Uses `text-align: right` in admin CSS for transcriptions

## dev review notes

I think fixing this is as simple as aligning the text right, as it is in search results, but this comment gave me pause:

```css
/* left-aligned transcriptions; rtl is controlled thru html "dir=" attribute */
```

I realized the reason why it reverted to left-alignment is because of the Django fieldset and div classes I used to make transcriptions look nice in the admin interface. But I want to make sure I'm not missing some intention here behind the comment!