### PR TITLE
Bump tahqiq commit hash, style drop zone (#1021, #1022)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -42,7 +42,8 @@
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@tinymce/tinymce-webcomponent": "^2.0.0"
+        "@tinymce/tinymce-webcomponent": "^2.0.0",
+        "@ungap/custom-elements": "^1.1.0"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.2",
@@ -2600,6 +2601,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@ungap/custom-elements": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
+      "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -2881,11 +2887,12 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#7965e14d63623bd3acb8578880b9a410be51df0b",
-      "integrity": "sha512-c/yPcYoTmCuFz9BXgz3UTksI2gLsF3xjAxNrVKyqYoBsAkapyEEyAIltL52ve0Sdrs0bCsa2yXX3/Rbsnq3gaw==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
+      "integrity": "sha512-MMgZCVm0KUBk2eNhZ8TDdTbNC6//7uyueJJUc+MX/0ylIP3LIvAsgSyJ/P6eVGxaJY7oyXf7aGuEhEzyjahbVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tinymce/tinymce-webcomponent": "^2.0.0"
+        "@tinymce/tinymce-webcomponent": "^2.0.0",
+        "@ungap/custom-elements": "^1.1.0"
       }
     },
     "node_modules/ansi-html-community": {
@@ -10667,6 +10674,11 @@
         "@types/node": "*"
       }
     },
+    "@ungap/custom-elements": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
+      "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -10937,11 +10949,12 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#7965e14d63623bd3acb8578880b9a410be51df0b",
-      "integrity": "sha512-c/yPcYoTmCuFz9BXgz3UTksI2gLsF3xjAxNrVKyqYoBsAkapyEEyAIltL52ve0Sdrs0bCsa2yXX3/Rbsnq3gaw==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
+      "integrity": "sha512-MMgZCVm0KUBk2eNhZ8TDdTbNC6//7uyueJJUc+MX/0ylIP3LIvAsgSyJ/P6eVGxaJY7oyXf7aGuEhEzyjahbVQ==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
       "requires": {
-        "@tinymce/tinymce-webcomponent": "^2.0.0"
+        "@tinymce/tinymce-webcomponent": "^2.0.0",
+        "@ungap/custom-elements": "^1.1.0"
       }
     },
     "ansi-html-community": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@recogito/annotorious": "^2.7.2",
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#7965e14d63623bd3acb8578880b9a410be51df0b",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
     "angle-input": "^0.0.1",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -4,11 +4,19 @@
 @use "../base/typography";
 
 div.annotate {
+    display: flex;
+    flex-flow: column;
+    height: 100%;
     .instructions {
         font-style: italic;
         font-size: typography.$text-size-md;
+        // override transcription paragraph spacing for instruction
+        margin-right: 0;
+        padding-right: 0;
     }
-
+    .tahqiq-drop-zone {
+        flex: 1 1 100%;
+    }
     div[contenteditable="true"],
     h3[contenteditable="true"] {
         background-color: white;


### PR DESCRIPTION
## In this PR

- Per #1021:
  - Bumps tahqiq to version including annotation reordering
- Per #1022:
  - Bumps tahqiq to version including moving annotations between canvases
  - Styles drop zone for canvases without annotations

See also https://github.com/Princeton-CDH/annotorious-tahqiq/pull/13