### PR TITLE
Multiple transcriptions selector in ITT panel (#899)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -32,6 +32,14 @@
     {% if document.has_image or document.iiif_urls %}
         <link rel="preconnect" href="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/3.0.0/images/" crossorigin />
     {% endif %}
+    {# Disable ITT Panel when no JS available #}
+    <noscript>
+        <style>
+            #itt-panel {
+                display: none;
+            }
+        </style>
+    </noscript>
 {% endblock extrascript %}
 
 {% block main %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -3,11 +3,11 @@
     {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}
     {# images displayed by default; disable if no images are available #}
     {# translators: label for checkbox toggle to show the images panel for a document #}
-    <input type="checkbox" id="images-on" aria-label="{% translate 'show images' %}" {% if document.has_image %}checked="true" {% else %} disabled="true"{% endif %}/>
+    <input type="checkbox" id="images-on" aria-label="{% translate 'show images' %}" {% if document.has_image %}checked="true" {% else %} disabled="true"{% endif %} data-action="transcription#togglePanel"/>
     <label for="images-on"></label>
     {# transcription displayed by default; disable if no content is available #}
     {# translators: label for checkbox toggle to show the transcription panel for a document #}
-    <input type="checkbox" id="transcription-on" aria-label="{% translate 'show transcription' %}" {% if document.digital_editions %}checked="true" {% else %} disabled="true"{% endif %}/>
+    <input type="checkbox" id="transcription-on" aria-label="{% translate 'show transcription' %}" {% if document.digital_editions %}checked="true" {% else %} disabled="true"{% endif %} data-action="transcription#togglePanel"/>
     <label for="transcription-on"><svg><use xlink:href="{% static 'img/ui/all/all/transcription-toggle.svg' %}#transcription-toggle" /></svg></label>
     {# translation disabled for now since we don't handle them in the system yet #}
     {# translators: label for checkbox toggle to show the translation panel for a document #}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -13,6 +13,25 @@
     {# translators: label for checkbox toggle to show the translation panel for a document #}
     <input type="checkbox" id="translation-on" aria-label="{% translate 'show translation' %}" disabled="true"/>
     <label for="translation-on"><svg><use xlink:href="{% static 'img/ui/all/all/translation-toggle.svg' %}#translation-toggle" /></svg></label>
+    <div class="dropdown-container">
+        <div></div>
+        <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails">
+            <summary class="transcription-select-trigger" data-action="keydown->transcription#shiftTabCloseDropdown">
+                <span data-transcription-target="editionShortLabel">Edition: {{ document.digital_editions.0.source.all_authors }}</span>
+            </summary>
+            <ul>
+                {% for ed in document.digital_editions.all %}
+                    <li>
+                        <label for="edition-{{ forloop.counter }}">
+                            <input type="radio" name="transcription" value="relevance" data-action="input->transcription#changeTranscription keydown->transcription#keyboardCloseDropdown" id="edition-{{ forloop.counter }}" data-edition="ed-{{ ed.pk }}" />
+                            <span>Edition: {{ ed.source.all_authors }}</span>
+                        </label>
+                    </li>
+                {% endfor %}
+            </ul>
+        </details>
+        <div></div>
+    </div>
     <div class="panel-container">
         {% comment %}
 NOTE: if we have more transcription pages than images,
@@ -34,29 +53,14 @@ Also doesn't currently account for fragments without images.
                 </div>
                 <div class="transcription-panel">
                     {% if forloop.first %}
-                        <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails">
-                            <summary class="transcription-select-trigger" data-transcription-target="dropdownLabel" data-action="keydown->transcription#shiftTabCloseDropdown">
-                                <span>Edition: {{ document.digital_editions.0.source.all_authors }}</span>
-                            </summary>
-                            <ul>
-                                {% for ed in document.digital_editions.all %}
-                                    <li>
-                                        <label for="edition-{{ forloop.counter }}">
-                                            <input type="radio" name="transcription" value="relevance" data-action="input->transcription#changeTranscription keydown->transcription#keyboardCloseDropdown" id="edition-{{ forloop.counter }}" data-edition="ed-{{ ed.pk }}" />
-                                            <span>Edition: {{ ed.source.all_authors }}</span>
-                                        </label>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </details>
                         <h3>Transcription</h3>
-
+                        <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
                     {% endif %}
 
                     <div class="editions">
                         {# display transcription in chunks by index #}
                         {% for edition in document.digital_editions.all %}
-                            <div class="transcription" id="ed-{{ edition.pk }}">
+                            <div class="transcription" id="ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
                                 {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
                             </div>
                         {% endfor %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -15,7 +15,7 @@
     <label for="translation-on"><svg><use xlink:href="{% static 'img/ui/all/all/translation-toggle.svg' %}#translation-toggle" /></svg></label>
     <div class="dropdown-container">
         <div></div>
-        <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails">
+        <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails"{% if document.digital_editions.count == 1 %} disabled="true"{% endif %}>
             <summary class="transcription-select-trigger" data-action="keydown->transcription#shiftTabCloseDropdown">
                 <span data-transcription-target="editionShortLabel">Edition: {{ document.digital_editions.0.source.all_authors }}</span>
             </summary>

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -1,5 +1,5 @@
 {% load i18n static corpus_extras %}
-<section id="itt-panel">
+<section id="itt-panel" data-controller="transcription" data-action="click@document->transcription#clickCloseDropdown">
     {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}
     {# images displayed by default; disable if no images are available #}
     {# translators: label for checkbox toggle to show the images panel for a document #}
@@ -32,20 +32,45 @@ Also doesn't currently account for fragments without images.
                         {{ image_info.image|iiif_image:"size:width=640" }} 640w,
                         {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
                 </div>
-                <div class="transcription">
-                    {% if forloop.first %}<h3>Transcription</h3>{% endif %}
-                    {# display transcription in chunks by index #}
-                    <div>{{ document.digital_editions.0.content.html|index:forloop.counter0|h1_to_h3|safe }}</div>
+                <div class="transcription-panel">
+                    {% if forloop.first %}
+                        <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails">
+                            <summary class="transcription-select-trigger" data-transcription-target="dropdownLabel" data-action="keydown->transcription#shiftTabCloseDropdown">
+                                <span>Edition: {{ document.digital_editions.0.source.all_authors }}</span>
+                            </summary>
+                            <ul>
+                                {% for ed in document.digital_editions.all %}
+                                    <li>
+                                        <label for="edition-{{ forloop.counter }}">
+                                            <input type="radio" name="transcription" value="relevance" data-action="input->transcription#changeTranscription keydown->transcription#keyboardCloseDropdown" id="edition-{{ forloop.counter }}" data-edition="ed-{{ ed.pk }}" />
+                                            <span>Edition: {{ ed.source.all_authors }}</span>
+                                        </label>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </details>
+                        <h3>Transcription</h3>
+
+                    {% endif %}
+
+                    <div class="editions">
+                        {# display transcription in chunks by index #}
+                        {% for edition in document.digital_editions.all %}
+                            <div class="transcription" id="ed-{{ edition.pk }}">
+                                {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
+                            </div>
+                        {% endfor %}
+                    </div>
                 </div>
             {% endfor %}
             {# if there are no images, loop based on the transcription chunks instead #}
         {% elif document.has_transcription %}
             {% for chunk in document.digital_editions.0.content.html %}
                 <div class="img"></div> {# empty image div needed for grid layout #}
-                <div class="transcription">
+                <div class="transcription-panel">
                     {% if forloop.first %}<h3>Transcription</h3>{% endif %}
                     {# display transcription in chunks based on loop index #}
-                    <div>{{ chunk|h1_to_h3|safe }}</div>
+                    <div class="transcription">{{ chunk|h1_to_h3|safe }}</div>
                 </div>
             {% endfor %}
         {% endif %}
@@ -55,47 +80,3 @@ Also doesn't currently account for fragments without images.
     </div>
 
 </section>
-
-{% comment %}
-<hr/>
-OLD panel
-
-
-<section id="iiif-viewer" data-controller="iiif">
-    <h1 class="sr-only">
-        {# Translators: accessibility label for document images and transcription section #}
-        {% translate "Images and transcription" %}
-    </h1>
-    {% if document.has_image %}
-        <noscript>
-            <ol id="iiif-images-fallback">
-                {% for image_dict in document.iiif_images %}
-                    <li id="image-{{ forloop.counter }}">
-                        <a href="{{ image_dict.image|iiif_image:"size:width=2880" }}">
-                            <img src="{{ image_dict.image|iiif_image:"size:width=500" }}" alt="{{ image_dict.label }}" title="{{ image_dict.label }}" loading="lazy">
-                        </a>
-                    </li>
-                {% endfor %}
-            </ol>
-        </noscript>
-        <div id="iiif-images" data-iiif-target="iiifContainer" data-iiif-urls="{{ document.iiif_images|iiif_info_json }}" class="{% if not document.has_transcription %}no-transcription{% endif %}">
-        </div>
-    {% endif %}
-    {% if document.digital_editions %}
-        <div class="transcription{% if not document.has_image %} no-image{% endif %}">
-            <h2>{% translate 'Transcription' %}</h2>
-            {% if document.digital_editions|length > 1 %}
-                {# when there are multiple editions, use disclosure element #}
-                {% for edition in document.digital_editions %}
-                    <details open>
-                        <summary class="source">{{ edition.source.display }}</summary>
-                        <div>{{ edition.content.html|h1_to_h3|safe }}</div>
-                    </details>
-                {% endfor %}
-            {% else %}
-                <div>{{ document.digital_editions.0.content.html|h1_to_h3|safe }}</div>
-            {% endif %}
-        </div>
-    {% endif %}
-</section>
-{% endcomment %}

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -55,7 +55,7 @@ class TestDocumentDetailTemplate:
         response = client.get(document.get_absolute_url())
         assertContains(
             response,
-            '<section id="itt-panel">',
+            '<section id="itt-panel" data-controller="transcription" data-action="click@document->transcription#clickCloseDropdown">',
         )
 
     def test_viewer_annotations(self, client, document, unpublished_editions):

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -64,7 +64,7 @@ class TestDocumentDetailTemplate:
         response = client.get(document.get_absolute_url())
         assertNotContains(
             response,
-            '<input type="checkbox" id="transcription-on" checked="true" aria-label="show transcription">',
+            '<input type="checkbox" id="transcription-on" checked="true" aria-label="show transcription" data-action="transcription#togglePanel">',
             html=True,
         )
 
@@ -78,7 +78,7 @@ class TestDocumentDetailTemplate:
         response = client.get(document.get_absolute_url())
         assertContains(
             response,
-            '<input type="checkbox" id="transcription-on" checked="true" aria-label="show transcription">',
+            '<input type="checkbox" id="transcription-on" checked="true" aria-label="show transcription" data-action="transcription#togglePanel">',
             html=True,
         )
 

--- a/sitemedia/js/controllers/transcription_controller.js
+++ b/sitemedia/js/controllers/transcription_controller.js
@@ -20,10 +20,7 @@ export default class extends Controller {
          */
         const edition = evt.currentTarget.dataset.edition;
         const chunks = document.querySelectorAll(`#${edition}`);
-        chunks.forEach((chunk) => {
-            chunk.parentNode.scrollLeft =
-                chunk.offsetLeft - chunk.parentNode.offsetLeft;
-        });
+        this.scrollChunksIntoView(chunks);
 
         // Set subheader to show full label for edition
         this.editionFullLabelTarget.innerHTML = chunks[0].dataset.label;
@@ -57,6 +54,27 @@ export default class extends Controller {
         // of it. This needs to be on the whole document because the click could be from anywhere!
         if (this.dropdownDetailsTarget.open) {
             this.dropdownDetailsTarget.removeAttribute("open");
+        }
+    }
+
+    scrollChunksIntoView(chunks) {
+        // Scroll the selected chunks into view
+        chunks.forEach((chunk) => {
+            chunk.parentNode.scrollLeft =
+                chunk.offsetLeft - chunk.parentNode.offsetLeft;
+        });
+    }
+
+    togglePanel() {
+        // When a panel is closed and reopened, the offsets for the transcription panel
+        // must be recalculated
+        const selectedEditionInput = document.querySelector(
+            'input:checked[type="radio"][name="transcription"]'
+        );
+        if (selectedEditionInput) {
+            const edition = selectedEditionInput.dataset.edition;
+            const chunks = document.querySelectorAll(`#${edition}`);
+            this.scrollChunksIntoView(chunks);
         }
     }
 }

--- a/sitemedia/js/controllers/transcription_controller.js
+++ b/sitemedia/js/controllers/transcription_controller.js
@@ -3,7 +3,11 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-    static targets = ["dropdownLabel", "dropdownDetails"];
+    static targets = [
+        "editionShortLabel",
+        "editionFullLabel",
+        "dropdownDetails",
+    ];
 
     // Change transcription dropdown: pseudo-<select> element with radio buttons to allow styling
     // dropdown menu options list
@@ -20,10 +24,13 @@ export default class extends Controller {
             chunk.parentNode.scrollLeft =
                 chunk.offsetLeft - chunk.parentNode.offsetLeft;
         });
-        this.setDropdownLabel(evt.currentTarget.parentElement.textContent);
-    }
-    setDropdownLabel(label) {
-        this.dropdownLabelTarget.children[0].innerHTML = label;
+
+        // Set subheader to show full label for edition
+        this.editionFullLabelTarget.innerHTML = chunks[0].dataset.label;
+
+        // Mimic "header" functionality by copying the shortened edition metadata from option to summary
+        this.editionShortLabelTarget.innerHTML =
+            evt.currentTarget.parentElement.textContent;
     }
 
     keyboardCloseDropdown(e) {

--- a/sitemedia/js/controllers/transcription_controller.js
+++ b/sitemedia/js/controllers/transcription_controller.js
@@ -1,0 +1,55 @@
+// controllers/transcriptionController.js
+
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["dropdownLabel", "dropdownDetails"];
+
+    // Change transcription dropdown: pseudo-<select> element with radio buttons to allow styling
+    // dropdown menu options list
+
+    changeTranscription(evt) {
+        /*
+         * Event listener to handle changes to the visible transcription content, and to
+         * mimic <select> menu "header" functionality in a details/summary with radio
+         * button inputs.
+         */
+        const edition = evt.currentTarget.dataset.edition;
+        const chunks = document.querySelectorAll(`#${edition}`);
+        chunks.forEach((chunk) => {
+            chunk.parentNode.scrollLeft =
+                chunk.offsetLeft - chunk.parentNode.offsetLeft;
+        });
+        this.setDropdownLabel(evt.currentTarget.parentElement.textContent);
+    }
+    setDropdownLabel(label) {
+        this.dropdownLabelTarget.children[0].innerHTML = label;
+    }
+
+    keyboardCloseDropdown(e) {
+        // exit the list and submit on enter/space
+        if (
+            this.dropdownDetailsTarget.open &&
+            (e.code === "Enter" ||
+                e.code === "Space" ||
+                (!e.shiftKey && e.code === "Tab")) // Tab out of a radio button = exiting the list
+        ) {
+            this.dropdownDetailsTarget.removeAttribute("open");
+        }
+    }
+
+    shiftTabCloseDropdown(e) {
+        // Shift-tab out of the summary = exiting the list
+        if (this.dropdownDetailsTarget.open && e.shiftKey && e.code === "Tab") {
+            this.dropdownDetailsTarget.removeAttribute("open");
+        }
+    }
+
+    clickCloseDropdown(e) {
+        // Event listener to close the dropdown <details> element when a click is registered outside
+        // of it. This needs to be on the whole document because the click could be from anywhere!
+        if (this.dropdownDetailsTarget.open) {
+            this.dropdownDetailsTarget.removeAttribute("open");
+        }
+    }
+}

--- a/sitemedia/scss/base/_colors.scss
+++ b/sitemedia/scss/base/_colors.scss
@@ -62,7 +62,7 @@ $off-white: #f7f7f7;
     --filter-border: rgba(0, 0, 0, 0.25);
     // active filter, metadata bullet color
     --filter-active: #7bac7b;
-    // "in PGP since" text
+    // "in PGP since" text, edition text in ITT panel
     --input-date-text: #595959;
     // permalink icon
     --permalink-icon: #f7f7f7;
@@ -120,7 +120,7 @@ $off-white: #f7f7f7;
     --filter-border: #161616;
     // active filter, metadata bullet color
     --filter-active: #c37f97;
-    // "in PGP since" text
+    // "in PGP since" text, edition text in ITT panel
     --input-date-text: #cfcfcf;
     // permalink icon
     --permalink-icon: #3d3d3d;

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -296,44 +296,6 @@ section#document-list {
     }
 }
 
-// styles specific to transcription;
-// appear in search results and in mirador viewer
-.transcription {
-    @include typography.transcription;
-    @include typography.hebrew;
-    align-self: flex-end;
-
-    text-align: right;
-    // direction: rtl; /* search results ae mixed rtl/ltr and include unicode order mark characters */
-
-    .search-result & p {
-        white-space: pre-line;
-        text-align: right;
-        // disable site default max character width for reading
-        max-width: none;
-    }
-
-    li {
-        white-space: pre-line;
-        margin-right: 2em; /* shift to make space for line numbers */
-        direction: rtl;
-    }
-
-    /* some transcription styles adapted from local admin site css */
-    li::before {
-        /* use pseudo marker to avoid periods for line numbers */
-        content: attr(value);
-        margin-right: -2em; /* shift outside text margin */
-        text-align: right;
-        float: right;
-        font-weight: bold;
-    }
-
-    li::marker {
-        direction: rtl;
-    }
-}
-
 // tweaks for RTL search results for hebrew, arabic
 html[dir="rtl"] .search-result {
     // spacing in between results

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1,6 +1,7 @@
 /* styles for image + transcription viewer */
 @use "../base/a11y";
 @use "../base/breakpoints";
+@use "../components/searchform";
 @use "../base/spacing";
 @use "../base/typography";
 
@@ -198,7 +199,7 @@
         padding-bottom: 30px;
 
         // transcription panel spacing
-        div.transcription {
+        div.transcription-panel {
             width: auto;
         }
 
@@ -222,7 +223,7 @@
         }
 
         // transcription panel spacing
-        div.transcription {
+        div.transcription-panel {
             width: 100%;
             @include breakpoints.for-tablet-landscape-up {
                 padding-left: 5%;
@@ -247,7 +248,7 @@
 
     /* content panels should have normal height when enabled */
     #images-on:checked ~ .panel-container .img,
-    #transcription-on:checked ~ .panel-container .transcription {
+    #transcription-on:checked ~ .panel-container .transcription-panel {
         height: 100%;
     }
 
@@ -281,7 +282,7 @@
         }
     }
     // transcription panel styles
-    .panel-container div.transcription {
+    .panel-container div.transcription-panel {
         * {
             max-width: none;
         }
@@ -290,13 +291,113 @@
             display: none;
         }
         @include breakpoints.for-tablet-landscape-up {
-            padding: 60px 0 0;
+            padding: 0 0 0;
             & > h3 {
                 display: block;
                 @include typography.body-bold;
             }
             h3 {
                 margin: 12px 0;
+            }
+        }
+
+        // multiple transcription pseudo-select element
+        details.transcription-select {
+            position: relative;
+            flex: 1 1 auto;
+            min-height: 2.5rem;
+            width: 100%;
+            summary {
+                display: flex;
+                min-height: 2.5rem;
+                cursor: pointer;
+                // Suppress default details marker
+                &::-webkit-details-marker {
+                    display: none;
+                }
+                span {
+                    cursor: pointer;
+                    background-color: var(--background);
+                    color: var(--on-background);
+                    flex: 1 1 auto;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: spacing.$spacing-2xs 0.7rem;
+                    margin-right: spacing.$spacing-sm;
+                    @include typography.body-bold;
+                    @include searchform.form-drop-shadow;
+                    &::after {
+                        content: "\f0c2"; // phosphor caret-down icon
+                        @include typography.icon-button-md;
+                    }
+                }
+            }
+            // List of transcription options
+            ul {
+                position: absolute;
+                z-index: 20;
+                width: calc(100% - 0.667rem);
+                padding: spacing.$spacing-sm 0;
+                @include searchform.form-drop-shadow;
+                background-color: var(--background);
+                li {
+                    display: flex;
+                    label {
+                        width: 100%;
+                        flex: 0 1 100%;
+                        display: flex;
+                        cursor: pointer;
+                        span {
+                            display: flex;
+                            align-items: center;
+                            width: 100%;
+                            flex: 0 1 100%;
+                            padding: spacing.$spacing-sm;
+                            transition: background-color 0.15s ease,
+                                color 0.15s ease;
+                        }
+                        &:hover,
+                        &:focus-within {
+                            background-color: var(--background-gray);
+                            color: var(--on-background-gray);
+                        }
+                        &:hover input[name="transcription"]:focus + span {
+                            background-color: var(--tertiary);
+                            color: var(--on-tertiary);
+                        }
+                        // Checkboxes only visible to screen readers
+                        input[name="transcription"] {
+                            @include a11y.sr-only;
+                            // Selected option
+                            &:checked + span {
+                                @include typography.form-option-sm-bold;
+                            }
+                            &:active + span {
+                                background-color: var(--secondary);
+                                color: var(--on-secondary);
+                            }
+                            &:disabled + span {
+                                color: var(--disabled);
+                                cursor: default;
+                                background-color: var(--background-light);
+                            }
+                        }
+                        // Non-selected options
+                        @include typography.form-option-sm;
+                    }
+                }
+            }
+        }
+
+        // "carousel" for switching between multiple transcriptions
+        width: 100%;
+        div.editions {
+            display: flex;
+            overflow-x: hidden;
+            & > div {
+                flex: 1 0 100%;
+                align-self: flex-start;
             }
         }
     }
@@ -404,5 +505,43 @@
                 }
             }
         }
+    }
+}
+
+// general transcription styles
+// appear in ITT viewer and in search results
+.transcription {
+    @include typography.transcription;
+    @include typography.hebrew;
+    align-self: flex-end;
+
+    text-align: right;
+    // direction: rtl; /* search results ae mixed rtl/ltr and include unicode order mark characters */
+
+    .search-result & p {
+        white-space: pre-line;
+        text-align: right;
+        // disable site default max character width for reading
+        max-width: none;
+    }
+
+    li {
+        white-space: pre-line;
+        margin-right: 2em; /* shift to make space for line numbers */
+        direction: rtl;
+    }
+
+    /* some transcription styles adapted from local admin site css */
+    li::before {
+        /* use pseudo marker to avoid periods for line numbers */
+        content: attr(value);
+        margin-right: -2em; /* shift outside text margin */
+        text-align: right;
+        float: right;
+        font-weight: bold;
+    }
+
+    li::marker {
+        direction: rtl;
     }
 }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -481,8 +481,10 @@
             margin: 30px 0 12px;
         }
         h3 + span.current-transcription {
+            display: block;
             @include typography.meta;
             color: var(--input-date-text);
+            min-height: calc(1rem * 1.5 * 2);
         }
         @include breakpoints.for-tablet-landscape-up {
             padding: 0 0 0;
@@ -492,6 +494,9 @@
             & > h3 {
                 @include typography.body-bold;
                 margin: 27px 0 0;
+            }
+            h3 + span.current-transcription {
+                min-height: calc(1.125rem * 1.5 * 2);
             }
         }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -88,7 +88,7 @@
                 }
                 // images panel toggle is wider
                 &[for="images-on"] {
-                    flex: 1 0 calc(0.48 * 100vw);
+                    flex: 1 0 calc(0.46 * 100vw);
                 }
                 // expand icon size
                 svg {
@@ -260,6 +260,19 @@
                     }
                 }
             }
+            // disable interaction when only 1 transcription (cannot use :disabled on <details>)
+            &[disabled="true"] {
+                * {
+                    cursor: default;
+                }
+                summary span:active {
+                    @include searchform.box-shadow(var(--on-background-25));
+                }
+                summary span::after,
+                ul {
+                    display: none;
+                }
+            }
             // spacing tweaks for transcription selector on desktop
             @include breakpoints.for-tablet-landscape-up {
                 width: auto;
@@ -307,7 +320,7 @@
         #images-on:checked ~ .dropdown-container {
             // Empty div for spacing
             div:first-child {
-                flex: 1 0 calc(0.48 * 100vw);
+                flex: 1 0 calc(0.46 * 100vw);
             }
         }
     }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -27,6 +27,7 @@
             width: 100px;
             max-width: 100px;
             @include breakpoints.for-tablet-landscape-up {
+                flex: 1 0 87px;
                 justify-content: center;
                 height: 95px;
                 width: 87px;
@@ -82,9 +83,12 @@
             &:checked + label {
                 max-width: 100vw;
                 flex: 1 0 auto;
+                &[for="transcription-on"] {
+                    flex: 1 0 calc(0.4 * 100vw);
+                }
                 // images panel toggle is wider
                 &[for="images-on"] {
-                    flex: 1 0 20%;
+                    flex: 1 0 calc(0.48 * 100vw);
                 }
                 // expand icon size
                 svg {
@@ -138,9 +142,178 @@
         }
     }
 
+    // Flex container for transcription and translation dropdowns
+    .dropdown-container {
+        max-width: none;
+        * {
+            max-width: none;
+        }
+        display: none;
+        align-items: center;
+        justify-content: space-between;
+        flex: 1 0 100%;
+        margin-top: 0.5rem;
+        background-color: var(--background-light);
+        div,
+        details {
+            transition: all 300ms ease;
+        }
+        flex-flow: column;
+        @include breakpoints.for-tablet-landscape-up {
+            flex-flow: row;
+            min-height: 2.5rem;
+            div:first-child {
+                margin-left: auto;
+                margin-right: 0.5rem;
+            }
+            // Empty div for spacing (will be translation dropdown)
+            div:last-child {
+                width: 87px;
+            }
+        }
+
+        // multiple transcription pseudo-select element
+        details.transcription-select {
+            position: relative;
+            width: 100%;
+            summary {
+                display: flex;
+                flex-flow: row;
+                cursor: pointer;
+                // Suppress default details marker
+                &::-webkit-details-marker {
+                    display: none;
+                }
+                // label for current selection
+                span {
+                    cursor: pointer;
+                    width: 1%;
+                    background-color: var(--background);
+                    color: var(--on-background);
+                    flex: 1 0 auto;
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    padding: spacing.$spacing-2xs 0.7rem;
+                    @include typography.body-bold;
+                    @include searchform.form-drop-shadow;
+                    &::after {
+                        content: "\f0c2"; // phosphor caret-down icon
+                        @include typography.icon-button-md;
+                        float: right;
+                    }
+                }
+            }
+            // List of transcription options
+            ul {
+                position: absolute;
+                z-index: 20;
+                width: calc(100% - 0.667rem);
+                padding: spacing.$spacing-sm 0;
+                @include searchform.form-drop-shadow;
+                background-color: var(--background);
+                // label for single transcription option
+                li {
+                    display: flex;
+                    label {
+                        width: 100%;
+                        flex: 0 1 100%;
+                        display: flex;
+                        cursor: pointer;
+                        span {
+                            display: flex;
+                            align-items: center;
+                            width: 100%;
+                            flex: 0 1 100%;
+                            padding: spacing.$spacing-sm;
+                            transition: background-color 0.15s ease,
+                                color 0.15s ease;
+                        }
+                        &:hover,
+                        &:focus-within {
+                            background-color: var(--background-gray);
+                            color: var(--on-background-gray);
+                        }
+                        &:hover input[name="transcription"]:focus + span {
+                            background-color: var(--tertiary);
+                            color: var(--on-tertiary);
+                        }
+                        // Checkboxes only visible to screen readers
+                        input[name="transcription"] {
+                            @include a11y.sr-only;
+                            // Selected option
+                            &:checked + span {
+                                @include typography.form-option-sm-bold;
+                            }
+                            &:active + span {
+                                background-color: var(--secondary);
+                                color: var(--on-secondary);
+                            }
+                            &:disabled + span {
+                                color: var(--disabled);
+                                cursor: default;
+                                background-color: var(--background-light);
+                            }
+                        }
+                        // Non-selected options
+                        @include typography.form-option-sm;
+                    }
+                }
+            }
+            // spacing tweaks for transcription selector on desktop
+            @include breakpoints.for-tablet-landscape-up {
+                width: auto;
+                flex: 1 0 calc(0.4 * 100vw);
+                min-height: 2.5rem;
+                // label for current selection
+                summary {
+                    min-height: 2.5rem;
+                    span {
+                        margin-right: spacing.$spacing-sm;
+                        text-align: center;
+                        padding: spacing.$spacing-2xs 0.7rem
+                            spacing.$spacing-2xs 24px;
+                        display: inline;
+                    }
+                }
+            }
+        }
+    }
+
+    // should show dropdown container if any toggles are checked
+    *:checked ~ .dropdown-container {
+        display: flex;
+    }
+    // images only checked, don't show transcription selector
+    #images-on:checked ~ .dropdown-container {
+        details.transcription-select {
+            opacity: 0;
+        }
+    }
+    // transcription checked, show transcription selector
+    #transcription-on:checked ~ .dropdown-container {
+        details.transcription-select {
+            opacity: 1;
+        }
+    }
+    @include breakpoints.for-tablet-landscape-up {
+        // transcription only checked, ensure empty div for images is small
+        #transcription-on:checked ~ .dropdown-container {
+            div:first-child {
+                width: 87px;
+            }
+        }
+        // images checked, ensure empty div for images is large
+        #images-on:checked ~ .dropdown-container {
+            // Empty div for spacing
+            div:first-child {
+                flex: 1 0 calc(0.48 * 100vw);
+            }
+        }
+    }
+
     .panel-container {
         background-color: var(--background-light);
-        margin-top: 0.5rem;
         display: grid;
         width: 100%;
         /* when no content panels are selected, don't show anything  */
@@ -200,7 +373,8 @@
 
         // transcription panel spacing
         div.transcription-panel {
-            width: auto;
+            width: 100%;
+            max-width: 604px;
         }
 
         // Attribution and license text
@@ -225,6 +399,7 @@
         // transcription panel spacing
         div.transcription-panel {
             width: 100%;
+            max-width: none;
             @include breakpoints.for-tablet-landscape-up {
                 padding-left: 5%;
             }
@@ -270,7 +445,7 @@
             margin: 0 auto;
         }
         @include breakpoints.for-tablet-landscape-up {
-            padding: 60px 0 0;
+            padding: 14px 0 0;
             max-width: 640px;
             h3 {
                 margin: 12px 0;
@@ -281,117 +456,33 @@
             }
         }
     }
+
     // transcription panel styles
     .panel-container div.transcription-panel {
+        width: 100%;
         * {
             max-width: none;
         }
         padding: 20px 10px 0;
         & > h3 {
-            display: none;
+            margin: 30px 0 12px;
+        }
+        h3 + span.current-transcription {
+            @include typography.meta;
+            color: var(--input-date-text);
         }
         @include breakpoints.for-tablet-landscape-up {
             padding: 0 0 0;
-            & > h3 {
-                display: block;
-                @include typography.body-bold;
-            }
             h3 {
                 margin: 12px 0;
             }
-        }
-
-        // multiple transcription pseudo-select element
-        details.transcription-select {
-            position: relative;
-            flex: 1 1 auto;
-            min-height: 2.5rem;
-            width: 100%;
-            summary {
-                display: flex;
-                min-height: 2.5rem;
-                cursor: pointer;
-                // Suppress default details marker
-                &::-webkit-details-marker {
-                    display: none;
-                }
-                span {
-                    cursor: pointer;
-                    background-color: var(--background);
-                    color: var(--on-background);
-                    flex: 1 1 auto;
-                    display: flex;
-                    justify-content: space-between;
-                    align-items: center;
-                    padding: spacing.$spacing-2xs 0.7rem;
-                    margin-right: spacing.$spacing-sm;
-                    @include typography.body-bold;
-                    @include searchform.form-drop-shadow;
-                    &::after {
-                        content: "\f0c2"; // phosphor caret-down icon
-                        @include typography.icon-button-md;
-                    }
-                }
-            }
-            // List of transcription options
-            ul {
-                position: absolute;
-                z-index: 20;
-                width: calc(100% - 0.667rem);
-                padding: spacing.$spacing-sm 0;
-                @include searchform.form-drop-shadow;
-                background-color: var(--background);
-                li {
-                    display: flex;
-                    label {
-                        width: 100%;
-                        flex: 0 1 100%;
-                        display: flex;
-                        cursor: pointer;
-                        span {
-                            display: flex;
-                            align-items: center;
-                            width: 100%;
-                            flex: 0 1 100%;
-                            padding: spacing.$spacing-sm;
-                            transition: background-color 0.15s ease,
-                                color 0.15s ease;
-                        }
-                        &:hover,
-                        &:focus-within {
-                            background-color: var(--background-gray);
-                            color: var(--on-background-gray);
-                        }
-                        &:hover input[name="transcription"]:focus + span {
-                            background-color: var(--tertiary);
-                            color: var(--on-tertiary);
-                        }
-                        // Checkboxes only visible to screen readers
-                        input[name="transcription"] {
-                            @include a11y.sr-only;
-                            // Selected option
-                            &:checked + span {
-                                @include typography.form-option-sm-bold;
-                            }
-                            &:active + span {
-                                background-color: var(--secondary);
-                                color: var(--on-secondary);
-                            }
-                            &:disabled + span {
-                                color: var(--disabled);
-                                cursor: default;
-                                background-color: var(--background-light);
-                            }
-                        }
-                        // Non-selected options
-                        @include typography.form-option-sm;
-                    }
-                }
+            & > h3 {
+                @include typography.body-bold;
+                margin: 27px 0 0;
             }
         }
 
         // "carousel" for switching between multiple transcriptions
-        width: 100%;
         div.editions {
             display: flex;
             overflow-x: hidden;


### PR DESCRIPTION
## In this PR

- Per #899:
  - Dropdown menu to switch between multiple transcriptions
  - Styles for dropdown menu ported mostly from search sort dropdown
- Moved the general transcription styling from `_results.scss` to `_transcription.scss`

## Questions

- How do you feel about the overall approach to the spacing and divs of the toggles + the dropdowns? It's working well for me, except for one minor issue, which is that the transitions seem somewhat differently timed between the two areas.
- I’ve been testing primarily with PGPIDs 5384 and 9121. I think PGPID 9121 shows one drawback to the "overflow hidden + horizontal scrolling" approach, which is that it doesn’t work well when one of the editions is drastically shorter than the other. It might be a data problem, though, since it seems like the addition is a bunch of text before the Recto side starts.