### PR TITLE
Revise placement of "burger" menu (#749)

### DIFF
--- a/sitemedia/scss/components/_controls.scss
+++ b/sitemedia/scss/components/_controls.scss
@@ -13,9 +13,13 @@ div.controls {
     width: auto;
     flex-direction: row;
     align-items: flex-start;
-    right: spacing.$spacing-sm;
-    top: spacing.$spacing-xs;
+    right: 4rem;
+    top: 1.25rem;
     z-index: 8;
+    @include breakpoints.for-tablet-landscape-up {
+        right: spacing.$spacing-sm;
+        top: spacing.$spacing-xs;
+    }
 
     // Language switcher form
     form#language {
@@ -33,7 +37,6 @@ div.controls {
 
     // Light mode/dark mode theme toggle checkbox
     label#theme-toggle {
-        margin-right: spacing.$spacing-xs;
         @include breakpoints.for-tablet-landscape-up {
             margin-right: spacing.$spacing-md;
         }
@@ -65,8 +68,11 @@ div.controls {
 
 // tweaks for RTL layout for hebrew, arabic
 html[dir="rtl"] div.controls {
-    left: spacing.$spacing-sm;
+    left: 4rem;
     right: auto;
+    @include breakpoints.for-tablet-landscape-up {
+        left: spacing.$spacing-sm;
+    }
     label#theme-toggle {
         margin-right: 0;
         margin-left: spacing.$spacing-xs;

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -53,7 +53,7 @@ header {
             }
         }
         li.menu-button {
-            margin-left: 9.75rem;
+            margin-left: 16.75rem;
             margin-top: 0.66rem;
             a {
                 @include typography.icon-button-md;
@@ -402,7 +402,7 @@ header {
 html[dir="rtl"] #site-nav {
     ul#corner-links li.menu-button {
         margin-left: 0;
-        margin-right: 11rem;
+        margin-right: 16.75rem;
     }
     ul.sub-menu li.menu-button a#back-to-main-menu::before {
         content: "\f0c4"; // phosphor caret-right icon


### PR DESCRIPTION
## What this PR does

- Per #749:
  - Moves the "burger" main menu button to the corner on mobile, and moves the light/dark toggle to accommodate its new position