### PR TITLE
Filter/select side in IIIF image/thumbnail methods (#955, #956)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,9 @@
 # Deploy Notes
 
+## 4.6.0
+
+-   This update includes Solr indexing changes to show the relevant side(s) of document images in search results. Run `python manage.py index` to reindex all content.
+
 ## 4.5.0
 
 -   Document date functionality in this release requires updating the Solr index. Run `python manage.py index` to reindex all content.

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -612,12 +612,8 @@ class Document(ModelIndexable, DocumentDateMixin):
             frag_images = b.fragment.iiif_images()
             # image indices of this TextBlock's side (0 is recto, 1 is verso)
             selected = [
-                0
-                if any(b.side == s for s in [TextBlock.RECTO_VERSO, TextBlock.RECTO])
-                else None,
-                1
-                if any(b.side == s for s in [TextBlock.RECTO_VERSO, TextBlock.VERSO])
-                else None,
+                0 if b.side in [TextBlock.RECTO_VERSO, TextBlock.RECTO] else None,
+                1 if b.side in [TextBlock.RECTO_VERSO, TextBlock.VERSO] else None,
             ]
             if frag_images is not None:
                 images, labels = frag_images

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -241,19 +241,28 @@ class Fragment(TrackChangesModel):
 
         return images, labels
 
-    def iiif_thumbnails(self):
+    def iiif_thumbnails(self, selected_side=None):
         """html for thumbnails of iiif image, for display in admin"""
         # if there are no iiif images for this fragment, bail out
         iiif_images = self.iiif_images()
         if iiif_images is None:
             return ""
 
+        # image indices of selected side (0 is recto, 1 is verso)
+        selected = [
+            0 if selected_side in [TextBlock.RECTO_VERSO, TextBlock.RECTO] else None,
+            1 if selected_side in [TextBlock.RECTO_VERSO, TextBlock.VERSO] else None,
+        ]
         images, labels = iiif_images
         return mark_safe(
             " ".join(
                 # include label as title for now
-                '<img src="%s" loading="lazy" height="200" title="%s">'
-                % (img.size(height=200), labels[i])
+                '<img src="%s" loading="lazy" height="200" title="%s" %s>'
+                % (
+                    img.size(height=200),
+                    labels[i],
+                    'class="selected" /' if i in selected else "/",
+                )
                 for i, img in enumerate(images)
             )
         )
@@ -1136,4 +1145,6 @@ class TextBlock(models.Model):
 
     def thumbnail(self):
         """iiif thumbnails for this fragment"""
-        return self.fragment.iiif_thumbnails()
+
+        # pass own side as selected side for admin form
+        return self.fragment.iiif_thumbnails(selected_side=self.side)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -611,6 +611,7 @@ class Document(ModelIndexable, DocumentDateMixin):
         side_labels = {
             TextBlock.RECTO: ["1r", "recto"],
             TextBlock.VERSO: ["1v", "verso"],
+            TextBlock.RECTO_VERSO: ["1r", "recto", "1v", "verso"],
         }
         for b in self.textblock_set.all():
             frag_images = b.fragment.iiif_images()

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1148,5 +1148,5 @@ class TextBlock(models.Model):
     def thumbnail(self):
         """iiif thumbnails for this TextBlock"""
 
-        # pass self to Fragment.iiif_thumbnails to only get thumbnails for this TextBlock
+        # pass image_indices to ensure only this TextBlock's side(s) are shown as selected
         return self.fragment.iiif_thumbnails(indices=self.image_indices)

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -185,6 +185,11 @@ class TestFragment(TestCase):
         assert 'title="1v"' in thumbnails
         assert isinstance(thumbnails, SafeString)
 
+        # test with verso side selected: should add class to 1v img, but not 1r img
+        thumbnails_verso_selected = frag.iiif_thumbnails(selected_side=TextBlock.VERSO)
+        assert 'title="1v" class="selected"' in thumbnails_verso_selected
+        assert 'title="1r" class="selected"' not in thumbnails_verso_selected
+
     @pytest.mark.django_db
     @patch("geniza.corpus.models.ManifestImporter")
     def test_iiif_images_locally_cached_manifest(self, mock_manifestimporter):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -186,7 +186,7 @@ class TestFragment(TestCase):
         assert isinstance(thumbnails, SafeString)
 
         # test with verso side selected: should add class to 1v img, but not 1r img
-        thumbnails_verso_selected = frag.iiif_thumbnails(selected_side=TextBlock.VERSO)
+        thumbnails_verso_selected = frag.iiif_thumbnails(indices=[1])
         assert 'title="1v" class="selected"' in thumbnails_verso_selected
         assert 'title="1r" class="selected"' not in thumbnails_verso_selected
 

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -221,3 +221,8 @@ a#needsreview:target {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
 }
+
+/* selected side thumbnail for fragment admin */
+img.selected {
+    border: 5px solid var(--accent);
+}


### PR DESCRIPTION
## In this PR

- Per #955:
  - Add `selected_side` param to `Fragment.iiif_thumbnails()`; use in `TextBlock.thumbnail`
  - Use that to set a class `"selected"` to the thumbnail of the selected side, and add some styling to the admin CSS
- Per #956:
  - Add `filter_side` param (filter by each `TextBlock`'s side) to `Document.iiif_images()`; use in solr indexing
  
## Questions

(asked on Slack but here is probably better)

1. For side filtering, should we go by index of the image (ie assume first image always = recto) for all methods? I only saw it mentioned for `iiif_thumbnails` so wasn’t sure if I should take the same approach on `Document.iiif_images`
   - I took an approach using labels in f7b102a and 073d023, but reverted to going by order—wondering if that's the direction we're going or if we should just go by order for now.
2. For the admin view, it will only update the UI for the “selected side” when you save the change. Should we somehow recalculate the thumbnail classes when you change the dropdown? I guess the thumbnails already don’t show up at all until you save the document with the fragment attached, so maybe it’s fine as is.
