### PR TITLE
Implement sort by shelfmark (#807)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -159,10 +159,8 @@ class DocumentSearchForm(forms.Form):
         ("scholarship_desc", _("Scholarship Records (Most–Least)")),
         # Translators: label for ascending sort by number of scholarship records
         ("scholarship_asc", _("Scholarship Records (Least–Most)")),
-        # Translators: label for ascending sort by shelfmark
-        ("shelfmark_asc", ("Shelfmark (A-Z)")),
-        # Translators: label for descending sort by shelfmark
-        ("shelfmark_desc", ("Shelfmark (Z-A)")),
+        # Translators: label for alphabetical sort by shelfmark
+        ("shelfmark", _("Shelfmark (A-Z)")),
     ]
     # NOTE: adding sort options and filters here to populate strings for translation;
     # this functionality is not yet implemented, but these translation strings

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -505,20 +505,12 @@ class TestDocumentSearchView:
         docsearch_view = DocumentSearchView()
         docsearch_view.request = Mock()
         # sort by shelfmark asc
-        docsearch_view.request.GET = {"sort": "shelfmark_asc"}
+        docsearch_view.request.GET = {"sort": "shelfmark"}
         qs = docsearch_view.get_queryset()
         # should return document with shelfmark starting with C first
         assert (
             qs[0]["pgpid"] == document.id
         ), "document with shelfmark CUL Add.2586 returned first"
-
-        # sort by shelfmark desc
-        docsearch_view.request.GET = {"sort": "shelfmark_desc"}
-        qs = docsearch_view.get_queryset()
-        # should return document with shelfmark starting with T first
-        assert (
-            qs[0]["pgpid"] == doc2.id
-        ), "document with shelfmark T-S 16.377 returned first"
 
     def test_doctype_filter(self, document, join, empty_solr):
         """Integration test for document type filter"""

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -47,8 +47,7 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
         "relevance": "-score",
         "scholarship_desc": "-scholarship_count_i",
         "scholarship_asc": "scholarship_count_i",
-        "shelfmark_asc": "shelfmark_s",
-        "shelfmark_desc": "-shelfmark_s",
+        "shelfmark": "shelfmark_s",
     }
 
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
## What this PR does

- Per #807:
  - Implements sort by shelfmark (not natural sort) ~~ascending and descending~~

## Questions

- Do we need descending or just ascending?
- I guess right now we're using the dynamic field type `*_s` for shelfmark. For natural sort, am I correct that we'd need to define another `fieldType` like the [one from the gist](https://gist.github.com/peaeater/0b3473e7457dbd4b527e) and use that instead? And would we want anything other than "Left-pad numbers with zeroes" and "Left-trim zeroes to produce 6 digit numbers"? I think I can accomplish that, though not terribly confident in my solr config skills!