### PR TITLE
Fix transcription switcher on docs w/ no images (#899), use full citation (#959)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -88,9 +88,18 @@ Also doesn't currently account for fragments without images.
             {% for chunk in document.digital_editions.0.content.html %}
                 <div class="img"></div> {# empty image div needed for grid layout #}
                 <div class="transcription-panel">
-                    {% if forloop.first %}<h3>Transcription</h3>{% endif %}
-                    {# display transcription in chunks based on loop index #}
-                    <div class="transcription">{{ chunk|h1_to_h3|safe }}</div>
+                    {% if forloop.first %}
+                        <h3>Transcription</h3>
+                        <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
+                    {% endif %}
+                    <div class="editions">
+                        {# display transcription in chunks based on loop index #}
+                        {% for edition in document.digital_editions.all %}
+                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
+                                {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
+                            </div>
+                        {% endfor %}
+                    </div>
                 </div>
             {% endfor %}
         {% endif %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -71,12 +71,14 @@ Also doesn't currently account for fragments without images.
                 <div class="transcription-panel">
                     {% if forloop.first %}
                         <h3>Transcription</h3>
-                        <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
+                        <span data-transcription-target="editionFullLabel" class="current-transcription{% if document.digital_editions.count > 1 %} multiple{% endif %}">
+                            {{ document.digital_editions.0.source.formatted_display|safe }}
+                        </span>
                     {% endif %}
                     <div class="editions">
                         {# display transcription in chunks by index #}
                         {% for edition in document.digital_editions.all %}
-                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
+                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display|safe }}">
                                 {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
                             </div>
                         {% endfor %}
@@ -90,12 +92,14 @@ Also doesn't currently account for fragments without images.
                 <div class="transcription-panel">
                     {% if forloop.first %}
                         <h3>Transcription</h3>
-                        <span data-transcription-target="editionFullLabel" class="current-transcription">{{ document.digital_editions.0.display|safe }}</span>
+                        <span data-transcription-target="editionFullLabel" class="current-transcription{% if document.digital_editions.count > 1 %} multiple{% endif %}">
+                            {{ document.digital_editions.0.source.formatted_display|safe }}
+                        </span>
                     {% endif %}
                     <div class="editions">
                         {# display transcription in chunks based on loop index #}
                         {% for edition in document.digital_editions.all %}
-                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.display|safe }}">
+                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display|safe }}">
                                 {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
                             </div>
                         {% endfor %}

--- a/sitemedia/js/controllers/transcription_controller.js
+++ b/sitemedia/js/controllers/transcription_controller.js
@@ -36,6 +36,7 @@ export default class extends Controller {
         const edition = evt.currentTarget.dataset.edition;
         const chunks = document.querySelectorAll(`.${edition}`);
         this.scrollChunksIntoView(chunks);
+        console.log(chunks);
 
         // Set subheader to show full label for edition
         this.editionFullLabelTarget.innerHTML = chunks[0].dataset.label;

--- a/sitemedia/js/controllers/transcription_controller.js
+++ b/sitemedia/js/controllers/transcription_controller.js
@@ -36,7 +36,6 @@ export default class extends Controller {
         const edition = evt.currentTarget.dataset.edition;
         const chunks = document.querySelectorAll(`.${edition}`);
         this.scrollChunksIntoView(chunks);
-        console.log(chunks);
 
         // Set subheader to show full label for edition
         this.editionFullLabelTarget.innerHTML = chunks[0].dataset.label;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -627,7 +627,9 @@
             display: block;
             @include typography.meta;
             color: var(--input-date-text);
-            min-height: calc(1rem * 1.5 * 2);
+            &.multiple {
+                min-height: calc(1rem * 1.5 * 2);
+            }
         }
         @include breakpoints.for-tablet-landscape-up {
             padding: 0 0 0;
@@ -638,7 +640,7 @@
                 @include typography.body-bold;
                 margin: 27px 0 0;
             }
-            h3 + span.current-transcription {
+            h3 + span.current-transcription.multiple {
                 min-height: calc(1.125rem * 1.5 * 2);
             }
         }


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/959#issuecomment-1194461536, fixes the transcription switcher (#899) for documents with no images. (It was not working at all before due to missing Stimulus targets)

## Questions

Similar to how the chunking index in documents with images relies on the number of images, the chunking index here relies on the number of chunks in `digital_editions.0`. I wonder if we should come up with a different way to handle chunk indices, since that's also the problem we're having with https://github.com/Princeton-CDH/geniza/pull/969?