### PR TITLE
Indicate excluded images in ITT viewer (#957 #958)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -621,6 +621,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                         "image": img,
                         "label": labels[i],
                         "shelfmark": b.fragment.shelfmark,
+                        "not_in_document": b.side and i not in b.image_indices,
                     }
                     for i, img in enumerate(images)
                     # include if filter inactive, tb has no side info, or index in tb indices

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -76,9 +76,8 @@ Also doesn't currently account for fragments without images.
                         <ul class="excluded-related">
                             {% for related_document in document.related_documents %}
                                 <li>
-                                    {% translate 'Unknown type' as unknown_type %}
                                     <a href="{% url 'corpus:document' related_document.pgpid %}">
-                                        <span class="doctype">{{ related_document.type|default:unknown_type }}</span>
+                                        <span class="doctype">{{ related_document.type }}</span>
                                         <span class="shelfmark">{{ related_document.shelfmark|shelfmark_wrap }}</span>
                                     </a>
                                 </li>

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -47,18 +47,20 @@ Also doesn't currently account for fragments without images.
                 <div class="img" id="{{ image_info.label }}" data-controller="iiif" data-iiif-target="imageContainer">
                     <div class="img-header" data-iiif-target="imageHeader">
                         <h3>{{ image_info.shelfmark }} {{ image_info.label }}</h3>
-                        <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
-                        <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
-                        <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
-                        <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
-                        <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
-                            <i class="ph-arrow-counter-clockwise"></i>
-                        </button>
-                        <button type="button" data-iiif-target="rotateRight" class="rotate" aria-label="{% translate 'Rotate right' %}" disabled>
-                            <i class="ph-arrow-clockwise"></i>
-                        </button>
+                        {% if not image_info.not_in_document %}
+                            <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
+                            <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
+                            <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
+                            <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
+                            <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
+                                <i class="ph-arrow-counter-clockwise"></i>
+                            </button>
+                            <button type="button" data-iiif-target="rotateRight" class="rotate" aria-label="{% translate 'Rotate right' %}" disabled>
+                                <i class="ph-arrow-clockwise"></i>
+                            </button>
+                        {% endif %}
                     </div>
-                    <div class="deep-zoom-container">
+                    <div class="deep-zoom-container{% if image_info.not_in_document %} excluded{% endif %}">
                         <img class="iiif-image" data-iiif-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
                             sizes="(max-width: 650px) 50vw, 94vw"
                             srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
@@ -69,18 +71,33 @@ Also doesn't currently account for fragments without images.
                     </div>
                 </div>
                 <div class="transcription-panel">
-                    {% if forloop.first %}
-                        <h3>Transcription</h3>
-                        <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
+                    {% if image_info.not_in_document %}
+                        {# if this image isn't actually in this document, link to related documents #}
+                        <ul class="excluded-related">
+                            {% for related_document in document.related_documents %}
+                                <li>
+                                    {% translate 'Unknown type' as unknown_type %}
+                                    <a href="{% url 'corpus:document' related_document.pgpid %}">
+                                        <span class="doctype">{{ related_document.type|default:unknown_type }}</span>
+                                        <span class="shelfmark">{{ related_document.shelfmark|shelfmark_wrap }}</span>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% else %}
+                        {% if forloop.first %}
+                            <h3>Transcription</h3>
+                            <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
+                        {% endif %}
+                        <div class="editions">
+                            {# display transcription in chunks by index #}
+                            {% for edition in document.digital_editions.all %}
+                                <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
+                                    {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
+                                </div>
+                            {% endfor %}
+                        </div>
                     {% endif %}
-                    <div class="editions">
-                        {# display transcription in chunks by index #}
-                        {% for edition in document.digital_editions.all %}
-                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
-                                {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
-                            </div>
-                        {% endfor %}
-                    </div>
                 </div>
             {% endfor %}
             {# if there are no images, loop based on the transcription chunks instead #}

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -591,6 +591,17 @@
                     opacity: 1;
                 }
             }
+            // 60% white overlay for images that are not included in the document (by side)
+            &.excluded::after {
+                position: absolute;
+                content: "";
+                display: block;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background: rgba(255, 255, 255, 0.6);
+            }
         }
         @include breakpoints.for-tablet-landscape-up {
             padding: 14px 0 0;
@@ -664,6 +675,19 @@
             & > div {
                 flex: 1 0 100%;
                 align-self: flex-start;
+            }
+        }
+
+        // related documents, to appear by excluded image(s)
+        .excluded-related {
+            @include breakpoints.for-tablet-landscape-up {
+                margin-top: 65px;
+            }
+            span.doctype {
+                @include typography.doctype;
+            }
+            span.shelfmark * {
+                @include typography.link;
             }
         }
     }


### PR DESCRIPTION
## In this PR

- Per #957:
  - Show a 60% white overlay on images that are not part of the document, based on `TextBlock.side`
  - Hide zoom controls for those excluded images
- Per #958:
  - Don't display transcription chunk next to image
  - Display related documents there instead

## Questions

- For related documents, I didn't fully understand the filtering you described in #958, so right now I'm just showing all related documents. Can you elaborate on "filter documents for display based on the iiif url indexed in Solr index data based on side information"? And when you said to call it in the view, did you mean the view class or the template?
  - Should there also be a label here before the link, like "See **Type: shelfmark**"?
- Also for related documents, should I create a reusable template snippet for document link with type + shelfmark? It's identical code to the document results page right now. (It's also nearly identical to the one in `document_header`, but that one uses `doctype` and `shelfmark_display` and has a fallback/translation for "Unknown type".)