### PR TITLE
Allow editing side info when no IIIF images present (#1023)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -17,6 +17,7 @@ from django.db.models.functions.text import Lower
 from django.db.models.query import Prefetch
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
@@ -248,10 +249,23 @@ class Fragment(TrackChangesModel):
 
     def iiif_thumbnails(self, selected=[]):
         """html for thumbnails of iiif image, for display in admin"""
-        # if there are no iiif images for this fragment, bail out
         iiif_images = self.iiif_images()
         if iiif_images is None:
-            return ""
+            # if there are no iiif images for this fragment, use placeholder
+            # images for recto/verso side selection
+            recto_img = static("img/ui/all/all/recto-placeholder.svg")
+            verso_img = static("img/ui/all/all/verso-placeholder.svg")
+            return mark_safe(
+                " ".join(
+                    '<img src="%s" loading="lazy" height="200" title="%s" %s>'
+                    % (
+                        [recto_img, verso_img][i],
+                        ["recto", "verso"][i],
+                        'class="selected" /' if i in selected else "/",
+                    )
+                    for i in range(2)
+                )
+            )
 
         images, labels, _ = iiif_images
         return mark_safe(

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -136,9 +136,21 @@ class TestFragment(TestCase):
 
     @patch("geniza.corpus.models.IIIFPresentation")
     def test_iiif_thumbnails(self, mockiifpres):
-        # no iiif
+        # no iiif, should use placeholders
         frag = Fragment(shelfmark="TS 1")
-        assert frag.iiif_thumbnails() == ""
+        placeholder_thumbnails = frag.iiif_thumbnails()
+        assert all(
+            img in placeholder_thumbnails
+            for img in ["recto-placeholder.svg", "verso-placeholder.svg"]
+        )
+        assert all(
+            label in placeholder_thumbnails
+            for label in ['title="recto"', 'title="verso"']
+        )
+        # test with recto side selected: should add class to recto img, but not verso img
+        thumbnails_recto_selected = frag.iiif_thumbnails(selected=[0])
+        assert 'title="recto" class="selected"' in thumbnails_recto_selected
+        assert 'title="verso" class="selected"' not in thumbnails_recto_selected
 
         frag.iiif_url = "http://example.co/iiif/ts-1"
         # return simplified part of the manifest we need for this

--- a/sitemedia/img/ui/all/all/recto-placeholder.svg
+++ b/sitemedia/img/ui/all/all/recto-placeholder.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 155 200" width="155px" height="200px" xmlns="http://www.w3.org/2000/svg">
+    <defs></defs>
+    <rect width="155" height="200" style="fill: rgb(216, 216, 216);"></rect>
+    <text style="white-space: pre; fill: rgb(51, 51, 51); font-family: Arial, sans-serif; font-size: 57.7px;" x="13.365" y="120.004">recto</text>
+</svg>

--- a/sitemedia/img/ui/all/all/verso-placeholder.svg
+++ b/sitemedia/img/ui/all/all/verso-placeholder.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 155 200" width="155px" height="200px" xmlns="http://www.w3.org/2000/svg">
+    <defs></defs>
+    <rect width="155" height="200" style="fill: rgb(216, 216, 216);"></rect>
+    <text style="white-space: pre; fill: rgb(51, 51, 51); font-family: Arial, sans-serif; font-size: 57.7px;" x="6.954"
+        y="120.004">verso</text>
+</svg>


### PR DESCRIPTION
## In this PR

- Per #1023:
  - Use placeholder SVG images when no IIIF image available, to allow editing side info with the same UI