### PR TITLE
Implement angle rotation (#978)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -51,12 +51,8 @@ Also doesn't currently account for fragments without images.
                         <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
                         <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
                         <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
-                        <button type="button" data-iiif-target="rotateLeft" class="rotate" aria-label="{% translate 'Rotate left' %}" disabled>
-                            <i class="ph-arrow-counter-clockwise"></i>
-                        </button>
-                        <button type="button" data-iiif-target="rotateRight" class="rotate" aria-label="{% translate 'Rotate right' %}" disabled>
-                            <i class="ph-arrow-clockwise"></i>
-                        </button>
+                        <div id="rotation-{{ forloop.counter0 }}" class="rotation" data-iiif-target="rotation" data-action="input->iiif#handleDeepZoom change->iiif#handleDeepZoom"></div>
+                        <label for="rotation-{{ forloop.counter0 }}" data-iiif-target="rotationLabel">0&deg;</label>
                     </div>
                     <div class="deep-zoom-container">
                         <img class="iiif-image" data-iiif-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@hotwired/stimulus": "^3.0.1",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
         "@hotwired/turbo": "^7.1.0",
+        "angle-input": "^0.0.1",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -1646,6 +1647,64 @@
       "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
       "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2551,9 +2610,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2631,6 +2690,11 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "node_modules/angle-input": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/angle-input/-/angle-input-0.0.1.tgz",
+      "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
@@ -7022,14 +7086,15 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
-      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
@@ -7062,15 +7127,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/through": {
@@ -9028,6 +9084,55 @@
       "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
       "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9842,9 +9947,9 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-import-assertions": {
@@ -9915,6 +10020,11 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "angle-input": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/angle-input/-/angle-input-0.0.1.tgz",
+      "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "ansi-html-community": {
       "version": "0.0.8",
@@ -13491,22 +13601,15 @@
       "dev": true
     },
     "terser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
-      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
+        "source-map-support": "~0.5.20"
       }
     },
     "terser-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo": "^7.1.0",
+    "angle-input": "^0.0.1",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -2,30 +2,44 @@
 
 import { Controller } from "@hotwired/stimulus";
 import OpenSeadragon from "openseadragon";
+import AngleInput from "angle-input";
 
 export default class extends Controller {
     static targets = [
         "imageHeader",
         "osd",
-        "rotateLeft",
-        "rotateRight",
+        "rotation",
+        "rotationLabel",
         "image",
         "zoomSlider",
         "zoomSliderLabel",
         "zoomToggle",
     ];
 
+    rotationTargetConnected() {
+        // initialize angle rotation input
+        AngleInput(this.rotationTarget, {
+            max: 360, // maximum value
+            min: 0, // minimum value
+            step: 1, // [min, min+step, ..., max]
+            name: this.rotationTarget.id, // used for <input name>
+        });
+    }
     osdTargetDisconnected() {
         // remove OSD on target disconnect (i.e. leaving page)
         this.deactivateDeepZoom();
     }
     handleDeepZoom(evt) {
-        // Enable OSD and/or zoom based on zoom slider level
+        // Enable OSD if not enabled
         // OSD needs to use DOM queries since it can't be assigned a target
         const OSD = this.osdTarget.querySelector(".openseadragon-container");
         if (!OSD || this.osdTarget.classList.contains("hidden")) {
             const isMobile = evt.currentTarget.id.startsWith("zoom-toggle");
             this.activateDeepZoom({ isMobile });
+            if (evt.currentTarget.classList.contains("rotation")) {
+                // if activated via rotate, ensure zoom UI appears active
+                this.updateZoomUI(1.0, false);
+            }
         }
     }
     activateDeepZoom(settings) {
@@ -40,16 +54,15 @@ export default class extends Controller {
         this.imageTarget.classList.add("hidden");
         this.osdTarget.classList.remove("hidden");
         this.osdTarget.classList.add("visible");
-        this.rotateRightTarget.removeAttribute("disabled");
-        this.rotateLeftTarget.removeAttribute("disabled");
+        this.rotationTarget.classList.add("active");
     }
     deactivateDeepZoom() {
         this.imageTarget.classList.add("visible");
         this.imageTarget.classList.remove("hidden");
         this.osdTarget.classList.remove("visible");
         this.osdTarget.classList.add("hidden");
-        this.rotateRightTarget.setAttribute("disabled", "true");
-        this.rotateLeftTarget.setAttribute("disabled", "true");
+        this.rotationTarget.classList.remove("active");
+        this.updateRotationUI(0);
     }
     addOpenSeaDragon(settings) {
         const { isMobile } = settings;
@@ -115,13 +128,15 @@ export default class extends Controller {
                     viewer.viewport.zoomTo(1.1);
                 }
             });
-            // initialize desktop rotation buttons
-            this.rotateLeftTarget.addEventListener("click", () => {
-                viewer.viewport.setRotation(viewer.viewport.getRotation() - 90);
-            });
-            this.rotateRightTarget.addEventListener("click", () => {
-                viewer.viewport.setRotation(viewer.viewport.getRotation() + 90);
-            });
+            // initialize desktop rotation control
+            this.rotationTarget.addEventListener(
+                "input",
+                this.handleRotationInput(viewer)
+            );
+            this.rotationTarget.addEventListener(
+                "change",
+                this.handleRotationInput(viewer)
+            );
         });
         viewer.addHandler("zoom", (evt) => {
             // Handle changes in the canvas zoom
@@ -134,6 +149,19 @@ export default class extends Controller {
             this.zoomSliderTarget.value = parseFloat(zoom);
             this.updateZoomUI(zoom, false);
         });
+        viewer.addHandler("rotate", (evt) => {
+            // Handle other changes in the canvas rotation (via Magic Trackpad, e.g.)
+            const { degrees } = evt;
+            this.updateRotationUI(-1 * parseInt(degrees));
+        });
+    }
+    handleRotationInput(viewer) {
+        return (evt) => {
+            const angle = parseInt(evt.target.querySelector("input").value);
+            // set rotation to -angle for natural UX
+            viewer.viewport.setRotation(-1 * angle);
+            this.updateRotationUI(angle, evt);
+        };
     }
     handleZoomSliderInput(viewer, minZoom) {
         return (evt) => {
@@ -171,6 +199,18 @@ export default class extends Controller {
             this.zoomSliderTarget.classList.add("active-thumb");
         }
         this.zoomSliderTarget.style.background = `linear-gradient(to right, var(--link-primary) 0%, var(--link-primary) ${percent}%, ${secondColor} ${percent}%, ${secondColor} 100%)`;
+    }
+    updateRotationUI(angle, autoUpdate) {
+        // update rotation label
+        this.rotationLabelTarget.innerHTML = `${angle}&deg;`;
+        if (!autoUpdate) {
+            // update input value and pivot angle
+            this.rotationTarget.querySelector("input").value =
+                -1 * angle.toString();
+            this.rotationTarget.querySelector(
+                "span.angle-input-pivot"
+            ).style.transform = `rotate(${-1 * angle}deg)`;
+        }
     }
     resetBounds(viewer) {
         // Reset OSD viewer to the boundaries of the image, position in top left corner

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -481,7 +481,8 @@
                     }
                 }
             }
