### PR TITLE
Only auto-sort by relevance from default sort

### DIFF
--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -158,9 +158,15 @@ export default class extends Controller {
         // when query is empty, disable sort by relevance
         if (this.queryTarget.value.trim() == "") {
             this.disableRelevanceSort();
-            // if this was triggered by an event and not in sortTargetConnected, sort by relevance
         } else if (event) {
-            this.sortByRelevance();
+            // if this was triggered by an event and not in sortTargetConnected,
+            // and the sort is currently "random" (the default), sort by relevance
+            const sortIsRandom = this.sortTargets.some(
+                (target) => target.value === "random" && target.checked
+            );
+            if (sortIsRandom) {
+                this.sortByRelevance();
+            }
         }
     }
 

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -160,11 +160,8 @@ export default class extends Controller {
             this.disableRelevanceSort();
         } else if (event) {
             // if this was triggered by an event and not in sortTargetConnected,
-            // and the sort is currently "random" (the default), sort by relevance
-            const sortIsRandom = this.sortTargets.some(
-                (target) => target.value === "random" && target.checked
-            );
-            if (sortIsRandom) {
+            // and the sort is currently the default, sort by relevance
+            if (this.defaultSortElement.checked) {
                 this.sortByRelevance();
             }
         }

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -158,12 +158,10 @@ export default class extends Controller {
         // when query is empty, disable sort by relevance
         if (this.queryTarget.value.trim() == "") {
             this.disableRelevanceSort();
-        } else if (event) {
+        } else if (event && this.defaultSortElement.checked) {
             // if this was triggered by an event and not in sortTargetConnected,
             // and the sort is currently the default, sort by relevance
-            if (this.defaultSortElement.checked) {
-                this.sortByRelevance();
-            }
+            this.sortByRelevance();
         }
     }
 


### PR DESCRIPTION
## In this PR

- Per #827:
  - Only auto-switch to relevance sort (by typing in the search query field) when the default sort element is checked