### PR TITLE
Click filters button before doctype in Percy

### DIFF
--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -71,8 +71,6 @@ class Command(BaseCommand):
         browser.get(
             "http://localhost:8000/en/documents/?per_page=2&sort=scholarship_desc"
         )
-        # open filters
-        browser.find_element_by_css_selector("a#filters-button").click()
         # open document type filter
         browser.find_element_by_css_selector(".doctype-filter summary").click()
         # click the first option

--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -69,8 +69,10 @@ class Command(BaseCommand):
 
         # document search with document type filter expanded
         browser.get(
-            "http://localhost:8000/en/documents/?per_page=2&sort=scholarship_desc#filters"
+            "http://localhost:8000/en/documents/?per_page=2&sort=scholarship_desc"
         )
+        # open filters
+        browser.find_element_by_css_selector("a#filters-button").click()
         # open document type filter
         browser.find_element_by_css_selector(".doctype-filter summary").click()
         # click the first option

--- a/geniza/common/management/commands/visual_tests.py
+++ b/geniza/common/management/commands/visual_tests.py
@@ -71,17 +71,17 @@ class Command(BaseCommand):
         browser.get(
             "http://localhost:8000/en/documents/?per_page=2&sort=scholarship_desc"
         )
+        # open filters
+        browser.find_element_by_css_selector("a#filters-button").click()
         # open document type filter
         browser.find_element_by_css_selector(".doctype-filter summary").click()
         # click the first option
         browser.find_element_by_css_selector(
             ".doctype-filter li:nth-child(1) label"
         ).click()
-        filter_modal_css = "fieldset#filters { display: flex !important; }"
         percy_snapshot(
             browser,
             "Document Search filter%s" % dark_mode_str,
-            percy_css=filter_modal_css,
         )
 
         # document search


### PR DESCRIPTION
## What this PR does

- Fixes a bug causing Percy to fail when attempting to open the doctype filter ("element not interactable")