### PR TITLE
Snap rotation to 0 within +/- 5 degrees (#978)

### DIFF
--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -149,15 +149,14 @@ export default class extends Controller {
             this.zoomSliderTarget.value = parseFloat(zoom);
             this.updateZoomUI(zoom, false);
         });
-        viewer.addHandler("rotate", (evt) => {
-            // Handle other changes in the canvas rotation (via Magic Trackpad, e.g.)
-            const { degrees } = evt;
-            this.updateRotationUI(-1 * parseInt(degrees));
-        });
     }
     handleRotationInput(viewer) {
         return (evt) => {
-            const angle = parseInt(evt.target.querySelector("input").value);
+            let angle = parseInt(evt.target.querySelector("input").value);
+            // if within a tolerance of +/- 5deg from 0deg, set to 0deg
+            if (angle <= 5 || angle >= 355) {
+                angle = 0;
+            }
             // set rotation to -angle for natural UX
             viewer.viewport.setRotation(-1 * angle);
             this.updateRotationUI(angle, evt);


### PR DESCRIPTION
## In this PR

- Remove handler on viewer to handle gesture "rotate" events triggered by interaction with the canvas itself, since per https://github.com/Princeton-CDH/geniza/pull/979#pullrequestreview-1051011969 gesture rotation doesn't seem to work on desktop anyway (and I can't test it)
- Per https://github.com/Princeton-CDH/geniza/issues/978#issuecomment-1195959854:
  - Snap rotation to 0 degrees within +/- 5