### PR TITLE
filter and sort documents by date

### DIFF
--- a/geniza/common/fields.py
+++ b/geniza/common/fields.py
@@ -1,3 +1,6 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.core.validators import RegexValidator
 from django.db import models
 from natsort import natsort_keygen, ns
 
@@ -40,3 +43,119 @@ class NaturalSortField(models.CharField):
             return f"{val:06}"  # 6 digits, leading zeros
         # no adjustment needed for strings
         return val
+
+
+# RangeWidget and RangeField adapted  mep-django
+
+
+class RangeWidget(forms.MultiWidget):
+    """date range widget, for two numeric inputs"""
+
+    #: template to use to render range multiwidget
+    # (based on multiwidget, but adds "to" between dates)
+    template_name = "common/widgets/rangewidget.html"
+
+    def __init__(self, *args, **kwargs):
+        widgets = [
+            forms.NumberInput(attrs={"aria-label": "start"}),
+            forms.NumberInput(attrs={"aria-label": "end"}),
+        ]
+        super().__init__(widgets, *args, **kwargs)
+
+    def decompress(self, value):
+        if value:
+            return [int(val) if val else None for val in value]
+        return [None, None]
+
+
+class RangeField(forms.MultiValueField):
+    """Date range field, for two numeric inputs. Compresses to a tuple of
+    two values for the start and end of the range; tuple values set to
+    None for no input."""
+
+    widget = RangeWidget
+
+    def __init__(self, *args, **kwargs):
+        fields = (
+            forms.IntegerField(
+                error_messages={"invalid": "Enter a number"},
+                validators=[
+                    RegexValidator(r"^[0-9]*$", "Enter a valid number."),
+                ],
+                required=False,
+            ),
+            forms.IntegerField(
+                error_messages={"invalid": "Enter a number"},
+                validators=[
+                    RegexValidator(r"^[0-9]*$", "Enter a valid number."),
+                ],
+                required=False,
+            ),
+        )
+        kwargs["fields"] = fields
+        super().__init__(require_all_fields=False, *args, **kwargs)
+
+    def compress(self, data_list):
+        """Compress into a single value; returns a two-tuple of range end,
+        start."""
+
+        # If neither values is set, return None
+        if not any(data_list):
+            return None
+
+        # if both values are set and the first is greater than the second,
+        # raise a validation error
+        if all(data_list) and len(data_list) == 2 and data_list[0] > data_list[1]:
+            raise ValidationError(
+                "Invalid range (%s - %s)" % (data_list[0], data_list[1])
+            )
+
+        return (data_list[0], data_list[1])
+
+    def set_min_max(self, min_val, max_val):
+        """Set a min and max value for :class:`RangeWidget` attributes
+        and placeholders.
+
+        :param min_value: minimum value to set on widget
+        :type min_value: int
+        :param max_value: maximum value to set on widget
+        :type max_value: int
+        :rtype: None
+        """
+        start_widget, end_widget = self.widget.widgets
+        # set placeholders for widgets individually
+        start_widget.attrs["placeholder"] = min_val
+        end_widget.attrs["placeholder"] = max_val
+        # valid min and max for both via multiwidget
+        self.widget.attrs.update({"min": min_val, "max": max_val})
+
+
+class RangeForm(forms.Form):
+    """Form mixin to initialize min/max values for range fields."""
+
+    def set_range_minmax(self, range_minmax):
+        """Set the min, max, and placeholder values for all
+        :class:`~mep.common.forms.RangeField` instances.
+
+        :param range_minmax: a dictionary with form fields as key names and
+            tuples of min and max integers as values.
+        :type range_minmax: dict
+
+        :rtype: None
+        """
+        for field_name, min_max in range_minmax.items():
+            self.fields[field_name].set_min_max(min_max[0], min_max[1])
+
+    def __init__(self, data=None, *args, **kwargs):
+        """
+        Override to set choices dynamically and configure min-max range values
+        based on form kwargs.
+        """
+        # pop range_minmax out of kwargs to avoid clashing
+        # with django args
+        range_minmax = kwargs.pop("range_minmax", {})
+
+        super().__init__(data=data, *args, **kwargs)
+
+        # call function to set min_max and placeholders
+        self.set_range_minmax(range_minmax)

