### PR TITLE
Transcription line number margin for 2 digits (#1038)

### DIFF
--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -918,7 +918,7 @@ a.editor-navigation {
 
     li {
         white-space: pre-line;
-        margin-right: 1em;
+        margin-right: 1.5em;
         padding-right: 1em; /* shift to make space for line numbers */
         direction: rtl;
     }


### PR DESCRIPTION
## In this PR

- Per #1038:
  - Increase margin on line number markers to allow space for 2 digits