### PR TITLE
Use IIIF viewer from doc detail view in admin UI (#724)

### DIFF
--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -1,4 +1,16 @@
 {% extends "admin/change_form.html" %}
+{% load static render_bundle_csp  %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    {% render_bundle_csp "iiif" "css" %}
+{% endblock %}
+{% block admin_change_form_document_ready %}
+    {{ block.super }}
+    {% render_bundle_csp "iiif" "js" attrs='defer' %}
+{% endblock %}
+
+
 {% block after_field_sets %}
     {% if original.pk %} {# don't display record history when adding new document #}
         <fieldset class="module aligned">
@@ -17,18 +29,11 @@
             </div>
         </fieldset>
     {% endif %}
-    {% if original.digital_editions %}
+    {% if original.digital_editions or original.has_image %}
         <fieldset class="module aligned transcriptions-field">
             <div class="form-row">
-                <label>Transcription{{ original.digital_editions.count|pluralize }}</label>
-                <ul class="transcriptions">
-                    {% for footnote in original.digital_editions %}
-                        <li>
-                            {% if original.digital_editions|length > 1 %}<h3 class="source">{{ footnote.source|safe }}</h3>{% endif %}
-                            {% include "footnotes/transcription.html" with transcription=footnote.content %}
-                        </li>
-                    {% endfor %}
-                </ul>
+                <label>Transcription{{ original.digital_editions.count|pluralize }}/image{{ original.iiif_images|length|pluralize }}</label>
+                {% include "corpus/snippets/document_transcription.html" with document=original %}
             </div>
         </fieldset>
     {% endif %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -19,7 +19,7 @@
         <div id="iiif-images" data-iiif-target="iiifContainer" data-iiif-urls="{{ document.iiif_images|iiif_info_json }}" class="{% if not document.has_transcription %}no-transcription{% endif %}">
         </div>
     {% endif %}
-    {% if document.has_transcription %}
+    {% if document.digital_editions %}
         <div class="transcription{% if not document.has_image %} no-image{% endif %}">
             <h2>{% translate 'Transcription' %}</h2>
             {% if document.digital_editions|length > 1 %}
@@ -27,11 +27,11 @@
                 {% for edition in document.digital_editions %}
                     <details open>
                         <summary class="source">{{ edition.source.display }}</summary>
-                        <div>{{ edition.content.html|safe }}</div>
+                        <div>{{ edition.content.html|h1_to_h3|safe }}</div>
                     </details>
                 {% endfor %}
             {% else %}
-                <div>{{ document.digital_editions.0.content.html|safe }}</div>
+                <div>{{ document.digital_editions.0.content.html|h1_to_h3|safe }}</div>
             {% endif %}
         </div>
         <div class="attribution">

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -59,9 +59,11 @@
         {# include current phosphor icons as css; check https://unpkg.com/phosphor-icons for latest version #}
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/phosphor-icons@1.3.2/src/css/phosphor.css" nonce="{{ reqest.csp_nonce }}"/>
         {% render_bundle_csp "main" "css" %}
+        {% render_bundle_csp "iiif" "css" %}
         {% block extrastyle %}{% endblock extrastyle %}
         <!-- scripts -->
         {% render_bundle_csp "main" "js" attrs='defer' %}
+        {% render_bundle_csp "iiif" "js" attrs='defer' %}
         {# analytics #}
         {% if not request.is_preview and GTAGS_ANALYTICS_ID %}
             {% include 'snippets/analytics.html' %}

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -100,10 +100,14 @@ a#needsreview:target {
     font-style: italic;
 }
 
+/* Transcription styles in admin */
+@media (min-width: 900px) {
+    .form-row #iiif-viewer {
+        padding: 10px;
+    }
+}
 /* rtl is controlled thru html "dir=" attribute */
 .transcription {
-    display: inline-block;
-    margin-right: auto;
     direction: rtl;
     text-align: right;
 }
@@ -132,14 +136,6 @@ a#needsreview:target {
     direction: rtl;
 }
 
-/* styling transcriptions with labels in document admin change form */
-.transcriptions-field ul.transcriptions {
-    display: flex;
-    overflow-x: scroll;
-}
-.transcriptions-field .transcription {
-    margin-left: 20px;
-}
 /* keep document relationship choices labels in line with checkboxes */
 .field-doc_relation {
     white-space: nowrap;
@@ -207,4 +203,14 @@ a#needsreview:target {
 .field-source .related-widget-wrapper span[role="combobox"] {
     display: flex;
     height: auto;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
 }

--- a/sitemedia/js/iiif.js
+++ b/sitemedia/js/iiif.js
@@ -1,6 +1,5 @@
 import { Application } from "@hotwired/stimulus";
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
-import * as Turbo from "@hotwired/turbo";
 
 const application = Application.start();
 // only require iiif_controller.js

--- a/sitemedia/js/iiif.js
+++ b/sitemedia/js/iiif.js
@@ -1,0 +1,8 @@
+import { Application } from "@hotwired/stimulus";
+import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
+import * as Turbo from "@hotwired/turbo";
+
+const application = Application.start();
+// only require iiif_controller.js
+const context = require.context("./controllers", true, /iiif_controller\.js$/);
+application.load(definitionsFromContext(context));

--- a/sitemedia/js/main.js
+++ b/sitemedia/js/main.js
@@ -3,7 +3,12 @@ import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
 import * as Turbo from "@hotwired/turbo";
 
 const application = Application.start();
-const context = require.context("./controllers", true, /\.js$/);
+// exclude iiif_controller.js
+const context = require.context(
+    "./controllers",
+    true,
+    /^.*\/(?!iiif_controller).*\.js$/
+);
 application.load(definitionsFromContext(context));
 
 // Workarounds to get document details page to scroll to top on "advance" visit;

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -88,7 +88,8 @@
             @include typography.headline-3;
             direction: ltr;
         }
-        h1 {
+        h1,
+        h3 {
             text-align: left;
         }
         li {

--- a/sitemedia/scss/iiif.scss
+++ b/sitemedia/scss/iiif.scss
@@ -1,2 +1,0 @@
-// Include all requirements for IIIF viewer
-@use "components/iiif";

--- a/sitemedia/scss/iiif.scss
+++ b/sitemedia/scss/iiif.scss
@@ -1,0 +1,2 @@
+// Include all requirements for IIIF viewer
+@use "components/iiif";

--- a/sitemedia/scss/main.scss
+++ b/sitemedia/scss/main.scss
@@ -10,7 +10,6 @@
 @use "components/tag";
 @use "components/results";
 @use "components/searchform";
-@use "components/iiif";
 @use "components/pagination";
 @use "components/docheader";
 @use "components/controls";

--- a/sitemedia/webpack-stats-ci.json
+++ b/sitemedia/webpack-stats-ci.json
@@ -3,6 +3,7 @@
   "publicPath": "/static/bundles/",
   "assets": [],
   "chunks": {
-    "main": []
+    "main": [],
+    "iiif": []
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,11 @@ module.exports = (env, options) => ({
         main: [
             // this name ("main") is referenced by django-webpack-loader's {% render_bundle %} tag
             "./sitemedia/scss/main.scss",
-            "./sitemedia/js/stimulus_app.js",
+            "./sitemedia/js/main.js",
+        ],
+        iiif: [
+            "./sitemedia/scss/components/_iiif.scss",
+            "./sitemedia/js/iiif.js",
         ],
     },
     output: {


### PR DESCRIPTION
## What this PR does
- Per #724:
  - Uses the template, JS, and CSS from the document detail view IIIF viewer in the admin UI
  - Changes the `has_transcription` check to `digital_editions`, since otherwise it was showing an empty transcription container in the admin UI
  - Converted `H1` to `H3` in all transcriptions to avoid the "language dropdown" issue (I hate that they attach that to ALL `H1` elements!)
  - Splits IIIF viewer JS/CSS into a separate bundle to allow only loading that, and not the other JS/CSS, in admin

## Dev notes
- I had to include the `iiif` Webpack bundles in `base.html` rather than `document_detail.html` in order for Turbo to pick them up. Not entirely sure why that is, but also not sure if it's worth investigating since we were already including that JS/CSS before in `base.html` anyway.