### PR TITLE
Add update & clean modes to convert dates script

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -236,13 +236,13 @@ class DocumentDateMixin(TrackChangesModel):
         # if original date is set and conversion is supported for this calendar,
         # generate the standardized date
         if self.doc_date_original and self.doc_date_calendar in Calendar.can_convert:
-            converted_date = display_date_range(
-                *standardize_date(self.doc_date_original, self.doc_date_calendar)
-            )
-            # if update is requested and standard date is unset, save the converted date
-            if update and not self.doc_date_standard:
-                self.doc_date_standard = converted_date
-            return converted_date
+            std_date = standardize_date(self.doc_date_original, self.doc_date_calendar)
+            if std_date:
+                converted_date = display_date_range(*std_date)
+                # if update is requested and standard date is unset, save the converted date
+                if update and not self.doc_date_standard:
+                    self.doc_date_standard = converted_date
+                return converted_date
 
     _parsed_date = {}
 

--- a/geniza/corpus/management/commands/convert_dates.py
+++ b/geniza/corpus/management/commands/convert_dates.py
@@ -1,6 +1,10 @@
 import csv
 
-from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+from django.contrib.admin.models import CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
 
 from geniza.corpus.dates import Calendar, display_date_range, standardize_date
 from geniza.corpus.models import Document
@@ -20,7 +24,7 @@ class Command(BaseCommand):
     ]
 
     def add_arguments(self, parser):
-        #     parser.add_argument("mode", choices=["report", "merge"])
+        parser.add_argument("mode", choices=["report", "update"])
         parser.add_argument(
             "report-path", type=str, nargs="?", default="date-conversion-report.csv"
         )
@@ -36,7 +40,14 @@ class Command(BaseCommand):
             doc_date_original="", doc_date_calendar=""
         ).filter(doc_date_calendar__in=Calendar.can_convert)
 
-        with open(options["report-path"], "w") as csvfile:
+        if options["mode"] == "report":
+            self.report(dated_docs, options["report-path"])
+        elif options["mode"] == "update":
+            self.standardize_dates(dated_docs)
+
+    def report(self, dated_docs, report_path):
+        """Generate a CSV report of documents with dates and converted standard dates"""
+        with open(report_path, "w") as csvfile:
             csvwriter = csv.writer(csvfile)
             csvwriter.writerow(self.report_fields)
 
@@ -65,3 +76,46 @@ class Command(BaseCommand):
                         error,
                     ]
                 )
+
+    def standardize_dates(self, dated_docs):
+        """Update documents with dates to standard format"""
+        doc_contenttype = ContentType.objects.get_for_model(Document)
+        script_user = User.objects.get(username=settings.SCRIPT_USERNAME)
+
+        # exclude documents with uncertain digits; looks like [..] or similar;
+        # also exclude date ranges, which we don't yet support
+        dated_docs = (
+            dated_docs.exclude(doc_date_original__contains="[.")
+            .exclude(doc_date_original__contains="–")
+            .exclude(doc_date_original__contains="-")
+        )
+        updated = 0
+
+        for doc in dated_docs:
+            try:
+                # standardize date, if possible
+                converted_date = doc.standardize_date()
+                # if it was successful, update if this is a change
+                if converted_date:
+                    doc.doc_date_standard = converted_date
+                    if doc.has_changed("doc_date_standard"):
+                        doc.save()
+                        # create log entry documenting the change
+                        LogEntry.objects.log_action(
+                            user_id=script_user.id,
+                            content_type_id=doc_contenttype.pk,
+                            object_id=doc.pk,
+                            object_repr=str(doc),
+                            change_message="Recalculated standard document date",
+                            action_flag=CHANGE,
+                        )
+                        updated += 1
+
+            except ValueError as e:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "Error converting date for document %s: %s" % (doc.id, e)
+                    )
+                )
+
+        self.stdout.write("Updated %d documents" % updated)

--- a/geniza/corpus/management/commands/convert_dates.py
+++ b/geniza/corpus/management/commands/convert_dates.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
             doc_date_standard__regex=Document.re_date_format.pattern
         )
 
-        print(
+        self.stdout.write(
             "%s documents with invalid standardized dates" % docs_invalid_dates.count()
         )
 

--- a/geniza/corpus/management/commands/convert_dates.py
+++ b/geniza/corpus/management/commands/convert_dates.py
@@ -85,7 +85,8 @@ class Command(BaseCommand):
                 )
 
     def standardize_dates(self, dated_docs):
-        """Update documents with dates to standard format"""
+        """Reconvert and update documents with historical dates with calendars
+        that support conversion."""
 
         # exclude documents with uncertain digits; looks like [..] or similar;
         # also exclude date ranges, which we don't yet support
@@ -126,7 +127,8 @@ class Command(BaseCommand):
         self.stdout.write("Updated %d documents" % updated)
 
     def clean_standard_dates(self):