--- a/geniza/common/templates/common/widgets/rangewidget.html
+++ b/geniza/common/templates/common/widgets/rangewidget.html
@@ -1,0 +1,4 @@
+{% comment %}
+Template for RangeWidget with numeric start and stop inputs.
+{% endcomment %}
+<div class="inputs">{% spaceless %}{% for subwidget in widget.subwidgets %}{% include subwidget.template_name with widget=subwidget %}{% if forloop.first %} <span class="sr-only">to</span>{% endif %}{% endfor %}{% endspaceless %}</div>

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -186,13 +186,15 @@ class DocumentDateMixin(models.Model):
         """
         Return a Solr date range for the document's standardized date.
         """
-        if self.doc_date_standard:
+        # only convert if standardized document date is set and passes validation
+        if self.doc_date_standard and self.re_date_format.match(self.doc_date_standard):
             date_parts = self.doc_date_standard.split("/")
+            num_parts = len(date_parts)
             # if there's only one date, return it as a single date range
-            if len(date_parts) == 1:
+            if num_parts == 1:
                 return date_parts[0]
-            # if there's more than one date, return it as a range
-            # TODO: do we need to validate to make sure Solr can handle this?
+
+            # if there's more than one date, return as a range
             return "[%s TO %s]" % tuple(date_parts)
 
 

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -75,6 +75,14 @@ class PartialDate:
     def __repr__(self) -> str:
         return f"PartialDate({self.isoformat()})"
 
