### PR TITLE
Combine all webpack js/css into one bundle

### DIFF
--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -61,7 +61,7 @@
         {% render_bundle_csp "main" "css" %}
         {% block extrastyle %}{% endblock extrastyle %}
         <!-- scripts -->
-        {% render_bundle_csp "stimulus_app" "js" attrs='defer' %}
+        {% render_bundle_csp "main" "js" attrs='defer' %}
         {# analytics #}
         {% if not request.is_preview and GTAGS_ANALYTICS_ID %}
             {% include 'snippets/analytics.html' %}

--- a/sitemedia/webpack-stats-ci.json
+++ b/sitemedia/webpack-stats-ci.json
@@ -3,7 +3,6 @@
   "publicPath": "/static/bundles/",
   "assets": [],
   "chunks": {
-    "main": [],
-    "stimulus_app": []
+    "main": []
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,8 +13,8 @@ module.exports = (env, options) => ({
         main: [
             // this name ("main") is referenced by django-webpack-loader's {% render_bundle %} tag
             "./sitemedia/scss/main.scss",
+            "./sitemedia/js/stimulus_app.js",
         ],
-        stimulus_app: "./sitemedia/js/stimulus_app.js",
     },
     output: {
         // locations and filenames of bundled files


### PR DESCRIPTION
## What this PR does

- Fixes an error with `webpack-dev-server` that required loading the JS output of a bundle (even if empty) alongside any CSS, by simply combining the two bundles into one