### PR TITLE
Shelfmark override revisions (#154)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -185,7 +185,7 @@ class DocumentAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     list_display = (
         "id",
         "needs_review",  # disabled by default with css
-        "shelfmark",
+        "view_shelfmark",
         "description",
         "doctype",
         "all_tags",
@@ -209,6 +209,13 @@ class DocumentAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     save_as = True
     # display unset document type as Unknown
     empty_value_display = "Unknown"
+
+    @admin.display(
+        description="Shelfmark",
+    )
+    def view_shelfmark(self, obj):
+        """Display shelfmark override as shelfmark in list when available"""
+        return obj.shelfmark_override or obj.shelfmark
 
     # customize old pgpid display so unset does not show up as "Unknown"
     @admin.display(

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -510,7 +510,7 @@ class Document(ModelIndexable):
         # ordering = [Least('textblock__fragment__shelfmark')]
 
     def __str__(self):
-        return f"{self.shelfmark or '??'} (PGPID {self.id or '??'})"
+        return f"{self.shelfmark_override or self.shelfmark or '??'} (PGPID {self.id or '??'})"
 
     @staticmethod
     def get_by_any_pgpid(pgpid):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -524,7 +524,7 @@ class Document(ModelIndexable):
         """shelfmarks for associated fragments"""
         # access via textblock so we follow specified order,
         # use dict keys to ensure unique
-        return self.shelfmark_override or " + ".join(
+        return " + ".join(
             dict.fromkeys(
                 block.fragment.shelfmark
                 for block in self.textblock_set.all()
@@ -793,8 +793,9 @@ class Document(ModelIndexable):
                 "description_t": strip_tags(self.description_en),
                 "notes_t": self.notes or None,
                 "needs_review_t": self.needs_review or None,
-                # index shelfmark display as a string
+                # index shelfmark display (full and override) as a string
                 "shelfmark_s": self.shelfmark,
+                "shelfmark_override_s": self.shelfmark_override,
                 # index individual shelfmarks for search
                 "fragment_shelfmark_ss": [f.shelfmark for f in fragments],
                 # library/collection possibly redundant?

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -18,7 +18,8 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "id": "id",  # needed to match results with highlighting
         "type": "type_s",
         "status": "status_s",
-        "shelfmark": "shelfmark_s",  # string version for display
+        "shelfmark": "shelfmark_s",  # full string version for metadata display
+        "shelfmark_override": "shelfmark_override_s",  # override string version for title display
         "collection": "collection_ss",
         "tags": "tags_ss_lower",
         "description": "description_txt_ens",  # use stemmed version for field search & highlight

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,5 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark" data-action="click->text#copy">{{ document.shelfmark|shelfmark_wrap }}</span>
+    <span class="shelfmark" data-action="click->text#copy">{{ document.shelfmark_override|default:document.shelfmark|shelfmark_wrap }}</span>
 </span>

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,6 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark" data-action="click->text#copy">{{ document.shelfmark_override|default:document.shelfmark|shelfmark_wrap }}</span>
+    {% firstof document.shelfmark_override document.shelfmark as shelfmark %}
+    <span class="shelfmark" data-action="click->text#copy">{{ shelfmark|shelfmark_wrap }}</span>
 </span>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -10,7 +10,8 @@
             <h2 class="title">
                 {# type and shelfmark #}
                 <span class="doctype">{{ document.type }}</span>
-                <span class="shelfmark">{{ document.shelfmark_override|default:document.shelfmark|shelfmark_wrap }}</span>
+                {% firstof document.shelfmark_override document.shelfmark as shelfmark %}
+                <span class="shelfmark">{{ shelfmark|shelfmark_wrap }}</span>
             </h2>
 
             {# metadata #}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -10,7 +10,7 @@
             <h2 class="title">
                 {# type and shelfmark #}
                 <span class="doctype">{{ document.type }}</span>
-                <span class="shelfmark">{{ document.shelfmark|shelfmark_wrap }}</span>
+                <span class="shelfmark">{{ document.shelfmark_override|default:document.shelfmark|shelfmark_wrap }}</span>
             </h2>
 
             {# metadata #}

--- a/geniza/corpus/tests/conftest.py
+++ b/geniza/corpus/tests/conftest.py
@@ -47,6 +47,7 @@ def make_document(fragment):
     """A real legal document from the PGP."""
     doc = Document.objects.create(
         id=3951,
+        shelfmark_override="Foo 1-34",
         description_en="""Deed of sale in which a father sells to his son a quarter
          of the apartment belonging to him in a house in the al- Mu'tamid
          passage of the Tujib quarter for seventeen dinars. Dated 1233.

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -299,6 +299,14 @@ class TestDocumentAdmin:
             assert "description" in headers
             assert "needs_review" in headers
 
+    def test_view_shelfmark(self, document, join):
+        """should return shelfmark override when present, otherwise shelfmark"""
+        doc_admin = DocumentAdmin(model=Document, admin_site=admin.site)
+        # should display shelfmark for a document with no override
+        assert doc_admin.view_shelfmark(join) == join.shelfmark
+        # should display shelfmark override for a document with one
+        assert doc_admin.view_shelfmark(document) == document.shelfmark_override
+
     def test_view_old_pgpids(self):
         doc_admin = DocumentAdmin(model=Document, admin_site=admin.site)
         obj = Document()

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -428,11 +428,6 @@ class TestDocument:
         # ensure that uncertain shelfmarks are not included in str
         assert doc2.shelfmark == "%s + %s" % (frag2.shelfmark, frag.shelfmark)
 
-    def test_shelfmark_override(self, document):
-        override = "Foo 1-34"
-        document.shelfmark_override = override
-        assert document.shelfmark == override
-
     def test_str(self):
         frag = Fragment.objects.create(shelfmark="Or.1081 2.25")
         doc = Document.objects.create()
@@ -693,6 +688,7 @@ class TestDocument:
         assert index_data["notes_t"] is None  # no notes
         assert index_data["needs_review_t"] is None  # no review notes
         assert index_data["shelfmark_s"] == document.shelfmark
+        assert index_data["shelfmark_override_s"] == document.shelfmark_override
         for frag in document.fragments.all():
             assert frag.shelfmark in index_data["fragment_shelfmark_ss"]
         for tag in document.tags.all():

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -151,6 +151,8 @@
 
   <copyField source="shelfmark_s" dest="shelfmark_t" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_textnum" maxChars="30000" />
+  <copyField source="shelfmark_override_s" dest="shelfmark_t" maxChars="30000" />
+  <copyField source="shelfmark_override_s" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_t" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -741,6 +741,7 @@
         collection_ss
         shelfmark_t^80
         shelfmark_s^100
+        shelfmark_override_s^90
         fragment_shelfmark_ss^50
         shelfmark_textnum^140
         tags_t
@@ -764,6 +765,7 @@
         type_s
         shelfmark_t
         shelfmark_s
+        shelfmark_override_s
         fragment_shelfmark_ss^50
         shelfmark_textnum
         tags_t


### PR DESCRIPTION
## What this PR does

- Per https://github.com/Princeton-CDH/geniza/issues/154#issuecomment-1110228879:
  - Only display shelfmark override as a title and keep as a searchable field, but display the full list of shelfmarks on the document detail view
  - Display shelfmark override when available in list view and form title for documents in the admin interface

## Questions

- Is it redundant to index both `shelfmark` and `fragment_shelfmark` now? I know we at least need to index the individual shelfmarks for searching, and to index the override for searching + displaying in the search results page, but not sure if we need to index the joined string that will only appear on the detail view.