+    def __eq__(self, other):
+        if not isinstance(other, PartialDate):
+            # don't attempt to compare against unrelated types
+            return NotImplemented
+
+        # equivalent if date and precision are the same
+        return self.date == other.date and self.precision == other.precision
+
     def isoformat(self, mode="min", fmt="precision"):
         """Display partial date in ISO format. By default, will display
         YYYY, YYYY-MM, or YYYY-MM-DD according to known precision. If min

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -182,6 +182,19 @@ class DocumentDateMixin(models.Model):
                 self.doc_date_standard = converted_date
             return converted_date
 
+    def solr_date_range(self):
+        """
+        Return a Solr date range for the document's standardized date.
+        """
+        if self.doc_date_standard:
+            date_parts = self.doc_date_standard.split("/")
+            # if there's only one date, return it as a single date range
+            if len(date_parts) == 1:
+                return date_parts[0]
+            # if there's more than one date, return it as a range
+            # TODO: do we need to validate to make sure Solr can handle this?
+            return "[%s TO %s]" % tuple(date_parts)
+
 
 # Julian Thursday, 4 October 1582, being followed by Gregorian Friday, 15 October
 # cut off between gregorian/julian dates, in julian days

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -5,6 +5,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
+from geniza.common.fields import RangeField, RangeWidget
 from geniza.corpus.models import Document
 
 
@@ -195,6 +196,10 @@ class DocumentSearchForm(forms.Form):
         ],
         required=False,
         widget=RadioSelectWithDisabled,
+    )
+    # Translators: label for document date range form filter
+    document_dates = RangeField(
+        label=_("Document Dates"), required=False, widget=RangeWidget(attrs={"size": 4})
     )
 
     doctype = FacetChoiceField(

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -192,7 +192,9 @@ class DocumentSearchForm(RangeForm):
     )
     # Translators: label for filter documents by date range
     document_dates = RangeField(
-        label=_("Document Dates"), required=False, widget=RangeWidget(attrs={"size": 4})
+        label=_("Document Dates"),
+        required=False,
+        widget=RangeWidget(attrs={"size": 4, "data-action": "input->search#update"}),
     )
 
     doctype = FacetChoiceField(

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -5,7 +5,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
-from geniza.common.fields import RangeField, RangeWidget
+from geniza.common.fields import RangeField, RangeForm, RangeWidget
 from geniza.corpus.models import Document
 
 
@@ -135,7 +135,7 @@ class BooleanFacetField(FacetFieldMixin, forms.BooleanField):
         self.widget.facet_counts = facet_dict
 
 
-class DocumentSearchForm(forms.Form):
+class DocumentSearchForm(RangeForm):
 
     q = forms.CharField(
         label="Keyword or Phrase",
@@ -156,6 +156,10 @@ class DocumentSearchForm(forms.Form):
         ("relevance", _("Relevance")),
         # Translators: label for sort in random order
         ("random", _("Random")),
+        # Translators: label for sort by document date (most recent first)
+        ("docdate_desc", _("Document Date (Latest-Earliest)")),
+        # Translators: label for sort by document date (oldest first)
+        ("docdate_asc", _("Document Date (Earliest-Latest)")),
         # Translators: label for sort by document input date (most recent first)
         ("input_date_desc", _("Input Date (Latest-Earliest)")),
         # Translators: label for sort by document input date (oldest first)
@@ -167,17 +171,6 @@ class DocumentSearchForm(forms.Form):
         # Translators: label for alphabetical sort by shelfmark
         ("shelfmark", _("Shelfmark (A-Z)")),
     ]
-    # NOTE: adding sort options and filters here to populate strings for translation;
-    # this functionality is not yet implemented, but these translation strings
-    # should be used when it is
-    planned_sort_choices = [
-        # Translators: label for sort by document date (most recent first)
-        ("docdate", _("Document Date (Latest-Earliest)")),
-        # Translators: label for sort by document date (oldest first)
-        ("docdate2", _("Document Date (Earliest-Latest)")),
-    ]
-    # Translators: label for filter documents by date
-    _("Document Dates")
     # Translators: label for start year when filtering by date range
     _("From year")
     # Translators: label for end year when filtering by date range
@@ -197,7 +190,7 @@ class DocumentSearchForm(forms.Form):
         required=False,
         widget=RadioSelectWithDisabled,
     )
-    # Translators: label for document date range form filter
+    # Translators: label for filter documents by date range
     document_dates = RangeField(
         label=_("Document Dates"), required=False, widget=RangeWidget(attrs={"size": 4})
     )

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -191,7 +191,7 @@ class DocumentSearchForm(RangeForm):
         widget=RadioSelectWithDisabled,
     )
     # Translators: label for filter documents by date range
-    document_dates = RangeField(
+    docdate = RangeField(
         label=_("Document Dates"),
         required=False,
         widget=RangeWidget(attrs={"size": 4, "data-action": "input->search#update"}),

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -768,7 +768,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                 # combined original/standard document date for display
                 "document_date_s": strip_tags(self.document_date) or None,
                 # date range for filtering
-                "date_dr": self.solr_date_range(),
+                "document_date_dr": self.solr_date_range(),
                 # start/end of document date or date range
                 "start_date_i": self.start_date.numeric_format()
                 if self.start_date

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -767,6 +767,8 @@ class Document(ModelIndexable, DocumentDateMixin):
                 "fragment_shelfmark_ss": [f.shelfmark for f in fragments],
                 # combined original/standard document date for display
                 "document_date_s": strip_tags(self.document_date) or None,
+                # date range for filtering
+                "document_date_dr": self.solr_date_range(),
                 # library/collection possibly redundant?
                 "collection_ss": [str(f.collection) for f in fragments],
                 "tags_ss_lower": [t.name for t in self.tags.all()],

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -768,7 +768,14 @@ class Document(ModelIndexable, DocumentDateMixin):
                 # combined original/standard document date for display
                 "document_date_s": strip_tags(self.document_date) or None,
                 # date range for filtering
-                "document_date_dr": self.solr_date_range(),
+                "date_dr": self.solr_date_range(),
+                # start/end of document date or date range
+                "start_date_i": self.start_date.numeric_format()
+                if self.start_date
+                else None,
+                "end_date_i": self.end_date.numeric_format(mode="max")
+                if self.end_date
+                else None,
                 # library/collection possibly redundant?
                 "collection_ss": [str(f.collection) for f in fragments],
                 "tags_ss_lower": [t.name for t in self.tags.all()],

--- a/geniza/corpus/sitemaps.py
+++ b/geniza/corpus/sitemaps.py
@@ -1,8 +1,4 @@
-from datetime import date
-from functools import cached_property
-
 from django.contrib.sitemaps import Sitemap
-from django.core import paginator
 from django.urls import reverse
 from parasolr.utils import solr_timestamp_to_datetime
 

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -29,10 +29,10 @@
                 <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>
                 {% translate "Filters" %}
             </a>
-            <label for="{{ form.document_dates.auto_id }}" class="date-range-label">
-                <span>{{ form.document_dates.label }}</span>
+            <label for="{{ form.docdate.auto_id }}" class="date-range-label">
+                <span>{{ form.docdate.label }}</span>
                 {# NOTE: stimulus action is configured via django widget attrs #}
-                {{ form.document_dates }}
+                {{ form.docdate }}
             </label>
             <label for="{{ form.has_image.auto_id }}">
                 {% render_field form.has_image data-action="search#update" %}

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -29,8 +29,8 @@
                 <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>
                 {% translate "Filters" %}
             </a>
-            <label for="{{ form.document_dates.auto_id }}">
-                {{ form.document_dates.label }}
+            <label for="{{ form.document_dates.auto_id }}" class="date-range-label">
+                <span>{{ form.document_dates.label }}</span>
                 {{ form.document_dates }}
             </label>
             <label for="{{ form.has_image.auto_id }}">

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -31,6 +31,7 @@
             </a>
             <label for="{{ form.document_dates.auto_id }}" class="date-range-label">
                 <span>{{ form.document_dates.label }}</span>
+                {# NOTE: stimulus action is configured via django widget attrs #}
                 {{ form.document_dates }}
             </label>
             <label for="{{ form.has_image.auto_id }}">

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -29,6 +29,10 @@
                 <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>
                 {% translate "Filters" %}
             </a>
+            <label for="{{ form.document_dates.auto_id }}">
+                {{ form.document_dates.label }}
+                {{ form.document_dates }}
+            </label>
             <label for="{{ form.has_image.auto_id }}">
                 {% render_field form.has_image data-action="search#update" %}
                 {{ form.has_image.label }}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -757,7 +757,7 @@ class TestDocument:
             id=123,
             doc_date_original="5 Elul 5567",
             doc_date_calendar=Calendar.ANNO_MUNDI,
-            doc_date_standard="September 8, 1807",
+            doc_date_standard="1807-09-08",
         )
         index_data = document.index_data()
         # should display form of the date without tags

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -252,6 +252,7 @@ class TestDocumentSearchView:
     def test_get_form_kwargs(self):
         docsearch_view = DocumentSearchView()
         docsearch_view.request = Mock()
+        docsearch_view.get_range_stats = Mock(return_value={})
         # no params
         docsearch_view.request.GET = {}
         assert docsearch_view.get_form_kwargs() == {
@@ -260,6 +261,7 @@ class TestDocumentSearchView:
             },
             "prefix": None,
             "data": {"sort": "random"},
+            "range_minmax": {},
         }
 
         # keyword search param
@@ -271,6 +273,7 @@ class TestDocumentSearchView:
                 "q": "contract",
                 "sort": "relevance",
             },
+            "range_minmax": {},
         }
 
         # sort search param
@@ -283,6 +286,7 @@ class TestDocumentSearchView:
             "data": {
                 "sort": "scholarship_desc",
             },
+            "range_minmax": {},
         }
 
         # keyword and sort search params
@@ -296,6 +300,7 @@ class TestDocumentSearchView:
                 "q": "contract",
                 "sort": "scholarship_desc",
             },
+            "range_minmax": {},
         }
 
     @pytest.mark.usefixtures("mock_solr_queryset")
@@ -312,6 +317,7 @@ class TestDocumentSearchView:
 
             # keyword search param
             docsearch_view.request.GET = {"q": "six apartments"}
+            docsearch_view.get_range_stats = Mock(return_value={})
             qs = docsearch_view.get_queryset()
 
             mock_queryset_cls.assert_called_with()
@@ -414,6 +420,7 @@ class TestDocumentSearchView:
             docsearch_view.queryset = mock_qs
             docsearch_view.object_list = mock_qs
             docsearch_view.request = rf.get("/documents/")
+            docsearch_view.get_range_stats = Mock(return_value={})
 
             context_data = docsearch_view.get_context_data()
             assert (

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -425,12 +425,19 @@ class TestDocumentSearchView:
             # convert integer date to year
             mock_queryset_cls.return_value.get_stats.return_value = {
                 "stats_fields": {
-                    "start_date_i": {"min": 10380101},
-                    "end_date_i": {"max": 10421231},
+                    "start_date_i": {"min": 10380101.0},
+                    "end_date_i": {"max": 10421231.0},
                 }
             }
             stats = docsearch_view.get_range_stats()
             assert stats == {"document_dates": (1038, 1042)}
+
+            # test three-digit year
+            mock_queryset_cls.return_value.get_stats.return_value["stats_fields"][
+                "start_date_i"
+            ]["min"] = 8430101.0
+            stats = docsearch_view.get_range_stats()
+            assert stats == {"document_dates": (843, 1042)}
 
     @pytest.mark.usefixtures("mock_solr_queryset")
     @patch("geniza.corpus.views.DocumentSearchView.get_queryset")

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -417,7 +417,7 @@ class TestDocumentSearchView:
 
             # should not error if solr returns none
             stats = docsearch_view.get_range_stats()
-            assert stats == {"document_dates": (None, None)}
+            assert stats == {"docdate": (None, None)}
             mock_queryset_cls.return_value.stats.assert_called_with(
                 "start_date_i", "end_date_i"
             )
@@ -430,14 +430,14 @@ class TestDocumentSearchView:
                 }
             }
             stats = docsearch_view.get_range_stats()
-            assert stats == {"document_dates": (1038, 1042)}
+            assert stats == {"docdate": (1038, 1042)}
 
             # test three-digit year
             mock_queryset_cls.return_value.get_stats.return_value["stats_fields"][
                 "start_date_i"
             ]["min"] = 8430101.0
             stats = docsearch_view.get_range_stats()
-            assert stats == {"document_dates": (843, 1042)}
+            assert stats == {"docdate": (843, 1042)}
 
     @pytest.mark.usefixtures("mock_solr_queryset")
     @patch("geniza.corpus.views.DocumentSearchView.get_queryset")
@@ -639,21 +639,21 @@ class TestDocumentSearchView:
         docsearch_view.request = Mock()
 
         # filter by date range after 1100
-        docsearch_view.request.GET = {"document_dates_0": 1100}
+        docsearch_view.request.GET = {"docdate_0": 1100}
         qs = docsearch_view.get_queryset()
         assert qs.count() == 1
         assert qs[0]["pgpid"] == join.id
 
         # filter by date range before 1050
-        docsearch_view.request.GET = {"document_dates_1": 1050}
+        docsearch_view.request.GET = {"docdate_1": 1050}
         qs = docsearch_view.get_queryset()
         assert qs.count() == 1
         assert qs[0]["pgpid"] == document.id
 
         # filter by date range between 1000 and 1100
         docsearch_view.request.GET = {
-            "document_dates_0": 1000,
-            "document_dates_1": 1100,
+            "dodate_0": 1000,
+            "docdate_1": 1100,
         }
         qs = docsearch_view.get_queryset()
         assert qs.count() == 1

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -111,6 +111,17 @@ class TestDocumentDateMixin:
         standardized = doc.standardize_date(update=True)
         assert doc.doc_date_standard == standardized
 
+    def test_solr_date_range(self):
+        doc = Document()
+        # no dates, returns none
+        assert doc.solr_date_range() is None
+        # single date returned as-is
+        doc.doc_date_standard = "1839-03-17"
+        assert doc.solr_date_range() == "1839-03-17"
+        # date range converted to solr format
+        doc.doc_date_standard = "1839-03-17/1840-03-04"
+        assert doc.solr_date_range() == "[1839-03-17 TO 1840-03-04]"
+
 
 # test hebrew date conversion
 def test_get_hebrew_month():

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -136,6 +136,28 @@ class TestDocumentDateMixin:
         doc.doc_date_standard = "94 CE"
         assert doc.solr_date_range() is None
 
+    def test_start_date(self):
+        doc = Document()
+        # no dates, returns none
+        assert doc.start_date is None
+        # single date returned as-is
+        doc.doc_date_standard = "1839-03-17"
+        assert doc.start_date == PartialDate("1839-03-17")
+        # start is beginning of date range
+        doc.doc_date_standard = "1839-03-17/1840-03-04"
+        assert doc.start_date == PartialDate("1839-03-17")
+
+    def test_end_date(self):
+        doc = Document()
+        # no dates, returns none
+        assert doc.end_date is None
+        # single date returned as-is
+        doc.doc_date_standard = "1839-03-17"
+        assert doc.end_date == PartialDate("1839-03-17")
+        # end is beginning of date range
+        doc.doc_date_standard = "1839-03-17/1840-03-04"
+        assert doc.end_date == PartialDate("1840-03-04")
+
 
 # test hebrew date conversion
 def test_get_hebrew_month():
@@ -238,6 +260,13 @@ class TestPartialDate:
 
     def test_repr(self):
         assert repr(PartialDate("1569-10")) == "PartialDate(1569-10)"
+
+    def test_eq(self):
+        assert PartialDate("1569-10") == PartialDate("1569-10")
+        assert PartialDate("1569") == PartialDate("1569")
+        assert PartialDate("1569-10") != PartialDate("1569")
+        assert PartialDate("1569-10") != PartialDate("1569-10-23")
+        assert PartialDate("1559-10-23") != PartialDate("1569-10-23")
 
     def test_isoformat(self):
         assert PartialDate("1569-10-23").isoformat() == "1569-10-23"

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -217,19 +217,52 @@ def test_convert_islamic_date():
     assert converted_date[1] == date(1050, 5, 25)
 
 
-def test_partialdate():
-    # single day
-    assert str(PartialDate("1569-10-23")) == "23 October, 1569"
+class TestPartialDate:
+    def test_partialdate_str(self):
+        # single day
+        assert str(PartialDate("1569-10-23")) == "23 October, 1569"
 
-    # month/year
-    assert str(PartialDate("1569-10")) == "October 1569"
+        # month/year
+        assert str(PartialDate("1569-10")) == "October 1569"
 
-    # year only
-    assert str(PartialDate("1569")) == "1569"
+        # year only
+        assert str(PartialDate("1569")) == "1569"
 
-    # raise value error for too many parts
-    with pytest.raises(ValueError):
-        PartialDate("1569-10-23-24")
+    def test_partialdate_init(self):
+        # raise value error for too many parts
+        with pytest.raises(ValueError):
+            PartialDate("1569-10-23-24")
 
-    with pytest.raises(ValueError):
-        PartialDate("1569--10-23")
+        with pytest.raises(ValueError):
+            PartialDate("1569--10-23")
+
+    def test_repr(self):
+        assert repr(PartialDate("1569-10")) == "PartialDate(1569-10)"
+
+    def test_isoformat(self):
+        assert PartialDate("1569-10-23").isoformat() == "1569-10-23"
+        assert PartialDate("1569-10").isoformat() == "1569-10"
+        assert PartialDate("1569").isoformat() == "1569"
+
+    def test_isoformat_min(self):
+        assert PartialDate("1569-10-23").isoformat("min", "iso") == "1569-10-23"
+        assert PartialDate("1569-10").isoformat("min", "iso") == "1569-10-01"
+        assert PartialDate("1569").isoformat("min", "iso") == "1569-01-01"
+
+    def test_isoformat_max(self):
+        assert PartialDate("1569-10-23").isoformat("max", "iso") == "1569-10-23"
+        assert PartialDate("1569-10").isoformat("max", "iso") == "1569-10-31"
+        assert PartialDate("1569").isoformat("max", "iso") == "1569-12-31"
+        # handle month-specific maxes
+        assert PartialDate("1569-02").isoformat("max", "iso") == "1569-02-28"
+
+    def test_numeric_format(self):
+        assert PartialDate("1569-10-23").numeric_format("min") == "15691023"
+        assert PartialDate("1569-06").numeric_format("min") == "15690601"
+        assert PartialDate("1569").numeric_format("min") == "15690101"
+
+        assert PartialDate("1569-10-23").numeric_format("max") == "15691023"
+        assert PartialDate("1569-10").numeric_format("max") == "15691031"
+        assert PartialDate("1569").numeric_format("max") == "15691231"
+        # handle month-specific maxes
+        assert PartialDate("1569-02").numeric_format("max") == "15690228"

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -122,6 +122,20 @@ class TestDocumentDateMixin:
         doc.doc_date_standard = "1839-03-17/1840-03-04"
         assert doc.solr_date_range() == "[1839-03-17 TO 1840-03-04]"
 
+        # invalid content should not error
+        doc.doc_date_standard = "1953/11/14"
+        assert doc.solr_date_range() is None
+        # invalid range format
+        doc.doc_date_standard = "1129/30"
+        assert doc.solr_date_range() is None
+
+        doc.doc_date_standard = "1129-01-01/1130"
+        assert doc.solr_date_range() == "[1129-01-01 TO 1130]"
+
+        # unparsable dates should not error
+        doc.doc_date_standard = "94 CE"
+        assert doc.solr_date_range() is None
+
 
 # test hebrew date conversion
 def test_get_hebrew_month():

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -102,7 +102,7 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
             # trim from the end to handle 3-digit years; includes .0 at end
             min_year = int(str(min_val)[:-6]) if min_val else None
             max_year = int(str(max_val)[:-6]) if max_val else None
-            return {"document_dates": (min_year, max_year)}
+            return {"docdate": (min_year, max_year)}
 
         return {}
 
@@ -198,9 +198,9 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
                 documents = documents.filter(has_discussion=True)
             if search_opts["has_translation"] == True:
                 documents = documents.filter(has_translation=True)
-            if search_opts["document_dates"]:
+            if search_opts["docdate"]:
                 # date range filter; returns tuple of value or None for open-ended range
-                start, end = search_opts["document_dates"]
+                start, end = search_opts["docdate"]
                 documents = documents.filter(
                     document_date_dr="[%s TO %s]" % (start or "*", end or "*")
                 )

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -99,8 +99,9 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
             min_val = stats["stats_fields"]["start_date_i"]["min"]
             max_val = stats["stats_fields"]["end_date_i"]["max"]
 
-            min_year = int(str(min_val)[:4]) if min_val else None
-            max_year = int(str(max_val)[:4]) if max_val else None
+            # trim from the end to handle 3-digit years; includes .0 at end
+            min_year = int(str(min_val)[:-6]) if min_val else None
+            max_year = int(str(max_val)[:-6]) if max_val else None
             return {"document_dates": (min_year, max_year)}
 
         return {}

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -92,7 +92,6 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
         :rtype: dict
         """
         stats = DocumentSolrQuerySet().stats("start_date_i", "end_date_i").get_stats()
