### PR TITLE
Apply shelfmark link style to spans in image permissions (#775)

### DIFF
--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -156,7 +156,8 @@
             margin-bottom: 0.5rem;
         }
         @include typography.permissions-statement;
-        a.shelfmark {
+        a.shelfmark,
+        span.shelfmark {
             @include typography.permissions-statement-bold;
         }
         // list of attributions/licenses


### PR DESCRIPTION
## What this PR does

- Fixes CSS for styling shelfmark links the same as spans in the image permissions section