### PR TITLE
Adjust related doclink text for translators

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -73,11 +73,14 @@ Also doesn't currently account for fragments without images.
                                 {% for related in related_documents %}
                                     {% if image_info.image|stringformat:"s" in related.images %}
                                         <li><a class="view-link" href="{% url 'corpus:document' related.document.pgpid %}">
-                                            {# translators: link to view a related document #}
-                                            <span>{% blocktranslate with type=related.document.type shelfmark=related.document.shelfmark|shelfmark_wrap trimmed %}
-                                                View {{ type }}:&nbsp;{{ shelfmark }}
-                                            {% endblocktranslate %}<span>
-                                            </a></li>
+                                            {% translate 'Unknown type' as unknown_type %}
+                                            {% with doctype=related.document.type|default:unknown_type shelfmark=related.document.shelfmark|shelfmark_wrap %}
+                                                {# translators: link to view a related document #}
+                                                {% blocktranslate with related_doc="<span>"|add:doctype|add:": "|add:shelfmark|add:"</span>"|safe trimmed %}
+                                                    View {{ related_doc }}
+                                                {% endblocktranslate %}
+                                            {% endwith %}
+                                        </a></li>
                                     {% endif %}
                                 {% endfor %}
                             </ul>

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-23 11:50-0400\n"
+"POT-Creation-Date: 2022-08-24 10:22-0400\n"
 "PO-Revision-Date: 2022-08-23 15:51\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: ar\n"
@@ -120,30 +121,31 @@ msgstr "لديه مناقشة"
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث بواسطة كلمة مفتاحية."
 
-#: corpus/models.py:757 templates/base.html:21
+#: corpus/models.py:771 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:759
+#: corpus/models.py:773
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "تجميع بواسطة %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:762
+#: corpus/models.py:776
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "التجميع والنسخ بواسطة %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:764
+#: corpus/models.py:778
 msgid "Additional restrictions may apply."
 msgstr "قد تطبق قيود إضافية."
 
 #. Translators: Default label when document does not have a type
-#: corpus/models.py:816
+#: corpus/models.py:830
 #: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:77
 msgid "Unknown type"
 msgstr "نوع غير معروف"
 
@@ -226,10 +228,12 @@ msgstr "تاريخ الإدخال"
 #. Translators: Date document was first added to the PGP
 #: corpus/templates/corpus/document_detail.html:124
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                In PGP since %(date)s\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "                في PGP منذ %(date)s\n"
 "            "
 
@@ -411,10 +415,11 @@ msgstr ""
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:78
-#, python-format
-msgid "View %(type)s:&nbsp;%(shelfmark)s</span>"
-msgstr ""
+#: corpus/templates/corpus/snippets/document_transcription.html:80
+#, fuzzy, python-format
+#| msgid "includes %(relation)s"
+msgid "View %(related_doc)s"
+msgstr "يشمل %(relation)s"
 
 #. Translators: label for a link to a resource with no named location
 #: corpus/templates/corpus/snippets/footnote_location.html:9
@@ -499,14 +504,21 @@ msgid "Discussion"
 msgstr "المناقشة"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "نص بديل للمستخدمين ضعاف البصر\n"
+msgstr ""
+"نص بديل للمستخدمين ضعاف البصر\n"
 "لإيصال الرسالة المقصودة للصورة في هذا السياق بإيجاز."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار الرئيسية من الرسوم. يسمح بفقرات متعددة."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار "
+"الرئيسية من الرسوم. يسمح بفقرات متعددة."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -637,4 +649,3 @@ msgstr "العودة إلى القائمة الرئيسية"
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
-

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-23 11:50-0400\n"
+"POT-Creation-Date: 2022-08-24 10:22-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -120,30 +120,31 @@ msgstr ""
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
-#: corpus/models.py:757 templates/base.html:21
+#: corpus/models.py:771 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:759
+#: corpus/models.py:773
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:762
+#: corpus/models.py:776
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr ""
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:764
+#: corpus/models.py:778
 msgid "Additional restrictions may apply."
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/models.py:816
+#: corpus/models.py:830
 #: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:77
 msgid "Unknown type"
 msgstr ""
 
@@ -378,9 +379,9 @@ msgstr ""
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:78
+#: corpus/templates/corpus/snippets/document_transcription.html:80
 #, python-format
-msgid "View %(type)s:&nbsp;%(shelfmark)s</span>"
+msgid "View %(related_doc)s"
 msgstr ""
 
 #. Translators: label for a link to a resource with no named location

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-23 11:50-0400\n"
+"POT-Creation-Date: 2022-08-24 10:22-0400\n"
 "PO-Revision-Date: 2022-08-23 15:51\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3;\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: he\n"
@@ -120,30 +121,31 @@ msgstr "קיים דיון"
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת מפתח לחיפוש."
 
-#: corpus/models.py:757 templates/base.html:21
+#: corpus/models.py:771 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:759
+#: corpus/models.py:773
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "קובץ על-ידי %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:762
+#: corpus/models.py:776
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "קובץ ותועתק על-ידי %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:764
+#: corpus/models.py:778
 msgid "Additional restrictions may apply."
 msgstr "ייתכנו מגבלות נוספות."
 
 #. Translators: Default label when document does not have a type
-#: corpus/models.py:816
+#: corpus/models.py:830
 #: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:77
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
 
@@ -218,10 +220,12 @@ msgstr "תאריך קלט"
 #. Translators: Date document was first added to the PGP
 #: corpus/templates/corpus/document_detail.html:124
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                In PGP since %(date)s\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "נמצא בPGP מאז %(date)s\n"
 "            "
 
@@ -395,10 +399,11 @@ msgstr ""
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:78
-#, python-format
-msgid "View %(type)s:&nbsp;%(shelfmark)s</span>"
-msgstr ""
+#: corpus/templates/corpus/snippets/document_transcription.html:80
+#, fuzzy, python-format
+#| msgid "includes %(relation)s"
+msgid "View %(related_doc)s"
+msgstr "כולל %(relation)s"
 
 #. Translators: label for a link to a resource with no named location
 #: corpus/templates/corpus/snippets/footnote_location.html:9
@@ -479,13 +484,21 @@ msgid "Discussion"
 msgstr "דיון"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום בהקשר זה."
+msgstr ""
+"טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
+"בהקשר זה."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים "
+"שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -616,4 +629,3 @@ msgstr "חזרה לתפריט הראשי"
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
-

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -669,6 +669,7 @@
                 display: none;
             }
             a.view-link {
+                align-items: center;
                 margin-top: 0;
                 color: var(--link-primary);
                 border-bottom: 3px solid var(--background-light);

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -670,21 +670,28 @@
             }
             a.view-link {
                 margin-top: 0;
+                color: var(--link-primary);
+                border-bottom: 3px solid var(--background-light);
+                @include typography.body;
+                // span inside span = related document title
                 & > span {
+                    @include typography.body-bold;
                     color: var(--link-primary);
-                    border-bottom: 3px solid var(--background-light);
-                    // span inside span = shelfmark
+                    border-bottom: none;
+                    /* space between text and document label */
+                    margin-left: 0.25em;
+                    /* space before shelfmark after type */
                     & > span {
-                        @include typography.body-bold;
+                        margin-left: 0.25em;
                     }
                 }
-                &:hover > span {
+                &:hover {
                     border-bottom-color: var(--icon-button);
                     @include breakpoints.for-tablet-landscape-up {
                         border-bottom-color: var(--icon-button-hover);
                     }
                 }
-                &:active > span {
+                &:active {
                     border-bottom-color: var(--icon-button);
                 }
             }


### PR DESCRIPTION
- revises the related document link on non-document images so translators can work with it (previously it had too many tokens and included tags)
- regenerated the translation files to incorporate the change
- adjusts the related document link to match the designs (both type and shelfmark should be bold)

@blms please review and adjust the styles as needed, something looks a little bit off to me with the font styles or line heights (discrepancy between "view" and the document label)