### PR TITLE
Permissions statement revisions: focus, fragment view url (#775)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_permissions.html
+++ b/geniza/corpus/templates/corpus/snippets/document_permissions.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+<details class="permissions">
+    <summary>
+        <span>{% translate 'Image Permissions Statement' %}</span>
+    </summary>
+    <ul>
+        {% for fragment in document.fragments.all %}
+            {% if fragment.iiif_url %}
+                <li class="fragment-permissions">
+                    {% if fragment.url %}
+                        <a href="{{ fragment.url }}" class="shelfmark">{{ fragment.shelfmark }}</a>:
+                    {% else %}
+                        <span class="shelfmark">{{ fragment.shelfmark }}</span>:
+                    {% endif %}
+                    {% if fragment.attribution or fragment.manifest.license %}
+                        {% if fragment.attribution %}{{ fragment.attribution }}{% endif %} {% if fragment.manifest.license %}{% include "corpus/snippets/fragment_license_statement.html" %}{% endif %}
+                    {% else %}
+                        {% translate "No attribution or license noted." %}
+                    {% endif %}
+                </li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+</details>

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -44,7 +44,7 @@
                 {% for fragment in document.fragments.all %}
                     {% if fragment.iiif_url %}
                         <li class="fragment-permissions">
-                            <span class="shelfmark">{{ fragment.shelfmark }}</span>:
+                            <a{% if fragment.url %} href="{{ fragment.url }}"{% endif %} class="shelfmark">{{ fragment.shelfmark }}</a>:
                             {% if fragment.attribution or fragment.manifest.license %}
                                 {% if fragment.attribution %}{{ fragment.attribution }}{% endif %} {% if fragment.manifest.license %}{% include "corpus/snippets/fragment_license_statement.html" %}{% endif %}
                             {% else %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -36,24 +36,6 @@
         </div>
     {% endif %}
     {% if document.has_image %}
-        <details class="permissions">
-            <summary>
-                <span>{% translate 'Image Permissions Statement' %}</span>
-            </summary>
-            <ul>
-                {% for fragment in document.fragments.all %}
-                    {% if fragment.iiif_url %}
-                        <li class="fragment-permissions">
-                            <a{% if fragment.url %} href="{{ fragment.url }}"{% endif %} class="shelfmark">{{ fragment.shelfmark }}</a>:
-                            {% if fragment.attribution or fragment.manifest.license %}
-                                {% if fragment.attribution %}{{ fragment.attribution }}{% endif %} {% if fragment.manifest.license %}{% include "corpus/snippets/fragment_license_statement.html" %}{% endif %}
-                            {% else %}
-                                {% translate "No attribution or license noted." %}
-                            {% endif %}
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        </details>
+        {% include "corpus/snippets/document_permissions.html" %}
     {% endif %}
 </section>

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -150,7 +150,7 @@
             margin-bottom: 0.5rem;
         }
         @include typography.permissions-statement;
-        span.shelfmark {
+        a.shelfmark {
             @include typography.permissions-statement-bold;
         }
         // list of attributions/licenses

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -125,6 +125,12 @@
             cursor: pointer;
             display: flex;
             align-items: center;
+            &:focus {
+                outline: none;
+                span {
+                    outline: 0.1rem solid var(--focus);
+                }
+            }
             span {
                 @include typography.link;
             }


### PR DESCRIPTION
## What this PR does

- Per #775
  - Fixes focus style for image permissions details/summary element
- Includes the fragment's `url` (view url) as link on shelfmark, if available