### PR TITLE
Unidecode all tags on pre_save signal (#943)

### DIFF
--- a/geniza/common/utils.py
+++ b/geniza/common/utils.py
@@ -48,6 +48,9 @@ def custom_tag_string(tag_string):
     - 'éxämplè' -> ["example"]
 
     This is configured in settings with TAGGIT_TAGS_FROM_STRING.
+
+    NOTE: Only runs on related save (i.e. tagging an instance of another model). For new tags
+    created separately, use a signal handler in :class:`~geniza.corpus.models.TagSignalHandlers`.
     """
     # Stack overflow solution: https://stackoverflow.com/questions/30513783/django-taggit-how-to-allow-multi-word-tags
     # Our github issue for taggit: https://github.com/jazzband/django-taggit/issues/783

--- a/geniza/corpus/apps.py
+++ b/geniza/corpus/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.db.models.signals import pre_save
 
 
 class CorpusAppConfig(AppConfig):
@@ -7,3 +8,8 @@ class CorpusAppConfig(AppConfig):
     def ready(self):
         # import and connect signal handlers for Solr indexing
         from parasolr.django.signals import IndexableSignalHandler
+
+        from geniza.corpus.models import TagSignalHandlers
+
+        pre_save.connect(TagSignalHandlers.unidecode_tag, sender="taggit.Tag")
+        return super().ready()

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -29,6 +29,7 @@ from piffle.image import IIIFImageClient
 from piffle.presentation import IIIFException, IIIFPresentation
 from requests.exceptions import ConnectionError
 from taggit_selectize.managers import TaggableManager
+from unidecode import unidecode
 from urllib3.exceptions import HTTPError, NewConnectionError
 
 from geniza.common.models import TrackChangesModel
@@ -420,6 +421,15 @@ class DocumentSignalHandlers:
         """reindex associated documents when a related object is deleted"""
         # delegate to common method
         DocumentSignalHandlers.related_change(instance, raw, "delete")
+
+
+class TagSignalHandlers:
+    """Signal handlers for :class:`taggit.Tag` records."""
+
+    @staticmethod
+    def unidecode_tag(sender, instance, **kwargs):
+        """Convert saved tags to ascii, stripping diacritics."""
+        instance.name = unidecode(instance.name)
 
 
 class Document(ModelIndexable, DocumentDateMixin):

--- a/geniza/corpus/tests/test_corpus_signals.py
+++ b/geniza/corpus/tests/test_corpus_signals.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from parasolr.django.indexing import ModelIndexable
+from taggit.models import Tag
 
 from geniza.corpus.models import (
     Document,
@@ -84,3 +85,10 @@ def test_related_delete(mock_indexitems, document, join):
     assert mock_indexitems.call_count == 1
     assert document in mock_indexitems.call_args[0][0]
     assert join not in mock_indexitems.call_args[0][0]
+
+
+@pytest.mark.django_db
+def test_unidecode_tags():
+    # pre_save signal should strip diacritics from tag and convert to ASCII
+    tag = Tag.objects.create(name="mu'ālim", slug="mualim")
+    assert tag.name == "mu'alim"


### PR DESCRIPTION
## In this PR

- Per #943:
  - Adds `pre_save` signal to `taggit.Tag` to ensure `unidecode` is run on the `name` field of model instances created manually, not just on related save of a tagged instance of another model.