### PR TITLE
Turbo revisions: scroll and page number (#638)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -33,7 +33,7 @@
     <h1 class="sr-only">{{ page_title }}</h1>
     {% include "corpus/snippets/document_header.html" %}
 
-    <div class="container" data-controller="document">
+    <div class="container">
         {# tabs #}
         {% include "corpus/snippets/document_tabs.html" %}
 

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -87,28 +87,25 @@
             </ul>
         {% endif %}
     </form>
-    {# keep pagination within the same frame but update history/location #}
-    <turbo-frame id="search-results" data-turbo-action="advance">
-        <section id="document-list">
-            <h1>
-                {% comment %}Translators: number of search results{% endcomment %}
-                {% blocktranslate with count_humanized=paginator.count|intcomma count counter=paginator.count trimmed %}
-                    1 result
-                {% plural %}
-                    {{ count_humanized }} total results
-                {% endblocktranslate %}
-            </h1>
-            {% if is_paginated %}
-                {% include "corpus/snippets/pagination.html" %}
-            {% endif %}
-            <ol>
-                {% for document in documents %}
-                    {% include "corpus/snippets/document_result.html" %}
-                {% endfor %}
-            </ol>
-            {% if is_paginated %}
-                {% include "corpus/snippets/pagination.html" %}
-            {% endif %}
-        </section>
-    </turbo>
+    <section id="document-list">
+        <h1>
+            {% comment %}Translators: number of search results{% endcomment %}
+            {% blocktranslate with count_humanized=paginator.count|intcomma count counter=paginator.count trimmed %}
+                1 result
+            {% plural %}
+                {{ count_humanized }} total results
+            {% endblocktranslate %}
+        </h1>
+        {% if is_paginated %}
+            {% include "corpus/snippets/pagination.html" %}
+        {% endif %}
+        <ol>
+            {% for document in documents %}
+                {% include "corpus/snippets/document_result.html" %}
+            {% endfor %}
+        </ol>
+        {% if is_paginated %}
+            {% include "corpus/snippets/pagination.html" %}
+        {% endif %}
+    </section>
 {% endblock main %}

--- a/sitemedia/js/controllers/document_controller.js
+++ b/sitemedia/js/controllers/document_controller.js
@@ -1,9 +1,0 @@
-// controllers/document_controller.js
-
-import { Controller } from "@hotwired/stimulus";
-
-export default class extends Controller {
-    connect() {
-        window.scrollTo(0, 0);
-    }
-}

--- a/sitemedia/js/stimulus_app.js
+++ b/sitemedia/js/stimulus_app.js
@@ -5,3 +5,27 @@ import * as Turbo from "@hotwired/turbo";
 const application = Application.start();
 const context = require.context("./controllers", true, /\.js$/);
 application.load(definitionsFromContext(context));
+
+// Workarounds to get document details page to scroll to top on "advance" visit;
+// this has a side effect of losing scroll position on navigating "back", so save
+// scroll position before cache and restore it before visit (if visit type is restore)
+
+function saveScrollPosition() {
+    document.body.dataset.scrollPosition = JSON.stringify([
+        window.scrollX,
+        window.scrollY,
+    ]);
+}
+function restoreScrollPosition(event) {
+    const scrollPosition = JSON.parse(
+        document.body.dataset.scrollPosition || "[]"
+    );
+    if (scrollPosition && event.detail.action == "restore") {
+        window.scrollTo(...scrollPosition);
+    } else if (event.detail.action === "advance") {
+        window.scrollTo(0, 0);
+    }
+}
+
+window.addEventListener("turbo:before-cache", saveScrollPosition);
+window.addEventListener("turbo:visit", restoreScrollPosition);


### PR DESCRIPTION
## What this PR does

- Per #638:
  - Fixes the issue with search page number reverting to 1 on "restore" visit
  - Saves and restores scroll position as a workaround for document detail/search scrolling issues