### PR TITLE
Link annotations to scholarship records (#913)

### DIFF
--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -166,3 +166,23 @@ class TestAnnotationSearch:
         # should bring back only anno1
         assertContains(response, anno1.uri())
         assertNotContains(response, anno2.uri())
+
+    def test_search_source(self, client):
+        # content__contains={"dc:source": source_uri}
+        source_uri = "http://example.com/source/1"
+        anno1 = Annotation.objects.create(content={"dc:source": source_uri})
+        anno2 = Annotation.objects.create(
+            content={"dc:source": "http://example.com/source/2"}
+        )
+        anno3 = Annotation.objects.create(
+            content={"target": {"source": {"id": source_uri}}}
+        )
+        response = client.get(self.anno_search_url, {"source": source_uri})
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        # response should indicate annotation list
+        assertContains(response, "sc:AnnotationList")
+        # should bring back only anno1
+        assertContains(response, anno1.uri())
+        assertNotContains(response, anno2.uri())
+        assertNotContains(response, anno3.uri())

--- a/geniza/annotations/views.py
+++ b/geniza/annotations/views.py
@@ -111,7 +111,7 @@ class AnnotationSearch(View, MultipleObjectMixin):
 
     def get(self, request, *args, **kwargs):
         """Search annotations and return an annotation list. Currently only supports
-        search by target uri."""
+        search by target uri and source uri."""
         # implement minimal search by uri
         # implement something similar to SAS search by uri
         annotations = self.get_queryset()
@@ -119,6 +119,12 @@ class AnnotationSearch(View, MultipleObjectMixin):
         target_uri = self.request.GET.get("uri")
         if target_uri:
             annotations = annotations.filter(content__target__source__id=target_uri)
+        source_uri = self.request.GET.get("source")
+        # if a source uri is specified, filter on content__dc:source
+        if source_uri:
+            annotations = annotations.filter(
+                content__contains={"dc:source": source_uri}
+            )
         # NOTE: if any params are ignored, they should be removed from id for search uri
         # and documented in the response as ignored
 

--- a/geniza/annotations/views.py
+++ b/geniza/annotations/views.py
@@ -112,6 +112,7 @@ class AnnotationSearch(View, MultipleObjectMixin):
     def get(self, request, *args, **kwargs):
         """Search annotations and return an annotation list. Currently only supports
         search by target uri and source uri."""
+        # TODO: Convert this to list when > 2 options
         # implement minimal search by uri
         # implement something similar to SAS search by uri
         annotations = self.get_queryset()

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -3,16 +3,16 @@
     {{ annotation_config|json_script:"annotation-config" }}
 {% elif perms.corpus.change_document and document.iiif_images %}
     {# NOTE: document.iiif_images check is temporary, remove once we can use generated canvas ids #}
-    <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id %}" data-turbo="false">
-        <i class="ph-plus-circle"></i>
-        <span>Add a new transcription</span>
-    </a>
     {% for ed in document.digital_editions.all %}
         <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id ed.source.pk %}" data-turbo="false">
             <i class="ph-pencil"></i>
             <span>Edit {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% empty %}[unknown]{% endfor %}'s edition</span>
         </a>
     {% endfor %}
+    <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id %}" data-turbo="false">
+        <i class="ph-plus-circle"></i>
+        <span>Add a new transcription</span>
+    </a>
 {% endif %}
 <section id="itt-panel" {% if not edit_mode %}data-controller="transcription" data-action="click@document->transcription#clickCloseDropdown"{% endif %}>
     {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -32,11 +32,17 @@
         {# label row #}
         <div class="label-row"></div> {# unused (no image label, needed for column alignment) #}
         <div class="transcription-panel label-row">
-            {# disable in editor mode #}
-            {% if not edit_mode %}
+            {% if edit_mode %}
+                {# show disabled details with source label in editor mode #}
+                <details class="transcription-select" aria-expanded="false" disabled="true">
+                    <summary>
+                        <span>Edition: {{ source_label }}</span>
+                    </summary>
+                </details>
+            {% else %}
                 {# dropdown is disabled by default; enable if javascript is active #}
                 <details class="transcription-select" aria-expanded="false" data-transcription-target="dropdownDetails" data-edition-count="{{ document.digital_editions.count }}" disabled="true">
-                    <summary class="transcription-select-trigger" data-action="keydown->transcription#shiftTabCloseDropdown">
+                    <summary data-action="keydown->transcription#shiftTabCloseDropdown">
                         <span data-transcription-target="editionShortLabel">Edition: {{ document.digital_editions.0.source.all_authors }}</span>
                     </summary>
                     <ul>

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -4,10 +4,15 @@
 {% elif perms.corpus.change_document and document.iiif_images %}
     {# NOTE: document.iiif_images check is temporary, remove once we can use generated canvas ids #}
     <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id %}" data-turbo="false">
-        <i class="ph-pencil"></i>
-        {# Translators: Transcription edit link for admins #}
-        <span>{% translate 'Add or edit transcription' %}</span>
+        <i class="ph-plus-circle"></i>
+        <span>Add a new transcription</span>
     </a>
+    {% for ed in document.digital_editions.all %}
+        <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id ed.source.pk %}" data-turbo="false">
+            <i class="ph-pencil"></i>
+            <span>Edit {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% empty %}[unknown]{% endfor %}'s edition</span>
+        </a>
+    {% endfor %}
 {% endif %}
 <section id="itt-panel" {% if not edit_mode %}data-controller="transcription" data-action="click@document->transcription#clickCloseDropdown"{% endif %}>
     {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -25,6 +25,7 @@ from geniza.corpus.views import (
     DocumentMerge,
     DocumentScholarshipView,
     DocumentSearchView,
+    DocumentTranscribeView,
     DocumentTranscriptionText,
     old_pgp_edition,
     old_pgp_tabulate_data,
@@ -1370,3 +1371,15 @@ class TestDocumentTranscribeView:
         )
         assert response.status_code == 302
         assert response.url.startswith("/accounts/login/")
+
+    def test_get_context_data(self, document, source, admin_client):
+        # request with no source_pk
+        response = admin_client.get(
+            reverse("corpus:document-transcribe", args=(document.id,))
+        )
+        assert not response.context["annotation_config"]["source_uri"]
+        # request with source_pk
+        response = admin_client.get(
+            reverse("corpus:document-transcribe", args=(document.id, source.pk))
+        )
+        assert response.context["annotation_config"]["source_uri"] == source.uri

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
         name="document-transcribe",
     ),
     path(
+        "documents/<int:pk>/transcribe/<int:source_pk>/",
+        corpus_views.DocumentTranscribeView.as_view(),
+        name="document-transcribe",
+    ),
+    path(
         "documents/<int:pk>/transcription/<int:transcription_pk>/",
         corpus_views.DocumentTranscriptionText.as_view(),
         name="document-transcription-text",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -664,7 +664,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
 
         # get source uri if source_pk present in kwargs (i.e. editing an existing transcription),
         # and the source exists
-        source_uri = ""
+        source = None
         source_pk = self.kwargs.get("source_pk", None)
         # if source_pk is None, it's a new transcription, so no Source query
         # TODO: once add transcription view is separated, this view should not be called without
@@ -672,7 +672,6 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
         if source_pk is not None:
             try:
                 source = Source.objects.get(pk=source_pk)
-                source_uri = source.uri
             except Source.DoesNotExist:
                 raise Http404
 
@@ -682,7 +681,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     # use local annotation server embedded in pgp application
                     "server_url": absolutize_url(reverse("annotations:list")),
                     # source uri for filtering, if we are editing an existing transcription
-                    "source_uri": source_uri,
+                    "source_uri": source.uri if source else "",
                     # use getattr to simplify test config; warn if not set?
                     "manifest_base_url": getattr(
                         settings, "ANNOTATION_MANIFEST_BASE_URL", ""
@@ -690,7 +689,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "csrf_token": csrf_token(self.request),
                 },
                 "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
-                # TODO: Pass the scholarship record choice form in context data
+                "source_label": source.all_authors if source else "",
             }
         )
         return context_data

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -666,13 +666,15 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
         # and the source exists
         source_uri = ""
         source_pk = self.kwargs.get("source_pk", None)
-        try:
-            source = Source.objects.get(pk=source_pk)
-            source_uri = source.uri
-        except Source.DoesNotExist:
-            # NOTE: Should this raise a 404 if source_pk is not None?
-            # TODO: If source_pk is None, instantiate the scholarship record choice form
-            pass
+        # if source_pk is None, it's a new transcription, so no Source query
+        # TODO: once add transcription view is separated, this view should not be called without
+        # source_pk, so we should redirect there if source_pk is none
+        if source_pk is not None:
+            try:
+                source = Source.objects.get(pk=source_pk)
+                source_uri = source.uri
+            except Source.DoesNotExist:
+                raise Http404
 
         context_data.update(
             {

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -1,3 +1,7 @@
+from os import path
+from urllib.parse import urljoin
+
+from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.humanize.templatetags.humanize import ordinal
@@ -359,6 +363,13 @@ class Source(models.Model):
         else:
             volume = shelfmark.split(" ")[0]
         return volume
+
+    @property
+    def uri(self):
+        """Generate a URI for this source to be used in transcription annotations,
+        in order to filter them by associated source"""
+        manifest_base_url = getattr(settings, "ANNOTATION_MANIFEST_BASE_URL", "")
+        return urljoin(manifest_base_url, path.join("source", str(self.pk)))
 
 
 class FootnoteQuerySet(models.QuerySet):

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -368,8 +368,9 @@ class Source(models.Model):
     def uri(self):
         """Generate a URI for this source to be used in transcription annotations,
         in order to filter them by associated source"""
+        # TODO: add a minimal view with json representation of the source so that this uri resolves
         manifest_base_url = getattr(settings, "ANNOTATION_MANIFEST_BASE_URL", "")
-        return urljoin(manifest_base_url, path.join("source", str(self.pk)))
+        return urljoin(manifest_base_url, path.join("sources", str(self.pk))) + "/"
 
 
 class FootnoteQuerySet(models.QuerySet):

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -212,7 +212,7 @@ class TestSource:
         with patch("geniza.footnotes.models.getattr") as mock_getattr:
             # mock getattr so we can define manifest base URL here
             mock_getattr.return_value = "http://example.com/"
-            assert source.uri == f"http://example.com/source/{source.pk}"
+            assert source.uri == f"http://example.com/sources/{source.pk}/"
 
 
 class TestFootnote:

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -206,6 +206,14 @@ class TestSource:
             in source.formatted_display()
         )
 
+    @pytest.mark.django_db
+    def test_uri(self, source):
+        # should generate a URI using set manifest base URL with /source/pk
+        with patch("geniza.footnotes.models.getattr") as mock_getattr:
+            # mock getattr so we can define manifest base URL here
+            mock_getattr.return_value = "http://example.com/"
+            assert source.uri == f"http://example.com/source/{source.pk}"
+
 
 class TestFootnote:
     @pytest.mark.django_db

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2403,9 +2403,9 @@
       "dev": true
     },
     "node_modules/@tinymce/tinymce-webcomponent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.0.tgz",
-      "integrity": "sha512-w2vjtEthv6uKZbnTRNb81Chwfa5q+Ct6jBDWErhDq7rSTCoaPBZIYOauLZx29eCZ0ix0qFKfa4wtYMKxS+d44Q=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.1.tgz",
+      "integrity": "sha512-17rbpsggiRqfDTKaAvCFlt9LWfb3JBXXhCZtGprb/Rk707ZMJAjCMMrrobPdCqc71r7BTMCFRH5PL4sP87lbdw=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.1.1",
@@ -2881,8 +2881,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
-      "integrity": "sha512-zpK5MVun7Hq/qNXmWu4ke4xYxfcmVZGEAzNwc26MyyMcgHNVUWLyI1gUCMv0r19fvyukRDB9qSns6qrshXAXSQ==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#7965e14d63623bd3acb8578880b9a410be51df0b",
+      "integrity": "sha512-c/yPcYoTmCuFz9BXgz3UTksI2gLsF3xjAxNrVKyqYoBsAkapyEEyAIltL52ve0Sdrs0bCsa2yXX3/Rbsnq3gaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
@@ -10473,9 +10473,9 @@
       "dev": true
     },
     "@tinymce/tinymce-webcomponent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.0.tgz",
-      "integrity": "sha512-w2vjtEthv6uKZbnTRNb81Chwfa5q+Ct6jBDWErhDq7rSTCoaPBZIYOauLZx29eCZ0ix0qFKfa4wtYMKxS+d44Q=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.1.tgz",
+      "integrity": "sha512-17rbpsggiRqfDTKaAvCFlt9LWfb3JBXXhCZtGprb/Rk707ZMJAjCMMrrobPdCqc71r7BTMCFRH5PL4sP87lbdw=="
     },
     "@trysound/sax": {
       "version": "0.1.1",
@@ -10937,9 +10937,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
-      "integrity": "sha512-zpK5MVun7Hq/qNXmWu4ke4xYxfcmVZGEAzNwc26MyyMcgHNVUWLyI1gUCMv0r19fvyukRDB9qSns6qrshXAXSQ==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#7965e14d63623bd3acb8578880b9a410be51df0b",
+      "integrity": "sha512-c/yPcYoTmCuFz9BXgz3UTksI2gLsF3xjAxNrVKyqYoBsAkapyEEyAIltL52ve0Sdrs0bCsa2yXX3/Rbsnq3gaw==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@recogito/annotorious": "^2.7.2",
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#87f628d2abb467fe13d5f2b2ea52d5664112c4a2",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
     "angle-input": "^0.0.1",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -70,6 +70,9 @@ export default class extends IIIFControler {
             manifest: config.manifest_base_url + manifestId,
             csrf_token: config.csrf_token,
         };
+        if (config.source_uri) {
+            annotationServerConfig["sourceUri"] = config.source_uri;
+        }
         const storagePlugin = new AnnotationServerStorage(
             anno,
             annotationServerConfig

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -790,7 +790,7 @@ a.editor-navigation {
     i {
         text-decoration: none;
     }
-    margin: -1rem 0 1rem;
+    margin: -1rem 0 2rem;
 }
 
 // general transcription styles


### PR DESCRIPTION
## In this PR

- Per #913:
  - Add `Source.uri` property
  - Allow searching annotations on `dc:source`/source URI
  - Pass source URI to Tahqiq when editing existing transcription

## Questions

- Should I raise `Http404` here if the source could not be found and `source_pk` is not None? (It will always be None when a user clicks "Add a new transcription")
   https://github.com/Princeton-CDH/geniza/blob/12515f671a1f279ddd3175ecd9c40364c07d4d85/geniza/corpus/views.py#L669-L675
  - Note: the latter behavior may change depending on our approach in https://github.com/Princeton-CDH/geniza/pull/1005 (e.g. https://github.com/Princeton-CDH/geniza/pull/1005/commits/71f5a2475ba7fb9d5e560543f0e993bc5b2a2cfc)