### PR TITLE
Adjust RTL search results page tags/transcription and remove "PGP ID" translation (#769)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -17,7 +17,8 @@
             <dl class="metadata">
                 <dt>{% translate 'Input date' %}</dt>
                 <dd>{{ document.input_year|default:'unknown' }}</dd>
-                <dt>{% translate 'PGP ID' %}</dt>
+                {# NOTE: Intentionally left untranslated #}
+                <dt>PGP ID</dt>
                 <dd>{{ document.pgpid }}</dd>
             </dl>
 

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -367,6 +367,10 @@ html[dir="rtl"] .search-result {
                 }
             }
         }
+        // document tags
+        ul.tags {
+            align-self: flex-end;
+        }
     }
     // document images
     ul.images {

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -419,4 +419,7 @@ html[dir="rtl"] .search-result {
             right: 0;
         }
     }
+    .transcription {
+        align-self: flex-start;
+    }
 }

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -369,6 +369,7 @@ html[dir="rtl"] .search-result {
         }
         // document tags
         ul.tags {
+            text-align: left;
             align-self: flex-end;
         }
     }

--- a/sitemedia/scss/components/_tag.scss
+++ b/sitemedia/scss/components/_tag.scss
@@ -30,10 +30,9 @@
 // tweaks for RTL tags for hebrew, arabic
 html[dir="rtl"] .tags li {
     // spacing between tags
-    margin-right: 0;
-    margin-left: 0.5rem;
-    &:last-of-type {
-        margin-left: 0;
+    margin-right: 0.5rem;
+    &:first-of-type {
+        margin-right: 0;
     }
     &::before {
         content: "";

--- a/sitemedia/scss/components/_tag.scss
+++ b/sitemedia/scss/components/_tag.scss
@@ -35,4 +35,14 @@ html[dir="rtl"] .tags li {
     &:last-of-type {
         margin-left: 0;
     }
+    &::before {
+        content: "";
+    }
+    &::after {
+        display: inline-block;
+        content: "#";
+    }
+    &.more::after {
+        content: "";
+    }
 }


### PR DESCRIPTION
## What this PR does

- Per #769:
  - Removes "PGP ID" translation in search results
  - Aligns transcription to flex-start in RTL search results, since they are RTL content and should be right-justified
  - Aligns tags according to design