-            label[for^="zoom-slider"] {
+            label[for^="zoom-slider"],
+            label[for^="rotation"] {
                 display: none;
                 @include breakpoints.for-tablet-landscape-up {
                     display: block;
@@ -491,41 +492,45 @@
                 color: var(--on-background);
                 @include typography.body-bold;
             }
-            // rotation controls
-            button.rotate {
-                display: block;
-                // float: right;
-                text-align: center;
-                margin: 0;
-                @include typography.icon-button-lg;
-                min-width: 48px;
-                min-height: 48px;
-                &:last-of-type {
-                    margin: 0 spacing.$spacing-xs 0 0;
-                }
+            // desktop rotation controls
+            div.rotation {
+                display: none;
                 @include breakpoints.for-tablet-landscape-up {
-                    min-width: 0px;
-                    min-height: 0px;
-                    @include typography.icon-button-md;
-                    margin: 0 0 0 spacing.$spacing-md;
-                    &:last-of-type {
-                        margin: 0 spacing.$spacing-3xs 0;
-                    }
-                }
-                background: none;
-                border: none;
-                padding: 0;
-                color: var(--on-backround);
-                transition: color 300ms ease;
-                cursor: pointer;
-                &:disabled {
-                    color: var(--disabled);
-                    cursor: default;
-                }
-                i {
-                    // ensure no extra space inside button
                     display: block;
                 }
+                margin: 0 0 0 spacing.$spacing-md;
+                position: relative;
+                border-radius: 50%;
+                height: 40px;
+                width: 40px;
+                background-color: var(--background-gray);
+                border: 4px solid var(--on-background-light-alt);
+                cursor: pointer;
+                span.angle-input-pivot {
+                    position: absolute;
+                    left: 0;
+                    right: 0;
+                    top: 50%;
+                    margin-top: -1px;
+                    height: 2px;
+                    &::before {
+                        content: "";
+                        position: absolute;
+                        right: 0;
+                        top: 50%;
+                        margin-top: -8px;
+                        background-color: var(--filter-active);
+                        width: 16px;
+                        height: 16px;
+                        border-radius: 50%;
+                    }
+                }
+                &.active span.angle-input-pivot::before {
+                    background-color: var(--link-primary);
+                }
+            }
+            label[for^="rotation"] {
+                flex: 0 1 45px;
             }
             // zoom control (mobile)
             input[type="checkbox"][id^="zoom-toggle"] {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const Autoprefixer = require("autoprefixer");
 const BundleTracker = require("webpack-bundle-tracker");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const { IgnorePlugin } = require("webpack");
 
 module.exports = (env, options) => ({
     // NOTE if you add a new entrypoint, update the dummy webpack-stats-ci.json
@@ -90,6 +91,11 @@ module.exports = (env, options) => ({
                 options.mode == "production"
                     ? "[name]-[contenthash].min.css"
                     : "[name].css",
+        }),
+        new IgnorePlugin({
+            // ignore unneeded jquery dependency in angle-input
+            resourceRegExp: /jquery/u,
+            contextRegExp: /angle-input/u,
         }),
     ],
     // configuration for dev server (run using `npm start`)


### PR DESCRIPTION
## In this PR

- Per #978:
  - Replace +/- 90º rotation with `angle-input` library, new design

## dev notes

- The Webpack IgnorePlugin is required because of a line `require("jquery")` in the angle rotation library, which Webpack will evaluate even if you aren't using the jQuery part of the library. Fortunately, the library doesn't list `jquery` in its requirements, so we aren't forced to include it in the bundle; instead, we need to tell Webpack specifically to ignore this `require` statement.
- I added this section to support rotation events on desktop that aren't triggered by the angle input, as I recalled from our meeting that @rlskoeser found it was possible. But I don't have a Magic Trackpad or similar, so I have no way of testing if this works. Please check to make sure that the angle input updates its UI when you rotate the canvas this way—or, let me know if you can't actually rotate without using the angle input, in which case I'll remove it.
    https://github.com/Princeton-CDH/geniza/blob/f55751b1fa6c4d1d48b0709be68eec7a0fbe083f/sitemedia/js/controllers/iiif_controller.js#L152-L156