### PR TITLE
Deep zoom revisions (#891)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -47,9 +47,9 @@ Also doesn't currently account for fragments without images.
                 <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-url="{{ image_info.image.info }}" data-iiif-target="imageContainer" data-action="click->iiif#scrollTo0">
                     <div class="img-header">
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
-                        <input data-action="iiif#handleDeepZoom" type="range" id="zoom-slider-{{ forloop.counter0 }}" name="zoom-slider" min="1" max="100" value="0" step="0.01">
-                        <label for="zoom-slider-{{ forloop.counter0 }}">100%</label>
-                        <input data-action="iiif#handleDeepZoom" type="checkbox" id="zoom-toggle-{{ forloop.counter0 }}" name="zoom-toggle">
+                        <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
+                        <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
+                        <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
                         <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
                         <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
                             <i class="ph-arrow-counter-clockwise"></i>
@@ -58,7 +58,7 @@ Also doesn't currently account for fragments without images.
                             <i class="ph-arrow-clockwise"></i>
                         </button>
                     </div>
-                    <img class="iiif-image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
+                    <img class="iiif-image" data-iiif-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
                         sizes="(max-width: 650px) 50vw, 94vw"
                         srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
                         {{ image_info.image|iiif_image:"size:width=500" }} 500w,

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -44,8 +44,8 @@ Also doesn't currently account for fragments without images.
         {# if we have images, loop based on them #}
         {% if document.iiif_urls %}
             {% for image_info in document.iiif_images %}
-                <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-target="imageContainer" data-action="click->iiif#scrollTo0">
-                    <div class="img-header">
+                <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-target="imageContainer">
+                    <div class="img-header" data-iiif-target="imageHeader">
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
                         <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
                         <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -44,7 +44,7 @@ Also doesn't currently account for fragments without images.
         {# if we have images, loop based on them #}
         {% if document.iiif_urls %}
             {% for image_info in document.iiif_images %}
-                <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-url="{{ image_info.image.info }}" data-iiif-target="imageContainer" data-action="click->iiif#scrollTo0">
+                <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-target="imageContainer" data-action="click->iiif#scrollTo0">
                     <div class="img-header">
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
                         <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
@@ -58,12 +58,15 @@ Also doesn't currently account for fragments without images.
                             <i class="ph-arrow-clockwise"></i>
                         </button>
                     </div>
-                    <img class="iiif-image" data-iiif-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
-                        sizes="(max-width: 650px) 50vw, 94vw"
-                        srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
-                        {{ image_info.image|iiif_image:"size:width=500" }} 500w,
-                        {{ image_info.image|iiif_image:"size:width=640" }} 640w,
-                        {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
+                    <div class="deep-zoom-container">
+                        <img class="iiif-image" data-iiif-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
+                            sizes="(max-width: 650px) 50vw, 94vw"
+                            srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
+                            {{ image_info.image|iiif_image:"size:width=500" }} 500w,
+                            {{ image_info.image|iiif_image:"size:width=640" }} 640w,
+                            {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
+                        <div class="osd-inner-container" data-iiif-target="osdInner" data-iiif-url="{{ image_info.image.info }}"></div>
+                    </div>
                 </div>
                 <div class="transcription-panel">
                     {% if forloop.first %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -65,7 +65,7 @@ Also doesn't currently account for fragments without images.
                             {{ image_info.image|iiif_image:"size:width=500" }} 500w,
                             {{ image_info.image|iiif_image:"size:width=640" }} 640w,
                             {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
-                        <div class="osd-inner-container" data-iiif-target="osdInner" data-iiif-url="{{ image_info.image.info }}"></div>
+                        <div class="osd" data-iiif-target="osd" data-iiif-url="{{ image_info.image.info }}"></div>
                     </div>
                 </div>
                 <div class="transcription-panel">

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -5,7 +5,7 @@ import OpenSeadragon from "openseadragon";
 
 export default class extends Controller {
     static targets = [
-        "imageContainer",
+        "imageHeader",
         "osd",
         "rotateLeft",
         "rotateRight",
@@ -29,12 +29,10 @@ export default class extends Controller {
         }
     }
     activateDeepZoom(settings) {
+        // scroll to top of controls
+        this.imageHeaderTarget.scrollIntoView();
         // hide image and add OpenSeaDragon to container
-        const height = this.imageTarget.getBoundingClientRect()["height"];
-        const width = this.imageTarget.getBoundingClientRect()["width"];
         let OSD = this.osdTarget.querySelector(".openseadragon-container");
-        this.osdTarget.style.height = `${height}px`;
-        this.osdTarget.style.width = `${width}px`;
         if (!OSD) {
             this.addOpenSeaDragon(settings);
         }
@@ -81,6 +79,8 @@ export default class extends Controller {
             maxZoomPixelRatio: maxZoom,
         });
         viewer.addHandler("open", () => {
+            // zoom to current zoom
+            viewer.viewport.zoomTo(parseFloat(this.zoomSliderTarget.value));
             // ensure image is positioned in top-left corner of viewer
             this.resetBounds(viewer);
             if (isMobile) {
@@ -184,9 +184,5 @@ export default class extends Controller {
         );
         viewer.viewport.fitBounds(newBounds, true);
         viewer.viewport.setRotation(0, true);
-    }
-    scrollTo0(evt) {
-        // Scroll container to top; necessary to prevent scroll issue when OSD is positioned absolutely
-        evt.currentTarget.scrollTop = 0;
     }
 }

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -6,7 +6,7 @@ import OpenSeadragon from "openseadragon";
 export default class extends Controller {
     static targets = [
         "imageContainer",
-        "osdInner",
+        "osd",
         "rotateLeft",
         "rotateRight",
         "image",
@@ -15,17 +15,15 @@ export default class extends Controller {
         "zoomToggle",
     ];
 
-    osdInnerTargetDisconnected() {
+    osdTargetDisconnected() {
         // remove OSD on target disconnect (i.e. leaving page)
         this.deactivateDeepZoom();
     }
     handleDeepZoom(evt) {
         // Enable OSD and/or zoom based on zoom slider level
         // OSD needs to use DOM queries since it can't be assigned a target
-        const OSD = this.osdInnerTarget.querySelector(
-            ".openseadragon-container"
-        );
-        if (!OSD || this.osdInnerTarget.classList.contains("hidden")) {
+        const OSD = this.osdTarget.querySelector(".openseadragon-container");
+        if (!OSD || this.osdTarget.classList.contains("hidden")) {
             const isMobile = evt.currentTarget.id.startsWith("zoom-toggle");
             this.activateDeepZoom({ isMobile });
         }
@@ -34,24 +32,24 @@ export default class extends Controller {
         // hide image and add OpenSeaDragon to container
         const height = this.imageTarget.getBoundingClientRect()["height"];
         const width = this.imageTarget.getBoundingClientRect()["width"];
-        let OSD = this.osdInnerTarget.querySelector(".openseadragon-container");
-        this.osdInnerTarget.style.height = `${height}px`;
-        this.osdInnerTarget.style.width = `${width}px`;
+        let OSD = this.osdTarget.querySelector(".openseadragon-container");
+        this.osdTarget.style.height = `${height}px`;
+        this.osdTarget.style.width = `${width}px`;
         if (!OSD) {
             this.addOpenSeaDragon(settings);
         }
         this.imageTarget.classList.remove("visible");
         this.imageTarget.classList.add("hidden");
-        this.osdInnerTarget.classList.remove("hidden");
-        this.osdInnerTarget.classList.add("visible");
+        this.osdTarget.classList.remove("hidden");
+        this.osdTarget.classList.add("visible");
         this.rotateRightTarget.removeAttribute("disabled");
         this.rotateLeftTarget.removeAttribute("disabled");
     }
     deactivateDeepZoom() {
         this.imageTarget.classList.add("visible");
         this.imageTarget.classList.remove("hidden");
-        this.osdInnerTarget.classList.remove("visible");
-        this.osdInnerTarget.classList.add("hidden");
+        this.osdTarget.classList.remove("visible");
+        this.osdTarget.classList.add("hidden");
         this.rotateRightTarget.setAttribute("disabled", "true");
         this.rotateLeftTarget.setAttribute("disabled", "true");
     }
@@ -64,10 +62,10 @@ export default class extends Controller {
 
         // inject OSD into the image container
         let viewer = OpenSeadragon({
-            element: this.osdInnerTarget,
+            element: this.osdTarget,
             prefixUrl:
                 "https://cdnjs.cloudflare.com/ajax/libs/openseadragon/3.0.0/images/",
-            tileSources: [this.osdInnerTarget.dataset.iiifUrl],
+            tileSources: [this.osdTarget.dataset.iiifUrl],
             sequenceMode: false,
             autoHideControls: true,
             showHomeControl: false,

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -6,6 +6,7 @@ import OpenSeadragon from "openseadragon";
 export default class extends Controller {
     static targets = [
         "imageContainer",
+        "osdInner",
         "rotateLeft",
         "rotateRight",
         "image",
@@ -14,68 +15,45 @@ export default class extends Controller {
         "zoomToggle",
     ];
 
-    imageContainerTargetDisconnected() {
+    osdInnerTargetDisconnected() {
         // remove OSD on target disconnect (i.e. leaving page)
         this.deactivateDeepZoom();
     }
     handleDeepZoom(evt) {
         // Enable OSD and/or zoom based on zoom slider level
         // OSD needs to use DOM queries since it can't be assigned a target
-        const OSD = this.imageContainerTarget.querySelector(
+        const OSD = this.osdInnerTarget.querySelector(
             ".openseadragon-container"
         );
-        if (!OSD || OSD.style.opacity === "0") {
+        if (!OSD || this.osdInnerTarget.classList.contains("hidden")) {
             const isMobile = evt.currentTarget.id.startsWith("zoom-toggle");
             this.activateDeepZoom({ isMobile });
         }
     }
     activateDeepZoom(settings) {
         // hide image and add OpenSeaDragon to container
-        const height =
-            this.imageContainerTarget.getBoundingClientRect()["height"];
-        let OSD = this.imageContainerTarget.querySelector(
-            ".openseadragon-container"
-        );
-        this.imageContainerTarget.style.height = `${height}px`;
-        this.imageTarget.classList.remove("visible");
-        this.imageTarget.classList.add("hidden");
+        const height = this.imageTarget.getBoundingClientRect()["height"];
+        const width = this.imageTarget.getBoundingClientRect()["width"];
+        let OSD = this.osdInnerTarget.querySelector(".openseadragon-container");
+        this.osdInnerTarget.style.height = `${height}px`;
+        this.osdInnerTarget.style.width = `${width}px`;
         if (!OSD) {
             this.addOpenSeaDragon(settings);
-            OSD = this.imageContainerTarget.querySelector(
-                ".openseadragon-container"
-            );
         }
-        // OSD styles have to be set directly on the element instead of adding a class, due to
-        // its use of inline styles
-        OSD.style.position = "absolute";
-        OSD.style.transition = "opacity 300ms ease, visibility 0s ease 0ms";
-        OSD.style.visibility = "visible";
-        OSD.style.opacity = "1";
-        // OSD needs top offset due to margin, padding, and header elements
-        if (settings.isMobile) {
-            OSD.style.top = "122px";
-        } else {
-            OSD.style.top = "72px";
-        }
-        // re-enable rotation buttons
+        this.imageTarget.classList.remove("visible");
+        this.imageTarget.classList.add("hidden");
+        this.osdInnerTarget.classList.remove("hidden");
+        this.osdInnerTarget.classList.add("visible");
         this.rotateRightTarget.removeAttribute("disabled");
         this.rotateLeftTarget.removeAttribute("disabled");
     }
     deactivateDeepZoom() {
-        // Hide OSD and show image
-        const OSD = this.imageContainerTarget.querySelector(
-            ".openseadragon-container"
-        );
-        if (OSD && this.imageTarget) {
-            OSD.style.transition =
-                "opacity 300ms ease, visibility 0s ease 300ms";
-            OSD.style.visibility = "hidden";
-            OSD.style.opacity = "0";
-            this.imageTarget.classList.add("visible");
-            this.imageTarget.classList.remove("hidden");
-            this.rotateRightTarget.setAttribute("disabled", "true");
-            this.rotateLeftTarget.setAttribute("disabled", "true");
-        }
+        this.imageTarget.classList.add("visible");
+        this.imageTarget.classList.remove("hidden");
+        this.osdInnerTarget.classList.remove("visible");
+        this.osdInnerTarget.classList.add("hidden");
+        this.rotateRightTarget.setAttribute("disabled", "true");
+        this.rotateLeftTarget.setAttribute("disabled", "true");
     }
     addOpenSeaDragon(settings) {
         const { isMobile } = settings;
@@ -86,10 +64,10 @@ export default class extends Controller {
 
         // inject OSD into the image container
         let viewer = OpenSeadragon({
-            element: this.imageContainerTarget,
+            element: this.osdInnerTarget,
             prefixUrl:
                 "https://cdnjs.cloudflare.com/ajax/libs/openseadragon/3.0.0/images/",
-            tileSources: [this.imageContainerTarget.dataset.iiifUrl],
+            tileSources: [this.osdInnerTarget.dataset.iiifUrl],
             sequenceMode: false,
             autoHideControls: true,
             showHomeControl: false,

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -569,12 +569,12 @@
                 width: 100%;
                 margin: 0 auto;
             }
-            .osd-inner-container {
+            .osd {
                 position: absolute !important;
                 top: 0;
             }
             img,
-            .osd-inner-container {
+            .osd {
                 &.hidden {
                     transition: opacity 300ms ease, visibility 0s ease 300ms;
                     opacity: 0;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -565,11 +565,19 @@
         }
         .deep-zoom-container {
             position: relative;
+            width: 100%;
+            text-align: center;
             img {
-                width: 100%;
-                margin: 0 auto;
+                width: auto;
             }
             .osd {
+                // height of screen, minus height of (controls + padding)
+                height: calc(100vh - 99px);
+                @include breakpoints.for-tablet-landscape-up {
+                    // controls are vertically slimmer on desktop
+                    height: calc(100vh - 58px);
+                }
+                width: 100%;
                 position: absolute !important;
                 top: 0;
             }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -563,18 +563,28 @@
                 }
             }
         }
-        img {
-            width: 100%;
-            margin: 0 auto;
-            &.hidden {
-                transition: opacity 300ms ease, visibility 0s ease 300ms;
-                opacity: 0;
-                visibility: hidden;
+        .deep-zoom-container {
+            position: relative;
+            img {
+                width: 100%;
+                margin: 0 auto;
             }
-            &.visible {
-                transition: opacity 300ms ease, visibility 0s ease 0ms;
-                visibility: visible;
-                opacity: 1;
+            .osd-inner-container {
+                position: absolute !important;
+                top: 0;
+            }
+            img,
+            .osd-inner-container {
+                &.hidden {
+                    transition: opacity 300ms ease, visibility 0s ease 300ms;
+                    opacity: 0;
+                    visibility: hidden;
+                }
+                &.visible {
+                    transition: opacity 300ms ease, visibility 0s ease 0ms;
+                    visibility: visible;
+                    opacity: 1;
+                }
             }
         }
         @include breakpoints.for-tablet-landscape-up {

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -567,9 +567,6 @@
             position: relative;
             width: 100%;
             text-align: center;
-            img {
-                width: auto;
-            }
             .osd {
                 // height of screen, minus height of (controls + padding)
                 height: calc(100vh - 99px);
@@ -577,12 +574,12 @@
                     // controls are vertically slimmer on desktop
                     height: calc(100vh - 58px);
                 }
-                width: 100%;
                 position: absolute !important;
                 top: 0;
             }
             img,
             .osd {
+                width: 100%;
                 &.hidden {
                     transition: opacity 300ms ease, visibility 0s ease 300ms;
                     opacity: 0;


### PR DESCRIPTION
## In this PR

- Per #891:
  - Fix issues with scrolling by putting OSD in its own container and constraining its height
- Use Stimulus targets rather than DOM queries to refer to elements

## Questions
- Should we increase the width of OSD when only images are checked? In that case, we'd need some way for Stimulus to pick that up, such that we could modify `resetBounds` to position OSD according to the static image. In addition, the following CSS would be required:
    ```scss
    #images-on:checked ~ .panel-container {
        [...]
        // image panel spacing
        div.img {
            margin: 0 auto;
            overflow: visible;
            .deep-zoom-container {
                overflow: visible;
            }
            .osd {
                width: 100vw; // Some other width?
            }
        }
    }
    ```
    Not sure what width makes the most sense though, 100vw might be overkill.