### PR TITLE
Count digital editions as editions when indexing

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -876,6 +876,12 @@ class Document(ModelIndexable, DocumentDateMixin):
                 fn.doc_relation
             )
 
+        # make sure digital editions are also counted as editions,
+        # whether or not there is a separate edition footnote
+        for source, doc_relations in source_relations.items():
+            if Footnote.DIGITAL_EDITION in doc_relations:
+                source_relations[source].add(Footnote.EDITION)
+
         # flatten sets of relations by source into a list of relations
         for relation in list(chain(*source_relations.values())):
             # add one for each relation in the flattened list

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -833,7 +833,7 @@ class TestDocument:
             doc_relation=Footnote.TRANSLATION,
         )
         index_data = document.index_data()
-        assert index_data["num_editions_i"] == 1
+        assert index_data["num_editions_i"] == 2  # edition + digital edition
         assert index_data["has_digital_edition_b"] == True
         assert index_data["num_translations_i"] == 2
         assert index_data["scholarship_count_i"] == 3  # unique sources


### PR DESCRIPTION
Rachel flagged this in testing, IDK if we have an issue anywhere that would make sense to test it  — in some cases after the migration we only have a digital edition footnote and no editions, and in the search results those records display as having no transcriptions, which is obviously false. This is a simple fix to make sure we count digital editions when tallying up editions.