### PR TITLE
Add labels to docdate filter inputs

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -135,6 +135,13 @@ class BooleanFacetField(FacetFieldMixin, forms.BooleanField):
         self.widget.facet_counts = facet_dict
 
 
+class YearRangeWidget(RangeWidget):
+    """Extend :class:`django.forms.widgets.RangeWidget` to customize the output and add
+    year start/end labels to the individual inputs."""
+
+    template_name = "corpus/widgets/yearrangewidget.html"
+
+
 class DocumentSearchForm(RangeForm):
 
     q = forms.CharField(
@@ -192,9 +199,11 @@ class DocumentSearchForm(RangeForm):
     )
     # Translators: label for filter documents by date range
     docdate = RangeField(
-        label=_("Document Dates"),
+        label=_("Document Dates (CE)"),
         required=False,
-        widget=RangeWidget(attrs={"size": 4, "data-action": "input->search#update"}),
+        widget=YearRangeWidget(
+            attrs={"size": 4, "data-action": "input->search#update"},
+        ),
     )
 
     doctype = FacetChoiceField(

--- a/geniza/corpus/templates/corpus/widgets/yearrangewidget.html
+++ b/geniza/corpus/templates/corpus/widgets/yearrangewidget.html
@@ -1,0 +1,5 @@
+{% comment %}
+Template for DateRangeWidget with numeric start and stop inputs.
+{% endcomment %}
+{% load i18n %}
+<div class="inputs">{% spaceless %}{% for subwidget in widget.subwidgets %}<label for={{ subwidget.attrs.id }}>{% if forloop.first %}{% translate "From year" %}{% else %}{% translate "To year" %}{% endif%}</label>{% include subwidget.template_name with widget=subwidget %}{% if forloop.first %} <span class="sr-only">to</span>{% endif %}{% endfor %}{% endspaceless %}</div>


### PR DESCRIPTION
Rachel wanted labels on the year inputs for more clarity about what this is. I couldn't figure out a way to pass them through as parameters, so just extended the widget so we could have a custom render template.

Please do a quick review and see if you have any concerns, and then adjust the styling so that the labels appear on the same line as the inputs.