-        print(stats)
         if stats.get("stats_fields"):
             # use minimum from start date and max from end date
             # - we're storing YYYYMMDD as 8-digit number for this we only want year

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -168,6 +168,12 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
                 documents = documents.filter(has_discussion=True)
             if search_opts["has_translation"] == True:
                 documents = documents.filter(has_translation=True)
+            if search_opts["document_dates"]:
+                # date range filter; returns tuple of value or None for open-ended range
+                start, end = search_opts["document_dates"]
+                documents = documents.filter(
+                    document_date_dr="[%s TO %s]" % (start or "*", end or "*")
+                )
 
         self.queryset = documents
 

--- a/sitemedia/scss/base/_colors.scss
+++ b/sitemedia/scss/base/_colors.scss
@@ -67,6 +67,8 @@ $off-white: #f7f7f7;
     // permalink icon
     --permalink-icon: #f7f7f7;
     --permalink-icon-bg: #3d3d3d;
+    // placeholder text for date input
+    --date-placeholder: #595959;
 }
 
 // Dark mode theme colors
@@ -119,6 +121,8 @@ $off-white: #f7f7f7;
     // permalink icon
     --permalink-icon: #3d3d3d;
     --permalink-icon-bg: #f7f7f7;
+    // placeholder text for date input
+    --date-placeholder: #ebebeb;
 }
 
 html {

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -329,7 +329,7 @@ main.search form {
             }
         }
         // all filter form inputs that are not nested within a details
