### PR TITLE
Include TinyMCE from CDN in transcribe view (#916)

### DIFF
--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -20,7 +20,7 @@
 {% endblock extrastyle %}
 {% block extrascript %}
     {% render_bundle_csp "annotation" "js" attrs='defer' %}
-    <script src="https://cdn.tiny.cloud/1/dxa2pi2u1fimtzb8r4t1mtpfckgiuj5vbpk3tdmxyxwdtu67/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+    <script src="https://cdn.tiny.cloud/1/{{ tiny_api_key }}/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 {% endblock extrascript %}
 
 {% block main %}

--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -20,6 +20,7 @@
 {% endblock extrastyle %}
 {% block extrascript %}
     {% render_bundle_csp "annotation" "js" attrs='defer' %}
+    <script src="https://cdn.tiny.cloud/1/dxa2pi2u1fimtzb8r4t1mtpfckgiuj5vbpk3tdmxyxwdtu67/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 {% endblock extrascript %}
 
 {% block main %}

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -308,14 +308,6 @@ class DocumentDetailView(DocumentDetailBase, DetailView):
                 "page_type": "document",
                 # preload transcription font when appropriate
                 "page_includes_transcriptions": self.object.has_transcription(),
-                # TODO: will need to be added to admin view also
-                "annotation_config": {
-                    # use getattr to simplify test config; warn if not set?
-                    "server_url": getattr(settings, "ANNOTATION_SERVER_URL", ""),
-                    "manifest_base_url": getattr(
-                        settings, "ANNOTATION_MANIFEST_BASE_URL", ""
-                    ),
-                },
             }
         )
         return context_data
@@ -666,6 +658,23 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
     def page_title(self):
         # Translators: title of transcription editor page
         return _("Edit transcription for %(doc)s") % {"doc": self.get_object().title}
+
+    def get_context_data(self, **kwargs):
+        """Pass annotation configuration and TinyMCE API key to page context"""
+        context_data = super().get_context_data(**kwargs)
+        context_data.update(
+            {
+                "annotation_config": {
+                    # use getattr to simplify test config; warn if not set?
+                    "server_url": getattr(settings, "ANNOTATION_SERVER_URL", ""),
+                    "manifest_base_url": getattr(
+                        settings, "ANNOTATION_MANIFEST_BASE_URL", ""
+                    ),
+                },
+                "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
+            }
+        )
+        return context_data
 
 
 # --------------- Publish CSV to sync with old PGP site --------------------- #

--- a/geniza/settings/local_settings.py.sample
+++ b/geniza/settings/local_settings.py.sample
@@ -109,3 +109,6 @@ TRANSCRIPTIONS_JSON_FILE = BASE_DIR.parent / "data" / "transcriptions.json"
 
 # Google Analytics tracking ID
 # GTAGS_ANALYTICS_ID = ''
+
+# TinyMCE API key
+# TINY_API_KEY = '';

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -9,7 +9,8 @@ div.annotate {
         font-size: typography.$text-size-md;
     }
 
-    div[contenteditable="true"] {
+    div[contenteditable="true"],
+    h3[contenteditable="true"] {
         background-color: white;
         color: black;
         min-height: 3em;


### PR DESCRIPTION
## In this PR

- Per #916:
  - In tandem with https://github.com/Princeton-CDH/annotorious-tahqiq/pull/5, allow editing using TinyMCE.

## dev notes

After spending some hours debugging bundling errors, I chose to use the CDN rather than Webpack. Hopefully that's OK! (For what it's worth, this is also [Tiny's recommendation](https://www.tiny.cloud/docs/tinymce/6/webcomponent-pm/))