### PR TITLE
Improve shelfmark selection (#705)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -12,9 +12,9 @@
 {% endif %}
 
 {# title #}
-<span id="formatted-title">
+<span id="formatted-title" data-controller="text">
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark">{% include "corpus/snippets/document_shelfmarks.html" %}</span>
+    <span class="shelfmark" data-action="click->text#copy">{% include "corpus/snippets/document_shelfmarks.html" %}</span>
 </span>

--- a/sitemedia/js/controllers/text_controller.js
+++ b/sitemedia/js/controllers/text_controller.js
@@ -1,0 +1,11 @@
+// src/controllers/text.js
+
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    async copy(e) {
+        // copy the text of the current target to the clipboard
+        // NOTE: disabled until we have design for UI feedback on this interaction
+        // await navigator.clipboard.writeText(e.currentTarget.innerText);
+    }
+}

--- a/sitemedia/scss/components/_docheader.scss
+++ b/sitemedia/scss/components/_docheader.scss
@@ -9,12 +9,14 @@
 
 // Document title
 span#formatted-title {
+    z-index: 2; // prevent edit container from overlapping
     @include typography.headline-1;
     // document type, inside title
     .doctype {
         @include typography.doctype;
     }
     .shelfmark {
+        user-select: all; // allow one-click select
         @include typography.shelfmark;
     }
     margin: spacing.$spacing-xl spacing.$spacing-md spacing.$spacing-md;


### PR DESCRIPTION
## What this PR does

- Per #705:
  - Uses CSS to improve ability to select shelfmarks in the document detail page
  - Adds preliminary functionality (commented out) for "click to copy"