-        # find documents with standardized dates that are set but don't match the new validation pattern
+        """Find documents with standardized dates that are set
+        but don't match the validation pattern and correct the ones that can be fixed."""
         docs_invalid_dates = Document.objects.exclude(doc_date_standard="").exclude(
             doc_date_standard__regex=Document.re_date_format.pattern
         )

--- a/geniza/corpus/tests/test_convert_dates.py
+++ b/geniza/corpus/tests/test_convert_dates.py
@@ -1,0 +1,101 @@
+import os
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from geniza.corpus.dates import Calendar
+from geniza.corpus.management.commands import convert_dates
+from geniza.corpus.models import Document
+
+
+@pytest.mark.django_db
+def test_convert_date_report(tmp_path, document, join):
+    # add convertable dates to the documents
+    document.doc_date_original = "507"
+    document.doc_date_calendar = Calendar.HIJRI
+    document.doc_date_standard = "1113"
+    document.save()
+
+    join.doc_date_original = "12 Elul 4968"
+    join.doc_date_calendar = Calendar.ANNO_MUNDI
+    join.doc_date_standard = "1208"
+    join.save()
+
+    stderr = StringIO()
+    report_file = tmp_path / "date-conversion-report.csv"
+    call_command("convert_dates", "report", report_file.name, stderr=stderr)
+    with open(report_file.name) as f:
+        lines = f.readlines()
+        # header + two documents with convertable dates
+        assert len(lines) == 3
+        assert document.doc_date_original in lines[1]
+        assert document.get_doc_date_calendar_display() in lines[1]
+        assert document.doc_date_standard in lines[1]
+        # converted date
+        assert "1113-06-18/1114-06-06" in lines[1]
+        assert "1208-08-26" in lines[2]
+
+
+@pytest.mark.django_db
+def test_convert_date_standardize(document, join):
+    # add convertable dates to the documents
+    # - one we can handle
+    document.doc_date_original = "507"
+    document.doc_date_calendar = Calendar.HIJRI
+    document.doc_date_standard = "1113"
+    document.save()
+    doc_logentry_count = document.log_entries.count()
+
+    # one we can't handle
+    join.doc_date_original = "First decade of Elul 4968"
+    join.doc_date_calendar = Calendar.ANNO_MUNDI
+    join.doc_date_standard = "1208"
+    join.save()
+    join_logentry_count = join.log_entries.count()
+
+    stdout = StringIO()
+    command = convert_dates.Command(stdout=stdout)
+    command.handle(mode="update")
+
+    # check that the first document has been updated
+    document.refresh_from_db()
+    assert document.doc_date_standard == "1113-06-18/1114-06-06"
+    # check that a log entry was created
+    assert document.log_entries.count() == doc_logentry_count + 1
+    # check that the second document has not been updated
+    join.refresh_from_db()
+    assert join.log_entries.exists() == join_logentry_count
+    output = stdout.getvalue()
+    assert "Error converting date for document {}".format(join.id) in output
+    assert "Updated 1 document" in output
+
+
+@pytest.mark.django_db
+def test_convert_date_clean(document, join):
+    # add non-standard dates to clean up
+    document.doc_date_standard = "1127–38"
+    document.save()
+    doc_logentry_count = document.log_entries.count()
+
+    join.doc_date_standard = "1208/10/03"
+    join.save()
+    join_logentry_count = join.log_entries.count()
+
+    stdout = StringIO()
+    command = convert_dates.Command(stdout=stdout)
+    command.handle(mode="clean")
+
+    # check that the first document has been updated
+    document.refresh_from_db()
+    assert document.doc_date_standard == "1127/1138"
+    # check that a log entry was created
+    assert document.log_entries.count() == doc_logentry_count + 1
+    # check that the second document has been updated
+    join.refresh_from_db()
+    assert join.doc_date_standard == "1208-10-03"
+    assert join.log_entries.exists() == join_logentry_count + 1
+    output = stdout.getvalue()
+    assert "Updated 2 documents" in output

--- a/geniza/corpus/tests/test_convert_dates.py
+++ b/geniza/corpus/tests/test_convert_dates.py
@@ -98,4 +98,5 @@ def test_convert_date_clean(document, join):
     assert join.doc_date_standard == "1208-10-03"
     assert join.log_entries.exists() == join_logentry_count + 1
     output = stdout.getvalue()
+    assert "2 documents with invalid standardized dates" in output
     assert "Updated 2 documents" in output


### PR DESCRIPTION
in this PR:
- revise `convert_dates` manage command to add modes, make current logic the `report` mode
- added an `update` mode, which converts dates with supported calendars & formats into the new format
- added a `clean` mode, which identifies standardized dates that don't follow the new validation pattern and cleans up the ones that can be automatically fixed

still needs tests & documentation