### PR TITLE
Reindex document on annotation update (#1000)

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -56,6 +56,14 @@ class Annotation(models.Model):
         )
 
     @cached_property
+    def label(self):
+        """convenience method to get annotation label"""
+        try:
+            return self.content.get("body", [])[0].get("label", "")
+        except IndexError:
+            pass
+
+    @cached_property
     def body_content(self):
         """convenience method to get annotation body content"""
         try:

--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -102,7 +102,7 @@ class TestAnnotationDetail:
         # update annotation with POST request as admin
         response = admin_client.post(
             annotation.get_absolute_url(),
-            json.dumps({**annotation.content, "body": "new text"}),
+            json.dumps({**annotation.content, "body": [{"value": "new text"}]}),
             content_type="application/json",
         )
         assert response.status_code == 200
@@ -111,7 +111,7 @@ class TestAnnotationDetail:
         # get a fresh copy of the annotation from the database
         updated_anno = Annotation.objects.get(pk=annotation.pk)
         # should match new content
-        assert updated_anno.content["body"] == "new text"
+        assert updated_anno.content["body"] == [{"value": "new text"}]
         # updated content should be returned in the response
         assert response.json() == updated_anno.compile()
 

--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -1,9 +1,11 @@
 import json
 import uuid
+from unittest.mock import patch
 
 import pytest
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.urls import reverse
+from parasolr.django.indexing import ModelIndexable
 from pytest_django.asserts import assertContains, assertNotContains
 
 from geniza.annotations.models import Annotation
@@ -98,7 +100,10 @@ class TestAnnotationDetail:
         )
         assert response.status_code == 403
 
-    def test_post_annotation_detail_admin(self, admin_client, annotation):
+    @patch.object(ModelIndexable, "index_items")
+    def test_post_annotation_detail_admin(
+        self, mock_indexitems, admin_client, annotation
+    ):
         # update annotation with POST request as admin
         response = admin_client.post(
             annotation.get_absolute_url(),

--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -27,6 +27,7 @@
     <!-- document details -->
     <h1 class="sr-only">{{ page_title }}</h1>
     {% include "corpus/snippets/document_header.html" %}
+    <h3>{{ source_detail }}</h3>
     <a class="editor-navigation" href="{% url "corpus:document" document.pk %}">
         <span>
             Return to document detail page

--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -27,7 +27,7 @@
     <!-- document details -->
     <h1 class="sr-only">{{ page_title }}</h1>
     {% include "corpus/snippets/document_header.html" %}
-    <h3>{{ source_detail }}</h3>
+    <span>{{ source_detail }}</span>
     <a class="editor-navigation" href="{% url "corpus:document" document.pk %}">
         <span>
             Return to document detail page

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -746,6 +746,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "csrf_token": csrf_token(self.request),
                 },
                 "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
+                # TODO: Add Footnote notes to the following display, if present
                 "source_detail": mark_safe(source.formatted_display())
                 if source
                 else "",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -746,7 +746,11 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "csrf_token": csrf_token(self.request),
                 },
                 "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
-                "source_detail": f"{source} {source.notes}." if source else "",
+                "source_detail": mark_safe(
+                    f"{source.formatted_display()} {source.notes}."
+                )
+                if source
+                else "",
                 "source_label": source.all_authors() if source else "",
                 "page_type": "document annotating",
             }

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -746,9 +746,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "csrf_token": csrf_token(self.request),
                 },
                 "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
-                "source_detail": mark_safe(
-                    f"{source.formatted_display()} {source.notes}."
-                )
+                "source_detail": mark_safe(source.formatted_display())
                 if source
                 else "",
                 "source_label": source.all_authors() if source else "",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -746,7 +746,9 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "csrf_token": csrf_token(self.request),
                 },
                 "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
+                "source_detail": f"{source} {source.notes}." if source else "",
                 "source_label": source.all_authors() if source else "",
+                "page_type": "document annotating",
             }
         )
         return context_data

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -513,6 +513,8 @@ class Footnote(TrackChangesModel):
             # handle multiple annotations on the same canvas
             html_content = defaultdict(list)
             for a in annos:
+                if a.label:
+                    html_content[a.target_source_id].append(f"<h1>{a.label}</h1>")
                 html_content[a.target_source_id].append(a.body_content)
             # cast to a regular dict to avoid weirdness in django templates
             return dict(html_content)

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -269,7 +269,10 @@ class TestFootnote:
         source = Source.from_uri(source_uri)
         document = Document.from_manifest_uri(manifest_uri)
         Annotation.objects.create(
-            content={**annotation.content, "body": [{"value": "Second annotation!"}]}
+            content={
+                **annotation.content,
+                "body": [{"label": "A label", "value": "Second annotation!"}],
+            }
         )
         digital_edition = document.footnotes.create(
             source=source, doc_relation=[Footnote.DIGITAL_EDITION]
@@ -279,6 +282,7 @@ class TestFootnote:
         # annotations are on the same canvas
         assert digital_edition.content_html[canvas_uri] == [
             "Test annotation",
+            "<h1>A label</h1>",
             "Second annotation!",
         ]
 

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -37,7 +37,7 @@ main.addsource {
 main.annotating {
     span#formatted-title {
         margin-bottom: 1rem;
-        & + h3 {
+        & + span {
             margin-bottom: 2rem;
         }
     }

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -34,6 +34,15 @@ main.addsource {
     }
 }
 
+main.annotating {
+    span#formatted-title {
+        margin-bottom: 1rem;
+        & + h3 {
+            margin-bottom: 2rem;
+        }
+    }
+}
+
 span.select2-container li[class^="select2"],
 span.select2-container span[class^="select2"],
 main.addsource .select2-container--default .select2-selection--single,


### PR DESCRIPTION
## In this PR

- Per #1000:
  - Ensure document is reindexed when annotation content changes
- Per Slack:
  - Cite full scholarship record in header of transcribe page

## Questions

-  The test in `test_annotations_views` was failing because it tries to index the document, and the unexpected value for `body` (a string) was causing an error in the `content_html` method, which is called during indexing. Is this the right way to handle that, or are there possible other kinds of `body` in the real world we should handle? (Or should we just be mocking indexing altogether during this test?)