### PR TITLE
Fix missing styles on transcription editor (#916)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "geniza",
       "dependencies": {
         "@hotwired/stimulus": "^3.0.1",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
@@ -12,7 +11,7 @@
         "@recogito/annotorious": "^2.7.2",
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -41,20 +40,31 @@
       "version": "1.0.0",
       "extraneous": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@tinymce/tinymce-webcomponent": "^2.0.0"
+      },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.2",
         "@types/jest": "^27.5.0",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
+        "autoprefixer": "^10.4.7",
         "core-js": "^3.22.4",
+        "css-loader": "^6.7.1",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^39.2.9",
         "eslint-plugin-prettier": "4.0.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^28.0.3",
         "jest-environment-jsdom": "^28.0.2",
+        "jest-fetch-mock": "^3.0.3",
+        "postcss-loader": "^7.0.1",
+        "sass": "^1.53.0",
+        "sass-loader": "^13.0.2",
+        "style-loader": "^3.3.1",
         "ts-jest": "^28.0.1",
         "ts-loader": "^9.3.0",
         "typescript": "^4.6.4",
@@ -2865,8 +2875,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
-      "integrity": "sha512-g8MdgxERCrO7vTz3fujXEwqtJol2li3Aq7ncd/O1AeRitTl1HEbgjcCW2aoshJR2gAb578sIP4U7BTEwg/N8nA==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#11446b71a282666fad772a98847e8333e7b6a8b0",
+      "integrity": "sha512-SE4VWTr/NGQgGh5rVG2pZj4wUWGWmNe+ppWs++7Jt4hwCsbM6+Fyu2i/QramkijZVD6/jBy2ZKpsbrcE9Uu6bw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
@@ -10916,9 +10926,9 @@
       "dev": true
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
-      "integrity": "sha512-g8MdgxERCrO7vTz3fujXEwqtJol2li3Aq7ncd/O1AeRitTl1HEbgjcCW2aoshJR2gAb578sIP4U7BTEwg/N8nA==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#11446b71a282666fad772a98847e8333e7b6a8b0",
+      "integrity": "sha512-SE4VWTr/NGQgGh5rVG2pZj4wUWGWmNe+ppWs++7Jt4hwCsbM6+Fyu2i/QramkijZVD6/jBy2ZKpsbrcE9Uu6bw==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "geniza",
       "dependencies": {
         "@hotwired/stimulus": "^3.0.1",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
@@ -1750,6 +1751,64 @@
       "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
       "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2723,9 +2782,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -7760,14 +7819,15 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
-      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
@@ -7800,15 +7860,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/through": {
@@ -9872,6 +9923,55 @@
       "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
       "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -10741,9 +10841,9 @@
       }
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-import-assertions": {
@@ -10818,7 +10918,7 @@
     "annotorious-tahqiq": {
       "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
       "integrity": "sha512-g8MdgxERCrO7vTz3fujXEwqtJol2li3Aq7ncd/O1AeRitTl1HEbgjcCW2aoshJR2gAb578sIP4U7BTEwg/N8nA==",
-      "from": "annotorious-tahqiq@https://github.com/Princeton-CDH/annotorious-tahqiq#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
       }
@@ -14803,22 +14903,15 @@
       "dev": true
     },
     "terser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
-      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
+        "source-map-support": "~0.5.20"
       }
     },
     "terser-webpack-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@recogito/annotorious": "^2.7.2",
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2875,8 +2875,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#11446b71a282666fad772a98847e8333e7b6a8b0",
-      "integrity": "sha512-SE4VWTr/NGQgGh5rVG2pZj4wUWGWmNe+ppWs++7Jt4hwCsbM6+Fyu2i/QramkijZVD6/jBy2ZKpsbrcE9Uu6bw==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
+      "integrity": "sha512-zpK5MVun7Hq/qNXmWu4ke4xYxfcmVZGEAzNwc26MyyMcgHNVUWLyI1gUCMv0r19fvyukRDB9qSns6qrshXAXSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
@@ -10926,9 +10926,9 @@
       "dev": true
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#11446b71a282666fad772a98847e8333e7b6a8b0",
-      "integrity": "sha512-SE4VWTr/NGQgGh5rVG2pZj4wUWGWmNe+ppWs++7Jt4hwCsbM6+Fyu2i/QramkijZVD6/jBy2ZKpsbrcE9Uu6bw==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
+      "integrity": "sha512-zpK5MVun7Hq/qNXmWu4ke4xYxfcmVZGEAzNwc26MyyMcgHNVUWLyI1gUCMv0r19fvyukRDB9qSns6qrshXAXSQ==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@recogito/annotorious": "^2.7.2",
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#e4f30d2b3965a67ef4359b15b25f88cdb0aaff27",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@recogito/annotorious": "^2.7.2",
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#11446b71a282666fad772a98847e8333e7b6a8b0",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -15,4 +15,12 @@ div.annotate {
         color: black;
         min-height: 3em;
     }
+    ol {
+        counter-reset: section;
+    }
+    li::before {
+        /* use pseudo marker to avoid periods for line numbers */
+        counter-increment: section;
+        content: counter(section);
+    }
 }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -612,7 +612,7 @@
             max-width: none;
         }
         padding: 20px 10px 0;
-
+        // transcription label / switcher
         &.label-row {
             padding-right: 0;
             padding-top: 0;
@@ -623,6 +623,7 @@
         & > h3 {
             margin: 30px 0 12px;
         }
+        // transcription citation
         h3 + span.current-transcription {
             display: block;
             @include typography.meta;
@@ -798,6 +799,14 @@ a.editor-navigation {
         text-align: right;
         // disable site default max character width for reading
         max-width: none;
+    }
+
+    sup {
+        font-size: 75%;
+        line-height: 0;
+        position: relative;
+        vertical-align: baseline;
+        top: -0.5em;
     }
 
     li {


### PR DESCRIPTION
## In this PR

- Per https://github.com/Princeton-CDH/geniza/issues/916#issuecomment-1194136341:
  - Style superscript
  - Style line numbers (in transcribe view; main view uses data attribute)
- Update tahqiq to allow editing empty annotations
  - We will probably need to update the commit hash once [the tahqiq PR](https://github.com/Princeton-CDH/annotorious-tahqiq/pull/11) is merged

## Questions

- How should we handle the discrepancy between the line numbering between the editor (plain `<li>` elements) and the existing TEI transcriptions (`<li>` elements with `data-value` attributes)? Something to think about for the upcoming changes to transcription format, maybe?
- Should there be some kind of validation to ensure content in the annotation body?