### PR TITLE
Pass Tiny API key to tahqiq, remove Tiny CDN JS from header

### DIFF
--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -20,7 +20,6 @@
 {% endblock extrastyle %}
 {% block extrascript %}
     {% render_bundle_csp "annotation" "js" attrs='defer' %}
-    <script src="https://cdn.tiny.cloud/1/{{ tiny_api_key }}/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
 {% endblock extrascript %}
 
 {% block main %}

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -759,8 +759,8 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                         settings, "ANNOTATION_MANIFEST_BASE_URL", ""
                     ),
                     "csrf_token": csrf_token(self.request),
+                    "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
                 },
-                "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
                 # TODO: Add Footnote notes to the following display, if present
                 "source_detail": mark_safe(source.formatted_display())
                 if source

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2887,8 +2887,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
-      "integrity": "sha512-MMgZCVm0KUBk2eNhZ8TDdTbNC6//7uyueJJUc+MX/0ylIP3LIvAsgSyJ/P6eVGxaJY7oyXf7aGuEhEzyjahbVQ==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
+      "integrity": "sha512-L4Tb9181/A0BwaqEEKF8ahAJNVtBvczciJADRS6iQq9vJog1esf35YND9SAmXTpVLICgBvKVKVH/oLsYDbMqgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
@@ -10949,9 +10949,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
-      "integrity": "sha512-MMgZCVm0KUBk2eNhZ8TDdTbNC6//7uyueJJUc+MX/0ylIP3LIvAsgSyJ/P6eVGxaJY7oyXf7aGuEhEzyjahbVQ==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
+      "integrity": "sha512-L4Tb9181/A0BwaqEEKF8ahAJNVtBvczciJADRS6iQq9vJog1esf35YND9SAmXTpVLICgBvKVKVH/oLsYDbMqgg==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#27599959d39e1ab1d03b5a84782a11406569b75b",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2887,8 +2887,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
-      "integrity": "sha512-L4Tb9181/A0BwaqEEKF8ahAJNVtBvczciJADRS6iQq9vJog1esf35YND9SAmXTpVLICgBvKVKVH/oLsYDbMqgg==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#27599959d39e1ab1d03b5a84782a11406569b75b",
+      "integrity": "sha512-I+qqqEV1ou8Qt+yi3eJ9o68mYVzwBKYHlFCxNEEtCgghZJBrZsl8dyX1G6LJjm31mZzJzn6FxekyUMSIcNUQ/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
@@ -10949,9 +10949,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
-      "integrity": "sha512-L4Tb9181/A0BwaqEEKF8ahAJNVtBvczciJADRS6iQq9vJog1esf35YND9SAmXTpVLICgBvKVKVH/oLsYDbMqgg==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#27599959d39e1ab1d03b5a84782a11406569b75b",
+      "integrity": "sha512-I+qqqEV1ou8Qt+yi3eJ9o68mYVzwBKYHlFCxNEEtCgghZJBrZsl8dyX1G6LJjm31mZzJzn6FxekyUMSIcNUQ/g==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#27599959d39e1ab1d03b5a84782a11406569b75b",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
     "angle-input": "^0.0.1",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#27599959d39e1ab1d03b5a84782a11406569b75b",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@recogito/annotorious": "^2.7.2",
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c7b5fdefada2d599e2d0a2d154989c8e3a8908b1",
     "angle-input": "^0.0.1",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#0c7f8559c9b8be2a9d6a38dcf5992eef36de47fa",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -82,7 +82,12 @@ export default class extends Controller {
             annotationServerConfig
         );
         // Initialize the TranscriptionEditor plugin
-        new TranscriptionEditor(anno, storagePlugin, annotationContainer);
+        new TranscriptionEditor(
+            anno,
+            storagePlugin,
+            annotationContainer,
+            config.tiny_api_key
+        );
         return viewer;
     }
 }


### PR DESCRIPTION
## In this PR

- Per #1065:
  - Pass the Tiny API key along to tahqiq, instantiate Tiny via the web component rather than a direct call to the CDN JS
  - Bump tahqiq commit hash