### PR TITLE
Related documents page

### DIFF
--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -97,6 +97,21 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
             keyword_query=self._search_term_cleanup(search_term)
         )
 
+    def related_to(self, document):
+        "Return documents related to the given document (i.e. shares any shelfmarks)"
+
+        # NOTE: using a string query filter because parasolr queryset
+        # # currently doesn't provide any kind of not/exclude filter
+        return (
+            self.filter(status=document.PUBLIC_LABEL)
+            .filter("NOT pgpid_i:%d" % document.id)
+            .filter(
+                fragment_shelfmark_ss__in=[
+                    '"%s"' % f.shelfmark for f in document.fragments.all()
+                ]
+            )
+        )
+
     def get_result_document(self, doc):
         # default implementation converts from attrdict to dict
         doc = super().get_result_document(doc)

--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load static render_bundle_csp  %}
+{% load static i18n render_bundle_csp  %}
 
 {% block extrastyle %}
     {{ block.super }}
@@ -29,6 +29,29 @@
             </div>
         </fieldset>
     {% endif %}
+    {# display & link to other documents on this fragment if there are any #}
+    {% with original.fragments_other_docs as other_docs %}
+        {% if other_docs %}
+            <section>
+                <h3>
+                    {# Translators: Other documents on the same fragment/shelfmark #}
+                    {% blocktranslate count counter=original.fragments.count trimmed %}
+                        Other documents on this shelfmark
+                    {% plural %}
+                        Other documents on these shelfmarks
+                    {% endblocktranslate %}
+                </h3>
+                <ul>
+                    {% for doc in other_docs %}
+                        <li><a href="{% url 'admin:corpus_document_change' doc.id %}">PGPID {{ doc.id }}</a> {{ doc.title }}
+                            <p>{{ doc.description }}</p>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </section>
+        {% endif %}
+    {% endwith %}
+
     {% if original.digital_editions or original.has_image %}
         <fieldset class="module aligned transcriptions-field">
             <div class="form-row">

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -149,28 +149,8 @@
             </section>
         {% endif %}
 
-        {% with document.fragments_other_docs as other_docs %}
-            {% if other_docs %}
-                <section>
-                    <dl class="metadata-list">
-                        <dt>
-                            {# Translators: Other documents on the same fragment/shelfmark #}
-                            {% blocktranslate count counter=document.fragments.count trimmed %}
-                                Other documents on this shelfmark
-                            {% plural %}
-                                Other documents on these shelfmarks
-                            {% endblocktranslate %}
-                        </dt>
-                        {% for doc in other_docs %}
-                            <dd><a href="{{ doc.get_absolute_url }}">{{ doc.title }}</a></dd>
-                        {% endfor %}
-                    </dl>
-                </section>
-            {% endif %}
-        {% endwith %}
+
     </div>
-
-
 
     {# viewer #}
     {% if document.has_transcription or document.iiif_urls %}

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -38,18 +38,16 @@
     <!-- document details -->
     <h1 class="sr-only">{{ page_title }}</h1>
     {% include "corpus/snippets/document_header.html" %}
-
+    {# tabs #}
+    {% include "corpus/snippets/document_tabs.html" %}
     <div class="container">
-        {# tabs #}
-        {% include "corpus/snippets/document_tabs.html" %}
-
-        <section>
+        <section class="metadata">
             <h2 class="sr-only">
                 {# Translators: label for document metadata section (editor, date, input date) #}
                 {% translate 'Metadata' %}
             </h2>
             {# metadata #}
-            <dl class="metadata primary">
+            <dl class="metadata-list primary">
                 <dt>{% translate 'Shelfmark' %}</dt>
                 <dd class="shelfmark">{{ document.shelfmark|shelfmark_wrap }}</dd>
                 {% if document.digital_editions %}
@@ -70,7 +68,7 @@
                 {% endif %}
             </dl>
             {# secondary metadata #}
-            <dl class="metadata secondary">
+            <dl class="metadata-list secondary">
                 {% if document.document_date %}
                     <dt>
                         {# Translators: label for date of this document, if known #}
@@ -154,7 +152,7 @@
         {% with document.fragments_other_docs as other_docs %}
             {% if other_docs %}
                 <section>
-                    <dd class="metadata">
+                    <dl class="metadata-list">
                         <dt>
                             {# Translators: Other documents on the same fragment/shelfmark #}
                             {% blocktranslate count counter=document.fragments.count trimmed %}
@@ -166,7 +164,8 @@
                         {% for doc in other_docs %}
                             <dd><a href="{{ doc.get_absolute_url }}">{{ doc.title }}</a></dd>
                         {% endfor %}
-                    </section>
+                    </dl>
+                </section>
             {% endif %}
         {% endwith %}
     </div>
@@ -179,7 +178,7 @@
     {% endif %}
 
     {# tertiary metadata #}
-    <dl class="metadata tertiary">
+    <dl class="metadata-list tertiary">
         <dt id="permalink">
             <svg role="presentation"><use xlink:href="{% static 'img/ui/all/all/permalink-icon.svg' %}#permalink-icon" /></svg>
             {# Translators: label for permanent link to a document #}

--- a/geniza/corpus/templates/corpus/document_scholarship.html
+++ b/geniza/corpus/templates/corpus/document_scholarship.html
@@ -8,8 +8,8 @@
     <h1 class="sr-only">{{ page_title }}</h1>
     <!-- document scholarship records -->
     {% include "corpus/snippets/document_header.html" %}
+    {% include "corpus/snippets/document_tabs.html" %}
     <div class="container">
-        {% include "corpus/snippets/document_tabs.html" %}
         <ol>
             {% regroup document.footnotes.all by source as source_list %}
             {% for source in source_list %}

--- a/geniza/corpus/templates/corpus/related_documents.html
+++ b/geniza/corpus/templates/corpus/related_documents.html
@@ -8,15 +8,12 @@
     <h1 class="sr-only">{{ page_title }}</h1>
     <!-- related documents -->
     {% include "corpus/snippets/document_header.html" %}
-    <div class="container">
-        {% include "corpus/snippets/document_tabs.html" %}
-
-        <section id="document-list">
-            <ol>
-                {% for document in document.related_documents %}
-                    {% include "corpus/snippets/document_result.html" %}
-                {% endfor %}
-            </ol>
-        </section>
-    </div>
+    {% include "corpus/snippets/document_tabs.html" %}
+    <section id="document-list" class="related-documents">
+        <ol>
+            {% for document in document.related_documents %}
+                {% include "corpus/snippets/document_result.html" %}
+            {% endfor %}
+        </ol>
+    </section>
 {% endblock main %}

--- a/geniza/corpus/templates/corpus/related_documents.html
+++ b/geniza/corpus/templates/corpus/related_documents.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% load static i18n corpus_extras %}
+
+{% block meta_title %}{{ page_title }}{% endblock meta_title %}
+{% block meta_description %}{{ page_description }}{% endblock meta_description %}
+
+{% block main %}
+    <h1 class="sr-only">{{ page_title }}</h1>
+    <!-- related documents -->
+    {% include "corpus/snippets/document_header.html" %}
+    <div class="container">
+        {% include "corpus/snippets/document_tabs.html" %}
+
+        <section id="document-list">
+            <ol>
+                {% for document in document.related_documents %}
+                    {% include "corpus/snippets/document_result.html" %}
+                {% endfor %}
+            </ol>
+        </section>
+    </div>
+{% endblock main %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -3,7 +3,9 @@
     <li class="search-result">
         {# result number #}
         <span class="counter">
-            {{ forloop.counter0|add:page_obj.start_index }}
+            {% with page_obj.start_index|default:1 as start_adjust %}
+                {{ forloop.counter0|add:start_adjust }}
+            {% endwith %}
         </span>
         <section class="{% if document.iiif_images %}has-image{% endif %}">
             {# title #}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -27,107 +27,108 @@
                         </time>
                     </dd>
                 {% endif %}
-                <dt>{% translate 'Input date' %}</dt>
-                <dd>{{ document.input_year|default:'unknown' }}</dd>
-                {# NOTE: Intentionally left untranslated #}
-                <dt>PGP ID</dt>
-                <dd>{{ document.pgpid }}</dd>
-            </dl>
+                {# Translators: Date document was first added to the PGP #}
+                <dt>{% translate "In PGP since" %}
+                    <dd>{{ document.input_year|default:'unknown' }}</dd>
+                    {# NOTE: Intentionally left untranslated #}
+                    <dt>PGP ID</dt>
+                    <dd>{{ document.pgpid }}</dd>
+                </dl>
 
-            {# description #}
-            <p class="description">
-                {# display keywords in context if any #}
-                {% with document_highlights=highlighting|dict_item:document.id %}
-                    {% if document_highlights.description %}
-                        {% for snippet in document_highlights.description %}
-                            {{ snippet|safe }}
-                        {% endfor %}
-                    {% else %}
-                        {# otherwise, display truncated description #}
-                        {{ document.description.0|truncatewords:25 }}
+                {# description #}
+                <p class="description">
+                    {# display keywords in context if any #}
+                    {% with document_highlights=highlighting|dict_item:document.id %}
+                        {% if document_highlights.description %}
+                            {% for snippet in document_highlights.description %}
+                                {{ snippet|safe }}
+                            {% endfor %}
+                        {% else %}
+                            {# otherwise, display truncated description #}
+                            {{ document.description.0|truncatewords:25 }}
+                        {% endif %}
+                    {% endwith %}
+                </p>
+
+                {# transcription: keywords in context if any, or excerpt #}
+                {% with document_highlights=highlighting|dict_item:document.id lang=document.language_code.0 %}
+                    {# use first language code, if any; otherwise empty lang attribute to indicate unknown language #}
+                    {# NOTE: this is problematic for documents with multiple primary languages #}
+                    {% if document_highlights.transcription %}
+                        <div class="transcription" lang="{{ lang }}">{% for snippet in document_highlights.transcription %}{{ snippet.strip|safe|linebreaks }}{% endfor %}</div>
+                    {% elif document.transcription %}
+                        {# otherwise, display truncated transcription #}
+                        {# NOTE: might be nice to display N lines instead of using truncatechars #}
+                        <div class="transcription" lang="{{ lang }}">{{ document.transcription.0|linebreaks|truncatechars_html:150 }}</div>
                     {% endif %}
                 {% endwith %}
-            </p>
 
-            {# transcription: keywords in context if any, or excerpt #}
-            {% with document_highlights=highlighting|dict_item:document.id lang=document.language_code.0 %}
-                {# use first language code, if any; otherwise empty lang attribute to indicate unknown language #}
-                {# NOTE: this is problematic for documents with multiple primary languages #}
-                {% if document_highlights.transcription %}
-                    <div class="transcription" lang="{{ lang }}">{% for snippet in document_highlights.transcription %}{{ snippet.strip|safe|linebreaks }}{% endfor %}</div>
-                {% elif document.transcription %}
-                    {# otherwise, display truncated transcription #}
-                    {# NOTE: might be nice to display N lines instead of using truncatechars #}
-                    <div class="transcription" lang="{{ lang }}">{{ document.transcription.0|linebreaks|truncatechars_html:150 }}</div>
+                {# scholarship records #}
+                <p class="scholarship">
+                    {% if document.scholarship_count %}
+                        {% if document.num_editions %}
+                            <span>
+                                {% comment %}Translators: number of editions for this document{% endcomment %}
+                                {% blocktranslate count counter=document.num_editions trimmed %}
+                                    1 Transcription
+                                {% plural %}
+                                    {{ counter }} Transcriptions
+                                {% endblocktranslate %}
+                            </span>
+                        {% endif %}
+                        {% if document.num_translations %}
+                            <span>
+                                {% comment %}Translators: number of translations for this document{% endcomment %}
+                                {% blocktranslate count counter=document.num_translations trimmed %}
+                                    1 Translation
+                                {% plural %}
+                                    {{ counter }} Translations
+                                {% endblocktranslate %}
+                            </span>
+                        {% endif %}
+                        {% if document.num_discussions %}
+                            <span>
+                                {% comment %}Translators: number of sources that discuss this document{% endcomment %}
+                                {% blocktranslate count counter=document.num_discussions trimmed %}
+                                    1 Discussion
+                                {% plural %}
+                                    {{ counter }} Discussions
+                                {% endblocktranslate %}
+                            </span>
+                        {% endif %}
+                    {% else %}
+                        {% translate 'No Scholarship Records' %}
+                    {% endif %}
+                </p>
+
+                {# tags #}
+                {% if document.tags %}
+                    {# Translators: label for tags on a document #}
+                    <h3 class="sr-only">{% translate 'Tags' %}</h3>
+                    <ul class="tags">
+                        {% for tag in document.tags|alphabetize|slice:":5" %}
+                            <li><a href='{% url "corpus:document-search" %}?q=tag:"{{ tag }}"'>{{ tag }}</a></li>
+                        {% endfor %}
+                        {% if document.tags|length > 5 %}
+                            <li class="more">(+ {{ document.tags|length|add:"-5" }} {% translate 'more' %})</li>
+                        {% endif %}
+                    </ul>
                 {% endif %}
-            {% endwith %}
+            </section>
 
-            {# scholarship records #}
-            <p class="scholarship">
-                {% if document.scholarship_count %}
-                    {% if document.num_editions %}
-                        <span>
-                            {% comment %}Translators: number of editions for this document{% endcomment %}
-                            {% blocktranslate count counter=document.num_editions trimmed %}
-                                1 Transcription
-                            {% plural %}
-                                {{ counter }} Transcriptions
-                            {% endblocktranslate %}
-                        </span>
-                    {% endif %}
-                    {% if document.num_translations %}
-                        <span>
-                            {% comment %}Translators: number of translations for this document{% endcomment %}
-                            {% blocktranslate count counter=document.num_translations trimmed %}
-                                1 Translation
-                            {% plural %}
-                                {{ counter }} Translations
-                            {% endblocktranslate %}
-                        </span>
-                    {% endif %}
-                    {% if document.num_discussions %}
-                        <span>
-                            {% comment %}Translators: number of sources that discuss this document{% endcomment %}
-                            {% blocktranslate count counter=document.num_discussions trimmed %}
-                                1 Discussion
-                            {% plural %}
-                                {{ counter }} Discussions
-                            {% endblocktranslate %}
-                        </span>
-                    {% endif %}
-                {% else %}
-                    {% translate 'No Scholarship Records' %}
-                {% endif %}
-            </p>
-
-            {# tags #}
-            {% if document.tags %}
-                {# Translators: label for tags on a document #}
-                <h3 class="sr-only">{% translate 'Tags' %}</h3>
-                <ul class="tags">
-                    {% for tag in document.tags|alphabetize|slice:":5" %}
-                        <li><a href='{% url "corpus:document-search" %}?q=tag:"{{ tag }}"'>{{ tag }}</a></li>
+            {% if document.iiif_images %}
+                <ul class="images">
+                    {# list of tuples of (IIIF image, label) #}
+                    {% for image in document.iiif_images|slice:":3" %}
+                        <li class="image-{{ forloop.counter }}">
+                            <img src="{{ image.0|iiif_image:"size:width=250" }}" loading="lazy" alt="{{ image.1 }}">
+                        </li>
                     {% endfor %}
-                    {% if document.tags|length > 5 %}
-                        <li class="more">(+ {{ document.tags|length|add:"-5" }} {% translate 'more' %})</li>
-                    {% endif %}
                 </ul>
             {% endif %}
-        </section>
-
-        {% if document.iiif_images %}
-            <ul class="images">
-                {# list of tuples of (IIIF image, label) #}
-                {% for image in document.iiif_images|slice:":3" %}
-                    <li class="image-{{ forloop.counter }}">
-                        <img src="{{ image.0|iiif_image:"size:width=250" }}" loading="lazy" alt="{{ image.1 }}">
-                    </li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-        {# view link #}
-        <a class="view-link" href="{% url 'corpus:document' document.pgpid %}" data-turbo-frame="main">
-            <span>{% translate 'View document details' %}</span>
-        </a>
-    </li>
+            {# view link #}
+            <a class="view-link" href="{% url 'corpus:document' document.pgpid %}" data-turbo-frame="main">
+                <span>{% translate 'View document details' %}</span>
+            </a>
+        </li>
 {% endspaceless %}

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -16,7 +16,7 @@
             </h2>
 
             {# metadata #}
-            <dl class="metadata">
+            <dl class="metadata-list">
                 {% if document.document_date %}
                     <dt>
                         {% translate "Document Date" %}

--- a/geniza/corpus/templates/corpus/snippets/document_tabs.html
+++ b/geniza/corpus/templates/corpus/snippets/document_tabs.html
@@ -12,16 +12,11 @@
             <li>{% if n_records > 0 %}<a href="{{ scholarship_url }}"{% if request.path == scholarship_url %} aria-current="page"{% endif %}>{{ srec_text }}</a>{% else %}<span disabled aria-disabled="true">{{ srec_text }}</span>{% endif %}</li>
         {% endwith %}
 
-        {# for MVP: external links is disabled; don't show a count #}
-        {% blocktranslate asvar elink_text %}External Links{% endblocktranslate %}
-        <li><span disabled aria-disabled="true">{{ elink_text }}</span></li>
-        {# preserving so we can get the text translation #}
-        {% with n_links=document.fragment_urls|length %}
-            {# Translators: n_links is number of external links #}
-            {% blocktranslate asvar elink_text %}External Links ({{ n_links }}){% endblocktranslate %}
-            {% comment %} {# after MVP: uncomment when we implement external links #}
-            <li>{% if n_links > 0 %}<a href="#">{{ elink_text }}</a>{% else %}<span>{{ elink_text }}</span>{% endif %}</li>
-            {% endcomment %}
+        {# Translators: n_reldocs is number of related documents #}
+        {% with n_reldocs=document.related_documents.count %}
+            {% blocktranslate asvar reldoc_text %}Related Documents ({{ n_reldocs }}){% endblocktranslate %}
+            {% url 'corpus:related-documents' pk=document.pk as reldoc_url %}
+            <li>{% if n_reldocs > 0 %}<a href="{{ reldoc_url }}"{% if request.path == reldoc_url %} aria-current="page"{% endif %}>{{ reldoc_text }}</a>{% else %}<span disabled aria-disabled="true">{{ reldoc_text }}</span>{% endif %}</li>
         {% endwith %}
     </ul>
 </nav>

--- a/geniza/corpus/templates/corpus/snippets/document_tabs.html
+++ b/geniza/corpus/templates/corpus/snippets/document_tabs.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <!-- document detail page navigation -->
 {# Translators: accessibility text label for document detail view tabs navigation #}
-<nav aria-label="{% translate "tabs" %}">
+<nav aria-label="{% translate "tabs" %}" id="tabs">
     <ul class="tabs">
         {% url 'corpus:document' pk=document.pk as document_url %}
         <li><a href="{{ document_url }}"{% if request.path == document_url %} aria-current="page"{% endif %}>{% translate "Document Details" %}</a></li>

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -32,7 +32,11 @@ def dict_item(dictionary, key):
 
         {{ mydict|dict_item:keyvar }}
     """
-    return dictionary.get(key, None)
+    try:
+        return dictionary.get(key, None)
+    except AttributeError:
+        # fail silently if something other than a dict is passed
+        return None
 
 
 @register.simple_tag(takes_context=True)

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -210,18 +210,6 @@ class TestDocumentDetailTemplate:
             response, "Download Khan, el-Leithy, Rustow and Vanthieghem's edition"
         )
 
-    def test_other_docs_none(self, document, client):
-        """If there are no other documents, don't show the other docs section"""
-        response = client.get(document.get_absolute_url())
-        assertNotContains(response, "Other documents on this shelfmark")
-
-    def test_other_docs(self, document, join, client):
-        """If there are other documents, show the other docs section"""
-        response = client.get(document.get_absolute_url())
-        assertContains(response, "Other documents on this shelfmark")
-        assertContains(response, join.get_absolute_url())
-        assertContains(response, join.title)
-
     def test_languages_none(self, client, document):
         response = client.get(document.get_absolute_url())
         assertNotContains(response, "Primary Language")

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -41,6 +41,8 @@ class TestCorpusExtrasTemplateTags:
 
 
 def test_dict_item():
+    # no error on non-dict first argument
+    assert corpus_extras.dict_item([], "foo") is None
     # no error on not found
     assert corpus_extras.dict_item({}, "foo") is None
     # string key

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pydoc import doc
 from time import sleep
 from unittest.mock import ANY, Mock, patch
 
@@ -1297,3 +1296,56 @@ class TestDocumentMergeView:
                 follow=True,
             )
             mock_merge_with.assert_called_with(ANY, "test", user=ANY)
+
+
+class TestRelatdDocumentview:
+    def test_page_title(self, document, client):
+        """should use doc title in related documents view meta title"""
+        response = client.get(reverse("corpus:related-documents", args=(document.id,)))
+        assert (
+            response.context["page_title"] == f"Related documents for {document.title}"
+        )
+
+    def test_page_description(self, client, document, join, fragment, empty_solr):
+        """should use count and pluralization in related documents view meta description"""
+
+        Document.index_items([document, join])
+        SolrClient().update.index([], commit=True)
+
+        # "join" fixture = 1 related document
+        response = client.get(reverse("corpus:related-documents", args=(document.id,)))
+        assert response.context["page_description"] == "1 related document"
+
+        # document on same fragment should add a related document to the other document
+        new_doc = Document.objects.create(
+            doctype=DocumentType.objects.get_or_create(name_en="Legal")[0],
+        )
+        TextBlock.objects.create(document=new_doc, fragment=fragment)
+        Document.index_items([document, join, new_doc])
+        SolrClient().update.index([], commit=True)
+        response = client.get(reverse("corpus:related-documents", args=(document.id,)))
+        assert response.context["page_description"] == "2 related documents"
+
+    def test_get_context_data(self, document, join, client, empty_solr):
+        """should raise 404 on no related, otherwise return inherited context data"""
+        # document on new shelfmark should not have any related documents, so should raise 404
+        new_doc = Document.objects.create(
+            doctype=DocumentType.objects.get_or_create(name_en="Legal")[0],
+        )
+        new_frag = Fragment.objects.create(shelfmark="fake_shelfmark_related_docs")
+        TextBlock.objects.create(document=new_doc, fragment=new_frag)
+        Document.index_items([new_doc, document, join])
+        SolrClient().update.index([], commit=True)
+        response = client.get(reverse("corpus:related-documents", args=(new_doc.id,)))
+        assert response.status_code == 404
+
+        # related document view should otherwise inherit context data function from detail view
+        related_response = client.get(
+            reverse("corpus:related-documents", args=(document.id,))
+        )
+        doc_response = client.get(reverse("corpus:document", args=(document.id,)))
+        assert related_response.status_code == 200
+        assert (
+            related_response.context["page_includes_transcriptions"]
+            == doc_response.context["page_includes_transcriptions"]
+        )

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -839,10 +839,7 @@ class TestDocumentScholarshipView:
         response = client.get(
             reverse("corpus:document-scholarship", args=(document.id,))
         )
-        assert (
-            response.context["page_description"]
-            == f"1 scholarship record for {document.title}"
-        )
+        assert response.context["page_description"] == f"1 scholarship record"
 
     def test_get_queryset(self, client, document, source):
         # no footnotes; should 404

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1299,8 +1299,11 @@ class TestDocumentMergeView:
 
 
 class TestRelatdDocumentview:
-    def test_page_title(self, document, client):
+    def test_page_title(self, document, join, client, empty_solr):
         """should use doc title in related documents view meta title"""
+        Document.index_items([document, join])
+        SolrClient().update.index([], commit=True)
+
         response = client.get(reverse("corpus:related-documents", args=(document.id,)))
         assert (
             response.context["page_title"] == f"Related documents for {document.title}"
@@ -1308,7 +1311,6 @@ class TestRelatdDocumentview:
 
     def test_page_description(self, client, document, join, fragment, empty_solr):
         """should use count and pluralization in related documents view meta description"""
-
         Document.index_items([document, join])
         SolrClient().update.index([], commit=True)
 

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -19,6 +19,11 @@ urlpatterns = [
         name="document-scholarship",
     ),
     path(
+        "documents/<int:pk>/related/",
+        corpus_views.RelatedDocumentView.as_view(),
+        name="related-documents",
+    ),
+    path(
         "documents/<int:pk>/transcription/<int:transcription_pk>/",
         corpus_views.DocumentTranscriptionText.as_view(),
         name="document-transcription-text",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -332,12 +332,11 @@ class DocumentScholarshipView(DocumentDetailView):
         count = doc.footnotes.count()
         # Translators: description of document scholarship page, for search engines
         return ngettext(
-            "%(count)d scholarship record for %(doc)s",
-            "%(count)d scholarship records for %(doc)s",
+            "%(count)d scholarship record",
+            "%(count)d scholarship records",
             count,
         ) % {
             "count": count,
-            "doc": doc.title,
         }
 
     def get_queryset(self, *args, **kwargs):
@@ -377,17 +376,15 @@ class RelatedDocumentView(DocumentDetailView):
         return _("Related documents for %(doc)s") % {"doc": self.get_object().title}
 
     def page_description(self):
-        # TODO description text
         doc = self.get_object()
-        count = doc.footnotes.count()
-        # Translators: description of document scholarship page, for search engines
+        count = doc.related_documents.count()
+        # Translators: description of related documents page, for search engines
         return ngettext(
-            "%(count)d scholarship record for %(doc)s",
-            "%(count)d scholarship records for %(doc)s",
+            "%(count)d related document",
+            "%(count)d related documents",
             count,
         ) % {
             "count": count,
-            "doc": doc.title,
         }
 
     def get_context_data(self, **kwargs):

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -392,10 +392,7 @@ class RelatedDocumentView(DocumentDetailView):
         # if there are no related documents, don't serve out this page
         if not doc.related_documents.count():
             raise Http404
-
-        context_data = super().get_context_data(**kwargs)
-        context_data.update({"highlighting": {}})  # no solr highlighting
-        return context_data
+        return super().get_context_data(**kwargs)
 
 
 class DocumentTranscriptionText(DocumentDetailView):

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -364,6 +364,43 @@ class DocumentScholarshipView(DocumentDetailView):
         return context_data
 
 
+class RelatedDocumentView(DocumentDetailView):
+    """List of :class:`~geniza.corpus.models.Document`
+    objects that are related to specific :class:`~geniza.corpus.models.Document`
+    (e.g., by occuring on the same shelfmark)."""
+
+    template_name = "corpus/related_documents.html"
+    viewname = "corpus:related-documents"
+
+    def page_title(self):
+        # Translators: title of related documents page
+        return _("Related documents for %(doc)s") % {"doc": self.get_object().title}
+
+    def page_description(self):
+        # TODO description text
+        doc = self.get_object()
+        count = doc.footnotes.count()
+        # Translators: description of document scholarship page, for search engines
+        return ngettext(
+            "%(count)d scholarship record for %(doc)s",
+            "%(count)d scholarship records for %(doc)s",
+            count,
+        ) % {
+            "count": count,
+            "doc": doc.title,
+        }
+
+    def get_context_data(self, **kwargs):
+        doc = self.get_object()
+        # if there are no related documents, don't serve out this page
+        if not doc.related_documents.count():
+            raise Http404
+
+        context_data = super().get_context_data(**kwargs)
+        context_data.update({"highlighting": {}})  # no solr highlighting
+        return context_data
+
+
 class DocumentTranscriptionText(DocumentDetailView):
     """Return transcription as plain text for download"""
 

--- a/sitemedia/scss/components/_metadata.scss
+++ b/sitemedia/scss/components/_metadata.scss
@@ -5,7 +5,7 @@
 @use "../base/spacing";
 @use "../base/typography";
 
-.metadata {
+dl.metadata-list {
     display: grid;
     @include typography.meta;
     dd,

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -9,6 +9,12 @@
 @use "../base/colors";
 
 section#document-list {
+    width: 100%;
+    @include container.two-column;
+    display: flex;
+    flex-direction: column;
+    padding: 0 spacing.$spacing-md spacing.$spacing-md;
+
     // count of results
     h1 {
         @include container.two-column;
@@ -110,7 +116,7 @@ section#document-list {
         }
 
         // other document metadata
-        .metadata {
+        dl.metadata-list {
             grid-template-columns: auto 1fr;
             column-gap: 1rem;
         }
@@ -283,7 +289,7 @@ section#document-list {
     /* raise tags & text over clickable pseudo content to allow selection */
     .description,
     .transcription,
-    .metadata dd,
+    dl.metadata-list dd,
     .tags {
         position: relative;
         z-index: 4;

--- a/sitemedia/scss/components/_tabs.scss
+++ b/sitemedia/scss/components/_tabs.scss
@@ -7,13 +7,22 @@
 @use "../base/spacing";
 @use "../base/typography";
 
+nav#tabs {
+    max-width: 60ch;
+    padding: spacing.$spacing-md spacing.$spacing-md 0;
+}
 .tabs {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    // on mobile, ensure third tab has enough space
+    grid-template-columns: 0.9fr 0.9fr 1.2fr;
+    @include breakpoints.for-tablet-landscape-up {
+        grid-template-columns: 1fr 1fr 1fr;
+    }
     align-content: stretch;
     justify-content: center;
     margin: 0 auto;
     max-width: none;
+    width: 100%;
     @include typography.nav-link;
     // Tabs styling
     a,
@@ -62,16 +71,6 @@
         // Don't show hover color on current page tab
         &:hover {
             border-bottom-color: var(--secondary);
-        }
-    }
-    // Extra padding to get External Links on two lines
-    li:last-child a,
-    li:last-child span {
-        padding-left: spacing.$spacing-sm;
-        padding-right: spacing.$spacing-sm;
-        @include breakpoints.for-tablet-landscape-up {
-            padding-left: spacing.$spacing-2xl;
-            padding-right: spacing.$spacing-2xl;
         }
     }
 }

--- a/sitemedia/scss/main.scss
+++ b/sitemedia/scss/main.scss
@@ -21,5 +21,6 @@
 @use "pages/document";
 @use "pages/error";
 @use "pages/home";
+@use "pages/related";
 @use "pages/scholarship";
 @use "pages/search";

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -13,12 +13,12 @@ main.document {
     .container {
         display: flex;
         flex-direction: column;
-        padding: spacing.$spacing-md;
+        padding: 0 spacing.$spacing-md spacing.$spacing-md;
         margin-bottom: spacing.$spacing-md;
         @include breakpoints.for-desktop-up {
             margin-bottom: spacing.$spacing-xl;
         }
-        section:first-of-type {
+        section.metadata {
             display: flex;
             flex-direction: column;
             @include breakpoints.for-desktop-up {
@@ -28,7 +28,7 @@ main.document {
             }
         }
         // Document metadata
-        dl.metadata {
+        dl.metadata-list {
             display: flex;
             flex-direction: column;
             margin: spacing.$spacing-2xl spacing.$spacing-md 0;
@@ -71,7 +71,7 @@ main.document {
                 margin-top: spacing.$spacing-xs;
             }
         }
-        dl.metadata.primary + dl.metadata.secondary {
+        dl.metadata-list.primary + dl.metadata-list.secondary {
             margin-top: 0;
             @include breakpoints.for-desktop-up {
                 margin-left: 35px;
@@ -134,7 +134,7 @@ main.document {
             }
         }
     }
-    dl.metadata.tertiary {
+    dl.metadata-list.tertiary {
         margin-top: 51px;
         padding: 0 20px;
         width: 100%;

--- a/sitemedia/scss/pages/_related.scss
+++ b/sitemedia/scss/pages/_related.scss
@@ -1,0 +1,9 @@
+// -----------------------------------------------------------------------------
+// List of documents related to a given document.
+// -----------------------------------------------------------------------------
+
+@use "../base/container";
+
+section#document-list.related-documents {
+    @include container.two-column;
+}

--- a/sitemedia/scss/pages/_scholarship.scss
+++ b/sitemedia/scss/pages/_scholarship.scss
@@ -10,9 +10,9 @@ main.scholarship {
     div.container {
         display: flex;
         flex-direction: column;
-        padding: spacing.$spacing-md spacing.$spacing-sm;
+        padding: 0 spacing.$spacing-sm spacing.$spacing-md;
         @include breakpoints.for-desktop-up {
-            padding: spacing.$spacing-md;
+            padding: 0 spacing.$spacing-md spacing.$spacing-md;
         }
     }
     ol {

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -19,11 +19,4 @@ main.search {
             margin-top: spacing.$spacing-2xl;
         }
     }
-    section#document-list {
-        width: 100%;
-        @include container.two-column;
-        display: flex;
-        flex-direction: column;
-        padding: 0 spacing.$spacing-md spacing.$spacing-md;
-    }
 }


### PR DESCRIPTION
in this pr:

- initial view & template for new related documents page (replaces placeholder "external links")
- solr query to find other documents that share any of the same shelfmarks
- update document tab template to display related docs link with count
- adjust document result template to work with or without pagination object
- simplify page description for scholarship record & related docs (document title is redundant)
- update existing tests for external links tab behavior

no tests yet for new methods/views/templates; no updates to styles