### PR TITLE
Basic rotation controls for ITT panel on desktop (#937)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -27,12 +27,6 @@
         {% endwith %}
     {% endif %}
 {% endblock extrameta %}
-{% block extrascript %}
-    {# include openseadragon if needed #}
-    {% if document.has_image or document.iiif_urls %}
-        <link rel="preconnect" href="https://cdnjs.cloudflare.com/ajax/libs/openseadragon/3.0.0/images/" crossorigin />
-    {% endif %}
-{% endblock extrascript %}
 
 {% block main %}
     <!-- document details -->

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -49,14 +49,14 @@ Also doesn't currently account for fragments without images.
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
                         <input data-action="iiif#handleDeepZoom" type="range" id="zoom-slider-{{ forloop.counter0 }}" name="zoom-slider" min="1" max="100" value="0" step="0.01">
                         <label for="zoom-slider-{{ forloop.counter0 }}">100%</label>
+                        <input data-action="iiif#handleDeepZoom" type="checkbox" id="zoom-toggle-{{ forloop.counter0 }}" name="zoom-toggle">
+                        <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
                         <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
                             <i class="ph-arrow-counter-clockwise"></i>
                         </button>
                         <button type="button" data-iiif-target="rotateRight" class="rotate" aria-label="{% translate 'Rotate right' %}" disabled>
                             <i class="ph-arrow-clockwise"></i>
                         </button>
-                        <input data-action="iiif#handleDeepZoom" type="checkbox" id="zoom-toggle-{{ forloop.counter0 }}" name="zoom-toggle">
-                        <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
                     </div>
                     <img class="iiif-image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
                         sizes="(max-width: 650px) 50vw, 94vw"

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -49,6 +49,12 @@ Also doesn't currently account for fragments without images.
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
                         <input data-action="iiif#handleDeepZoom" type="range" id="zoom-slider-{{ forloop.counter0 }}" name="zoom-slider" min="1" max="100" value="0" step="0.01">
                         <label for="zoom-slider-{{ forloop.counter0 }}">100%</label>
+                        <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
+                            <i class="ph-arrow-counter-clockwise"></i>
+                        </button>
+                        <button type="button" data-iiif-target="rotateRight" class="rotate" aria-label="{% translate 'Rotate right' %}" disabled>
+                            <i class="ph-arrow-clockwise"></i>
+                        </button>
                         <input data-action="iiif#handleDeepZoom" type="checkbox" id="zoom-toggle-{{ forloop.counter0 }}" name="zoom-toggle">
                         <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
                     </div>

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -4,7 +4,7 @@ import { Controller } from "@hotwired/stimulus";
 import OpenSeadragon from "openseadragon";
 
 export default class extends Controller {
-    static targets = ["imageContainer"];
+    static targets = ["imageContainer", "rotateLeft", "rotateRight"];
 
     imageContainerTargetDisconnected(container) {
         // remove OSD on target disconnect (i.e. leaving page)
@@ -48,6 +48,9 @@ export default class extends Controller {
         } else {
             OSD.style.top = "72px";
         }
+        // re-enable rotation buttons
+        this.rotateRightTarget.removeAttribute("disabled");
+        this.rotateLeftTarget.removeAttribute("disabled");
     }
     deactivateDeepZoom(container, image) {
         // Hide OSD and show image
@@ -59,6 +62,8 @@ export default class extends Controller {
             OSD.style.opacity = "0";
             image.classList.add("visible");
             image.classList.remove("hidden");
+            this.rotateRightTarget.setAttribute("disabled", "true");
+            this.rotateLeftTarget.setAttribute("disabled", "true");
         }
     }
     addOpenSeaDragon(element, tileSources, isMobile) {
@@ -143,6 +148,13 @@ export default class extends Controller {
                     this.resetBounds(viewer);
                     viewer.viewport.zoomTo(1.1);
                 }
+            });
+            // initialize desktop rotation buttons
+            this.rotateLeftTarget.addEventListener("click", () => {
+                viewer.viewport.setRotation(viewer.viewport.getRotation() - 90);
+            });
+            this.rotateRightTarget.addEventListener("click", () => {
+                viewer.viewport.setRotation(viewer.viewport.getRotation() + 90);
             });
         });
         viewer.addHandler("zoom", (evt) => {

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -44,7 +44,7 @@ export default class extends Controller {
         OSD.style.opacity = "1";
         // OSD needs top offset due to margin, padding, and header elements
         if (isMobile) {
-            OSD.style.top = "122px";
+            OSD.style.top = "130px";
         } else {
             OSD.style.top = "72px";
         }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -487,16 +487,21 @@
                 display: block;
                 float: right;
                 margin: 0 0 0 spacing.$spacing-2xs;
+                @include typography.icon-button-lg;
+                min-width: 48px;
+                min-height: 48px;
                 &:last-of-type {
                     margin: 0 spacing.$spacing-md 0 spacing.$spacing-3xs;
                 }
                 @include breakpoints.for-tablet-landscape-up {
+                    min-width: 0px;
+                    min-height: 0px;
+                    @include typography.icon-button-md;
                     margin: 0 0 0 spacing.$spacing-md;
                     &:last-of-type {
                         margin: 0 spacing.$spacing-3xs 0;
                     }
                 }
-                @include typography.icon-button-md;
                 background: none;
                 border: none;
                 padding: 0;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -495,6 +495,8 @@
                 border: none;
                 padding: 0;
                 vertical-align: middle;
+                color: var(--on-backround);
+                transition: color 300ms ease;
                 cursor: pointer;
                 &:disabled {
                     color: var(--disabled);

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -480,6 +480,31 @@
                 color: var(--on-background);
                 @include typography.body-bold;
             }
+            // rotation controls (desktop)
+            button.rotate {
+                display: none;
+                @include breakpoints.for-tablet-landscape-up {
+                    display: block;
+                }
+                margin: 0 0 0 spacing.$spacing-md;
+                &:last-of-type {
+                    margin: 0 spacing.$spacing-3xs 0;
+                }
+                @include typography.icon-button-md;
+                background: none;
+                border: none;
+                padding: 0;
+                vertical-align: middle;
+                cursor: pointer;
+                &:disabled {
+                    color: var(--disabled);
+                    cursor: default;
+                }
+                i {
+                    // ensure no extra space inside button
+                    display: block;
+                }
+            }
             // zoom control (mobile)
             input[type="checkbox"][id^="zoom-toggle"] {
                 display: block;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -485,13 +485,14 @@
             // rotation controls
             button.rotate {
                 display: block;
-                float: right;
-                margin: 0 0 0 spacing.$spacing-2xs;
+                // float: right;
+                text-align: center;
+                margin: 0;
                 @include typography.icon-button-lg;
                 min-width: 48px;
                 min-height: 48px;
                 &:last-of-type {
-                    margin: 0 spacing.$spacing-md 0 spacing.$spacing-3xs;
+                    margin: 0 spacing.$spacing-xs 0 0;
                 }
                 @include breakpoints.for-tablet-landscape-up {
                     min-width: 0px;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -411,12 +411,11 @@
         }
         .img-header {
             display: flex;
-            flex-flow: column;
-            align-items: flex-start;
+            flex-flow: row wrap;
+            align-items: center;
             margin-bottom: 8px;
             @include breakpoints.for-tablet-landscape-up {
                 flex-flow: row;
-                align-items: center;
                 margin-bottom: 12px;
             }
             h3 {
@@ -424,7 +423,10 @@
                 text-align: left;
                 margin: 8px;
                 display: inline-block;
-                flex: 1 0 auto;
+                flex: 1 0 100%;
+                @include breakpoints.for-tablet-landscape-up {
+                    flex: 1 0 auto;
+                }
             }
             // zoom control (desktop)
             input[type="range"][id^="zoom-slider"] {
@@ -480,21 +482,24 @@
                 color: var(--on-background);
                 @include typography.body-bold;
             }
-            // rotation controls (desktop)
+            // rotation controls
             button.rotate {
-                display: none;
-                @include breakpoints.for-tablet-landscape-up {
-                    display: block;
-                }
-                margin: 0 0 0 spacing.$spacing-md;
+                display: block;
+                float: right;
+                margin: 0 0 0 spacing.$spacing-2xs;
                 &:last-of-type {
-                    margin: 0 spacing.$spacing-3xs 0;
+                    margin: 0 spacing.$spacing-md 0 spacing.$spacing-3xs;
+                }
+                @include breakpoints.for-tablet-landscape-up {
+                    margin: 0 0 0 spacing.$spacing-md;
+                    &:last-of-type {
+                        margin: 0 spacing.$spacing-3xs 0;
+                    }
                 }
                 @include typography.icon-button-md;
                 background: none;
                 border: none;
                 padding: 0;
-                vertical-align: middle;
                 color: var(--on-backround);
                 transition: color 300ms ease;
                 cursor: pointer;
@@ -515,7 +520,7 @@
                     display: none;
                 }
                 & + label[for^="zoom-toggle"] {
-                    align-self: flex-end;
+                    flex: 1 0 auto;
                     display: flex;
                     @include breakpoints.for-tablet-landscape-up {
                         display: none;


### PR DESCRIPTION
## In this PR

- Per #937:
  - Remove OSD icons preconnect
  - Implement basic rotate controls with phosphor icons

## Questions

- Should the rotation controls always be enabled? For now, I've disabled them when deep zoom isn't enabled; I know we discussed eventually allowing users to enable/disable OSD using the rotation controls, but not sure if that makes as much sense for the MVP version. The strict 90º rotation could be quite jarring; it makes the transition much harder to handle, certainly. And not sure if a deactivation state should exist with this rotation control. But I can also easily see it being confusing to have the rotation controls simply disabled until you start zooming. Wonder if there's a good interim solution?
- With taller images, some surprising OSD stuff can happen on rotation. I noticed that the rotation axis seems to be the canvas, rather than the center of the image (or maybe I have that backwards, but something about the axis is unexpected to me). I also noticed the "bounds" of the canvas seem to change on rotation, like you can't pan as far up and down when the image is rotated. Should we try to do anything about this or just chalk it up to OSD limitations?