### PR TITLE
Revise ordered list style to use actual line numbers (#1038)

### DIFF
--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -15,14 +15,6 @@ div.annotate {
         color: black;
         min-height: 3em;
     }
-    // ol {
-    //     counter-reset: section;
-    // }
-    // li::before {
-    //     /* use pseudo marker to avoid periods for line numbers */
-    //     counter-increment: section;
-    //     content: counter(section);
-    // }
 }
 
 main.addsource {

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -15,14 +15,14 @@ div.annotate {
         color: black;
         min-height: 3em;
     }
-    ol {
-        counter-reset: section;
-    }
-    li::before {
-        /* use pseudo marker to avoid periods for line numbers */
-        counter-increment: section;
-        content: counter(section);
-    }
+    // ol {
+    //     counter-reset: section;
+    // }
+    // li::before {
+    //     /* use pseudo marker to avoid periods for line numbers */
+    //     counter-increment: section;
+    //     content: counter(section);
+    // }
 }
 
 main.addsource {

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -918,22 +918,19 @@ a.editor-navigation {
 
     li {
         white-space: pre-line;
-        margin-right: 2em; /* shift to make space for line numbers */
+        margin-right: 1em;
+        padding-right: 1em; /* shift to make space for line numbers */
         direction: rtl;
     }
 
-    /* some transcription styles adapted from local admin site css */
-    li::before {
-        /* use pseudo marker to avoid periods for line numbers */
-        content: attr(value);
-        margin-right: -2em; /* shift outside text margin */
-        text-align: right;
-        float: right;
-        font-weight: bold;
+    ol {
+        list-style: decimal;
     }
 
     li::marker {
-        direction: rtl;
+        text-align: right;
+        float: right;
+        font-weight: bold;
     }
 }
 


### PR DESCRIPTION
## In this PR

- Per #1038:
  - Remove counter from `<ol>` lists in transcription content, and use the decimal list style, so that line numbers respect the HTML start attribute
  - Adjust margin/padding to adjust for line number marker pseudo-elements