### PR TITLE
Light/dark toggle revisions (#989)

### DIFF
--- a/sitemedia/scss/components/_controls.scss
+++ b/sitemedia/scss/components/_controls.scss
@@ -70,7 +70,7 @@ label#theme-toggle {
             width: 70px;
         }
         transition: transform 500ms ease;
-        transform: rotate(180deg);
+        transform: rotate(-180deg);
     }
     input:checked + span::before {
         transform: rotate(0deg);

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -44,6 +44,10 @@ footer {
         flex-flow: row wrap;
         justify-content: space-between;
     }
+    // extra style for hiding the theme toggle on desktop only
+    @include breakpoints.for-desktop-up {
+        z-index: 4;
+    }
 
     // footer site navigation (mobile)
     nav#footer-nav {

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -133,6 +133,14 @@ main.document {
             max-width: none;
             padding: 0 10rem;
         }
+        // extra style for hiding the theme toggle on desktop only
+        @include breakpoints.for-desktop-up {
+            z-index: 3;
+            background-color: var(--background);
+            margin-top: 0;
+            margin-bottom: -120px;
+            padding: 53px 10rem 120px;
+        }
         // hanging "link" phosphor icon before permalink label
         dt#permalink {
             display: flex;


### PR DESCRIPTION
## in this pr

- Per #989:
  - Hide theme toggle below transcription panel (extending permalink area to cover the bottom)
  - Rotate clockwise from light -> dark, then counter-clockwise from dark -> light