### PR TITLE
Unmark HTML safe in data attribute (#959)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -74,7 +74,7 @@ Also doesn't currently account for fragments without images.
                     <div class="editions">
                         {# display transcription in chunks by index #}
                         {% for edition in document.digital_editions.all %}
-                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display|safe }}">
+                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display }}">
                                 {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
                             </div>
                         {% endfor %}
@@ -95,7 +95,7 @@ Also doesn't currently account for fragments without images.
                     <div class="editions">
                         {# display transcription in chunks based on loop index #}
                         {% for edition in document.digital_editions.all %}
-                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display|safe }}">
+                            <div class="transcription ed-{{ edition.pk }}" data-label="{{ edition.source.formatted_display }}">
                                 {{ edition.content.html|index:forloop.parentloop.counter0|h1_to_h3|safe }}
                             </div>
                         {% endfor %}


### PR DESCRIPTION
## In this PR

The use of `|safe` inside a data attribute of an element was causing broken HTML. This PR removes it and leaves the HTML escaped in that context.