-        & > label {
+        & > label:not(.date-range-label) {
             flex: 0 0 2.5rem;
             max-width: 100%;
             width: 100%;
@@ -384,6 +384,48 @@ main.search form {
             input:checked:active + span + span.count::after {
                 content: "\f0e8"; // phosphor check-circle icon
             }
+        }
+        // Date range label and input
+        & > label.date-range-label {
+            max-width: 100%;
+            width: 100%;
+            cursor: default;
+            span {
+                margin: 0 spacing.$spacing-sm;
+                @include breakpoints.for-tablet-landscape-up {
+                    margin: 0;
+                }
+            }
+            div.inputs {
+                display: flex;
+                flex-flow: column;
+                margin-top: spacing.$spacing-xs;
+                input[type="number"] {
+                    flex: 1 0 2.9375rem;
+                    max-width: 100%;
+                    width: 100%;
+                    @include typography.form-option;
+                    background-color: var(--background-light);
+                    color: var(--on-background-light);
+                    @include form-drop-shadow;
+                    border-left: none;
+                    border-right: none;
+                    border-top: 1px solid transparent;
+                    border-bottom: 1px solid var(--filter-border);
+                    padding: 0 spacing.$spacing-sm;
+                    @include breakpoints.for-tablet-landscape-up {
+                        padding: 0 spacing.$spacing-md;
+                    }
+                    &::placeholder {
+                        color: var(--date-placeholder);
+                    }
+                    &:focus-within,
+                    &:active {
+                        z-index: 3;
+                    }
+                }
+            }
+            margin-bottom: 0.75rem;
         }
         // document type filter
         details.doctype-filter {

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -29,7 +29,8 @@
   <fieldType name="float" class="solr.TrieFloatField" positionIncrementGap="0" docValues="true" precisionStep="0"/>
   <fieldType name="floats" class="solr.TrieFloatField" positionIncrementGap="0" docValues="true" multiValued="true" precisionStep="0"/>
   <fieldType name="ignored" class="solr.StrField" indexed="false" stored="false" docValues="false" multiValued="true"/>
-  <fieldType name="int" class="solr.TrieIntField" positionIncrementGap="0" docValues="true" precisionStep="0"/>
+  <!-- revised from default to sort missing last -->
+  <fieldType name="int" class="solr.TrieIntField" positionIncrementGap="0" docValues="true" precisionStep="0" sortMissingLast="true"/>
   <fieldType name="ints" class="solr.TrieIntField" positionIncrementGap="0" docValues="true" multiValued="true" precisionStep="0"/>
   <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
   <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" maxDistErr="0.001" distErrPct="0.025" distanceUnits="kilometers"/>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -15,6 +15,7 @@
   <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
   <fieldType name="date" class="solr.TrieDateField" positionIncrementGap="0" docValues="true" precisionStep="0"/>
   <fieldType name="dates" class="solr.TrieDateField" positionIncrementGap="0" docValues="true" multiValued="true" precisionStep="0"/>
+  <fieldType name="daterange" class="solr.DateRangeField" />
   <fieldType name="descendent_path" class="solr.TextField">
     <analyzer type="index">
       <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
@@ -188,6 +189,7 @@
   <dynamicField name="*_fs" type="floats" indexed="true" stored="true"/>
   <dynamicField name="*_ds" type="doubles" indexed="true" stored="true"/>
   <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
+  <dynamicField name="*_dr" type="daterange" indexed="true" stored="false"/>
   <dynamicField name="*_pi" type="pint" indexed="true" stored="true"/>
   <dynamicField name="*_pl" type="plong" indexed="true" stored="true"/>
   <dynamicField name="*_pf" type="pfloat" indexed="true" stored="true"/>


### PR DESCRIPTION
in this pr:
- define date range field type in solr schema (requires updating configset)
- index standardized dates as date range in solr
- port range filter & widget from other CDH codebases
- display range filter on form (preliminary / unstyled)
- implement range filtering in the document search view

does not include styles or placeholder text; unit tests are incomplete

questions:
- The range input I ported over uses integer fields. Technically we could support YYYY-MM-DD, but Marina indicated year was sufficient and I'm not sure we need the additional complexity (number input is easier to validate). However, I'm not sure if we can add placeholder text to a numeric input, which might be reason enough to switch (maybe).
