### PR TITLE
Revise logic for when shelfmark override is displayed

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -185,7 +185,7 @@ class DocumentAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     list_display = (
         "id",
         "needs_review",  # disabled by default with css
-        "shelfmark",
+        "label",  #  = combined shelfmark or shelfmark override
         "description",
         "doctype",
         "all_tags",

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -185,7 +185,7 @@ class DocumentAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     list_display = (
         "id",
         "needs_review",  # disabled by default with css
-        "label",  #  = combined shelfmark or shelfmark override
+        "shelfmark_display",  #  = combined shelfmark or shelfmark override
         "description",
         "doctype",
         "all_tags",

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -510,7 +510,7 @@ class Document(ModelIndexable):
         # ordering = [Least('textblock__fragment__shelfmark')]
 
     def __str__(self):
-        return f"{self.label or '??'} (PGPID {self.id or '??'})"
+        return f"{self.shelfmark_display or '??'} (PGPID {self.id or '??'})"
 
     @staticmethod
     def get_by_any_pgpid(pgpid):
@@ -534,7 +534,7 @@ class Document(ModelIndexable):
 
     @property
     @admin.display(description="Shelfmark")
-    def label(self):
+    def shelfmark_display(self):
         """Label for this document; by default, based on the combined shelfmarks from all certain
         associated fragments; uses :attr:`shelfmark_override` if set"""
         return self.shelfmark_override or self.shelfmark
@@ -688,7 +688,7 @@ class Document(ModelIndexable):
     @property
     def title(self):
         """Short title for identifying the document, e.g. via search."""
-        return f"{self.doctype or _('Unknown type')}: {self.label or '??'}"
+        return f"{self.doctype or _('Unknown type')}: {self.shelfmark_display or '??'}"
 
     def editions(self):
         """All footnotes for this document where the document relation includes
@@ -801,7 +801,7 @@ class Document(ModelIndexable):
                 "notes_t": self.notes or None,
                 "needs_review_t": self.needs_review or None,
                 # index shelfmark label as a string (combined shelfmark OR shelfmark override)
-                "shelfmark_s": self.label,
+                "shelfmark_s": self.shelfmark_display,
                 # index individual shelfmarks for search (includes uncertain fragments)
                 "fragment_shelfmark_ss": [f.shelfmark for f in fragments],
                 # library/collection possibly redundant?

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,5 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark" data-action="click->text#copy">{{ document.shelfmark|shelfmark_wrap }}</span>
+    <span class="shelfmark" data-action="click->text#copy">{{ document.label|shelfmark_wrap }}</span>
 </span>

--- a/geniza/corpus/templates/corpus/snippets/document_header.html
+++ b/geniza/corpus/templates/corpus/snippets/document_header.html
@@ -16,5 +16,5 @@
     {# Translators: Default label when document does not have a type #}
     {% translate 'Unknown type' as unknown_type %}
     <span class="doctype">{{ document.doctype|default:unknown_type }}</span>
-    <span class="shelfmark" data-action="click->text#copy">{{ document.label|shelfmark_wrap }}</span>
+    <span class="shelfmark" data-action="click->text#copy">{{ document.shelfmark_display|shelfmark_wrap }}</span>
 </span>

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -429,10 +429,10 @@ class TestDocument:
         assert doc2.shelfmark == "%s + %s" % (frag2.shelfmark, frag.shelfmark)
 
     def test_shelfmark_override(self, document):
-        assert document.label == document.shelfmark
+        assert document.shelfmark_display == document.shelfmark
         override = "Foo 1-34"
         document.shelfmark_override = override
-        assert document.label == override
+        assert document.shelfmark_display == override
 
     def test_str(self):
         frag = Fragment.objects.create(shelfmark="Or.1081 2.25")

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -429,9 +429,10 @@ class TestDocument:
         assert doc2.shelfmark == "%s + %s" % (frag2.shelfmark, frag.shelfmark)
 
     def test_shelfmark_override(self, document):
+        assert document.label == document.shelfmark
         override = "Foo 1-34"
         document.shelfmark_override = override
-        assert document.shelfmark == override
+        assert document.label == override
 
     def test_str(self):
         frag = Fragment.objects.create(shelfmark="Or.1081 2.25")


### PR DESCRIPTION
changes:
- implemented a `label` property that displays combined shelfmark or shelfmark override if set
- use the new label field for indexing shelfmark in solr for display
- label is displayed in search results, document title, document metadata, admin document change list
- actual shelfmark is displayed in metadata and shelfmark display field on document change form

question:
Is `label` confusing since we already have a `title` property? maybe `shelfmark_label` ? `shelfmark_display` ?