### PR TITLE
Implement basic solution for displaying IIIF logos (#802)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_image_rights.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_rights.html
@@ -8,9 +8,7 @@
             {% if fragment.iiif_url %}
                 <li class="fragment-permissions">
                     {% with fragment.url|yesno:"a,span" as tag %}
-                        <{{ tag }} class="shelfmark"{% if tag == "a" %} href="{{ fragment.url }}" target="_blank"{% endif %}>
-                        {{ fragment.shelfmark }}
-                        </{{ tag }}>:
+                        <{{ tag }} class="shelfmark"{% if tag == "a" %} href="{{ fragment.url }}" target="_blank"{% endif %}>{{ fragment.shelfmark }}</{{ tag }}>:
                     {% endwith %}
                     {{ fragment.attribution|default_if_none:"" }}
                     {% if fragment.manifest.license %}
@@ -22,4 +20,18 @@
             {% endif %}
         {% endfor %}
     </ul>
+    <ul class="logos">
+        {% for fragment in document.fragments.all %}
+            {% if fragment.manifest %}
+                {% ifchanged fragment.manifest.logo %}
+                    <li>
+                        {# Translators: Accessibilty label for logos of IIIF image providers #}
+                        {% translate 'Logo for image provider' as alt_text %}
+                        <img src="{{ fragment.manifest.logo }}" alt="{{ alt_text }}" width="32" height="32" />
+                    </li>
+                {% endifchanged %}
+            {% endif %}
+        {% endfor %}
+    </ul>
+
 </details>

--- a/geniza/corpus/templates/corpus/snippets/document_image_rights.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_rights.html
@@ -20,17 +20,12 @@
             {% endif %}
         {% endfor %}
     </ul>
+    {% regroup document.fragments.all by manifest.logo as logos_list %}
     <ul class="logos">
-        {% for fragment in document.fragments.all %}
-            {% if fragment.manifest %}
-                {% ifchanged fragment.manifest.logo %}
-                    <li>
-                        {# Translators: Accessibilty label for logos of IIIF image providers #}
-                        {% translate 'Logo for image provider' as alt_text %}
-                        <img src="{{ fragment.manifest.logo }}" alt="{{ alt_text }}" width="32" height="32" loading="lazy" />
-                    </li>
-                {% endifchanged %}
-            {% endif %}
+        {% for logo in logos_list %}
+            <li>
+                <img src="{{ logo.grouper }}" alt="" aria-role="presentation" width="32" height="32" loading="lazy" />
+            </li>
         {% endfor %}
     </ul>
 

--- a/geniza/corpus/templates/corpus/snippets/document_image_rights.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_rights.html
@@ -24,7 +24,7 @@
     <ul class="logos">
         {% for logo in logos_list %}
             <li>
-                <img src="{{ logo.grouper }}" alt="" aria-role="presentation" width="32" height="32" loading="lazy" />
+                <img src="{{ logo.grouper }}" alt="" role="presentation" width="32" height="32" loading="lazy" />
             </li>
         {% endfor %}
     </ul>

--- a/geniza/corpus/templates/corpus/snippets/document_image_rights.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_rights.html
@@ -27,7 +27,7 @@
                     <li>
                         {# Translators: Accessibilty label for logos of IIIF image providers #}
                         {% translate 'Logo for image provider' as alt_text %}
-                        <img src="{{ fragment.manifest.logo }}" alt="{{ alt_text }}" width="32" height="32" />
+                        <img src="{{ fragment.manifest.logo }}" alt="{{ alt_text }}" width="32" height="32" loading="lazy" />
                     </li>
                 {% endifchanged %}
             {% endif %}

--- a/geniza/corpus/templates/corpus/snippets/document_image_rights.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_rights.html
@@ -24,7 +24,7 @@
     <ul class="logos">
         {% for logo in logos_list %}
             <li>
-                <img src="{{ logo.grouper }}" alt="" role="presentation" width="32" height="32" loading="lazy" />
+                <img src="{{ logo.grouper }}" alt="" role="presentation" width="64" height="64" loading="lazy" />
             </li>
         {% endfor %}
     </ul>

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -185,8 +185,8 @@
                 margin-top: spacing.$spacing-sm;
             }
             li img {
-                width: 32px;
-                height: 32px;
+                width: 4rem;
+                height: 4rem;
             }
             li + li {
                 margin-left: spacing.$spacing-xs;

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -181,7 +181,9 @@
         ul.logos {
             display: flex;
             flex-flow: row;
-            margin-top: spacing.$spacing-sm;
+            &:not(:empty) {
+                margin-top: spacing.$spacing-sm;
+            }
             li img {
                 width: 32px;
                 height: 32px;

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -177,6 +177,19 @@
                 vertical-align: text-top;
             }
         }
+        // provider logos (interim solution)
+        ul.logos {
+            display: flex;
+            flex-flow: row;
+            margin-top: spacing.$spacing-sm;
+            li img {
+                width: 32px;
+                height: 32px;
+            }
+            li + li {
+                margin-left: spacing.$spacing-xs;
+            }
+        }
         // spacing tweaks for desktop
         @include breakpoints.for-tablet-landscape-up {
             margin: 50px 0 0;


### PR DESCRIPTION
## What this PR does

- Per #802:
  - Displays unique logos in a list below the list of fragment attributions, with preliminary/basic styling
- Prevents an extra space from being added between the shelfmark and colon in the image permissions section

## Questions

- What do you make of the `alt` text? I think using the name of the organization would be preferable (and would be good for a `title` attribute as well), but I couldn't figure out a way to get that from the manifest.
- Using `ifchanged` is sufficient to guarantee uniqueness for all of my local data, but it somewhat depends on the order of fragments retrieved. Is there some way we should order the fragments first, or should the uniqueness not be handled in the template?