### PR TITLE
Separate date and calendar with comma when needed (#779)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -537,9 +537,12 @@ class Document(ModelIndexable):
         """Generate formatted display for the document's original/historical date"""
         # separate with comma if both date and calendar are present, else just return whichever is present
         # TODO: remove conditional once validation is implemented, since one will never be present alone
-        return ", ".join([v for v in [self.doc_date_original, self.get_doc_date_calendar_display()] if v])
-
-            [self.doc_date_original, self.get_doc_date_calendar_display()]
+        return ", ".join(
+            [
+                v
+                for v in [self.doc_date_original, self.get_doc_date_calendar_display()]
+                if v
+            ]
         ).strip()
 
     @property

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -535,7 +535,14 @@ class Document(ModelIndexable):
     @property
     def original_date(self):
         """Generate formatted display for the document's original/historical date"""
-        return " ".join(
+        # separate with comma if both date and calendar are present, else just return whichever is present
+        # TODO: remove conditional once validation is implemented, since one will never be present alone
+        separator = (
+            ", "
+            if self.doc_date_original and self.get_doc_date_calendar_display()
+            else ""
+        )
+        return separator.join(
             [self.doc_date_original, self.get_doc_date_calendar_display()]
         ).strip()
 

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -537,12 +537,8 @@ class Document(ModelIndexable):
         """Generate formatted display for the document's original/historical date"""
         # separate with comma if both date and calendar are present, else just return whichever is present
         # TODO: remove conditional once validation is implemented, since one will never be present alone
-        separator = (
-            ", "
-            if self.doc_date_original and self.get_doc_date_calendar_display()
-            else ""
-        )
-        return separator.join(
+        return ", ".join([v for v in [self.doc_date_original, self.get_doc_date_calendar_display()] if v])
+
             [self.doc_date_original, self.get_doc_date_calendar_display()]
         ).strip()
 

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -447,7 +447,7 @@ class TestDocument:
         doc = Document.objects.create(
             doc_date_original="507", doc_date_calendar=Document.CALENDAR_HIJRI
         )
-        assert doc.original_date == "507 Hijrī"
+        assert doc.original_date == "507, Hijrī"
         # with no calendar, just display the date
         doc.doc_date_calendar = ""
         assert doc.original_date == "507"
@@ -462,7 +462,7 @@ class TestDocument:
         assert doc.document_date == doc.original_date
         # should wrap standard date in parentheses and add CE
         doc.doc_date_standard = "1113/14"
-        assert doc.document_date == "507 Hijrī (1113/14 CE)"
+        assert doc.document_date == "507, Hijrī (1113/14 CE)"
         # should return standard date only, no parentheses
         doc.doc_date_original = ""
         doc.doc_date_calendar = ""


### PR DESCRIPTION
## What this PR does

- Per #779:
  - Adds a comma between original date and calendar name

## Questions

- Does this make sense? I wanted to make the function as simple as possible while allowing either original date or calendar name to be blank, but it still reads a bit weird.