### PR TITLE
Add line numbers to transcription lines in indexed html (#1049)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -912,7 +912,9 @@ class Document(ModelIndexable, DocumentDateMixin):
             # if this is an edition/transcription, try to get plain text for indexing
             if Footnote.DIGITAL_EDITION in fn.doc_relation:
                 if fn.content_html_str:
-                    transcription_texts.append(fn.content_html_str)
+                    transcription_texts.append(
+                        Footnote.explicit_line_numbers(fn.content_html_str)
+                    )
             # add any doc relations to this footnote's source's set in source_relations
             source_relations[fn.source] = source_relations[fn.source].union(
                 fn.doc_relation

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from functools import cached_property
-from html.parser import HTMLParser
 from os import path
 from urllib.parse import urljoin
 

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -560,17 +560,18 @@ class Footnote(TrackChangesModel):
     @cached_property
     def content_html_str(self):
         "content as a single string of html, if available"
-        # content html is a dict; values are lists of html content
-        html = "\n".join(
-            [
-                section
-                for canvas_annos in self.content_html.values()
-                for section in canvas_annos
-            ]
-        )
         # parse to add line numbers
         parser = HTMLLineNumberParser()
-        parser.feed(html)
+        parser.feed(
+            "\n".join(
+                [
+                    section
+                    # content html is a dict; values are lists of html content
+                    for canvas_annos in self.content_html.values()
+                    for section in canvas_annos
+                ]
+            )
+        )
         return parser.html_str
 
     @property

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -21,6 +21,7 @@ from multiselectfield import MultiSelectField
 from geniza.annotations.models import Annotation
 from geniza.common.fields import NaturalSortField
 from geniza.common.models import TrackChangesModel
+from geniza.footnotes.utils import HTMLLineNumberParser
 
 
 class SourceType(models.Model):
@@ -411,43 +412,6 @@ class FootnoteQuerySet(models.QuerySet):
         return self.filter(doc_relation__contains=Footnote.EDITION)
 
 
-class HTMLLineNumberParser(HTMLParser):
-    """HTML parser to add numbering to line elements for search indexing purposes"""
-
-    def __init__(self, *args, **kwargs):
-        """Initialize empty string and line numbering at 1"""
-        self.html_str = ""
-        self.line_number = 1
-        super().__init__(*args, **kwargs)
-
-    def handle_starttag(self, tag, attrs):
-        """Restart line numbering on <ol>, include line number with <li>, and construct
-        start tags with included attributes"""
-        if tag == "ol":
-            # restart line numbering on encountering ol
-            self.line_number = 1
-            for (attr, val) in attrs:
-                # if start present in attrs, restart to start number
-                if attr == "start":
-                    self.line_number = int(val)
-        elif tag == "li":
-            # append the line number as a data attribute
-            attrs += [("value", str(self.line_number))]
-            # increment line number
-            self.line_number += 1
-        # construct attribute definitions and final start tag string
-        attr_strings = [' %s="%s"' % (attr, val) for (attr, val) in attrs]
-        self.html_str += "<%s%s>" % (tag, "".join(attr_strings))
-
-    def handle_endtag(self, tag):
-        """Close all encountered HTML endtags"""
-        self.html_str += "</%s>" % (tag,)
-
-    def handle_data(self, data):
-        """Append any text nodes as-is"""
-        self.html_str += data
-
-
 class Footnote(TrackChangesModel):
     """a footnote that links a :class:`~geniza.corpus.models.Document` to a :class:`Source`"""
 
@@ -560,18 +524,20 @@ class Footnote(TrackChangesModel):
     @cached_property
     def content_html_str(self):
         "content as a single string of html, if available"
-        # parse to add line numbers
-        parser = HTMLLineNumberParser()
-        parser.feed(
-            "\n".join(
-                [
-                    section
-                    # content html is a dict; values are lists of html content
-                    for canvas_annos in self.content_html.values()
-                    for section in canvas_annos
-                ]
-            )
+        # content html is a dict; values are lists of html content
+        return "\n".join(
+            [
+                section
+                for canvas_annos in self.content_html.values()
+                for section in canvas_annos
+            ]
         )
+
+    @staticmethod
+    def explicit_line_numbers(html):
+        """add explicit line numbers to passed HTML (in value attributes of ol > li)"""
+        parser = HTMLLineNumberParser()
+        parser.feed(html)
         return parser.html_str
 
     @property

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -299,6 +299,39 @@ class TestFootnote:
         del digital_edition.content_html
         assert digital_edition.content_html == {}
 
+    def test_content_html_str(self, document, source, twoauthor_source):
+        # should parse html to include line numbers in li "value" attribute
+        Annotation.objects.create(
+            content={
+                "dc:source": source.uri,
+                "target": {"source": {"partOf": {"id": document.manifest_uri}}},
+                "body": [{"value": "<ol><li>one</li><li>two</li></ol><p>test</p>"}],
+            }
+        )
+        digital_edition = document.footnotes.create(
+            source=source, doc_relation=[Footnote.DIGITAL_EDITION]
+        )
+        assert (
+            digital_edition.content_html_str
+            == '<ol><li value="1">one</li><li value="2">two</li></ol><p>test</p>'
+        )
+
+        # should respect ol "start" attribute in li "value" attributes
+        Annotation.objects.create(
+            content={
+                "dc:source": twoauthor_source.uri,
+                "target": {"source": {"partOf": {"id": document.manifest_uri}}},
+                "body": [{"value": '<ol start="5"><li>one</li><li>two</li></ol>'}],
+            }
+        )
+        digital_edition = document.footnotes.create(
+            source=twoauthor_source, doc_relation=[Footnote.DIGITAL_EDITION]
+        )
+        assert (
+            digital_edition.content_html_str
+            == '<ol start="5"><li value="5">one</li><li value="6">two</li></ol>'
+        )
+
 
 class TestFootnoteQuerySet:
     @pytest.mark.django_db

--- a/geniza/footnotes/utils.py
+++ b/geniza/footnotes/utils.py
@@ -1,0 +1,42 @@
+from html.parser import HTMLParser
+
+
+class HTMLLineNumberParser(HTMLParser):
+    """HTML parser to add numbering to line elements for search indexing purposes"""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize empty string and line numbering at 1"""
+        self.html_str = ""
+        self.line_number = 1
+        self.within_ol = False
+        super().__init__(*args, **kwargs)
+
+    def handle_starttag(self, tag, attrs):
+        """Restart line numbering on <ol>, include line number with <li>, and construct
+        start tags with included attributes"""
+        if tag == "ol":
+            # restart line numbering, ol state indicator on encountering ol
+            self.within_ol = True
+            self.line_number = 1
+            for (attr, val) in attrs:
+                # if start present in attrs, restart to start number
+                if attr == "start":
+                    self.line_number = int(val)
+        elif tag == "li" and self.within_ol:
+            # append the line number as a data attribute
+            attrs += [("value", str(self.line_number))]
+            # increment line number
+            self.line_number += 1
+        # construct attribute definitions and final start tag string
+        attr_strings = [' %s="%s"' % (attr, val) for (attr, val) in attrs]
+        self.html_str += "<%s%s>" % (tag, "".join(attr_strings))
+
+    def handle_endtag(self, tag):
+        """Close all encountered HTML endtags"""
+        if tag == "ol":
+            self.within_ol = False
+        self.html_str += "</%s>" % (tag,)
+
+    def handle_data(self, data):
+        """Append any text nodes as-is"""
+        self.html_str += data

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -126,17 +126,14 @@ a#needsreview:target {
     font-size: 115%;
 }
 
-.transcription li {
-    list-style: none; /* suppress default line numbers */
-}
-
-.transcription li::before {
-    /* use pseudo marker to avoid periods for line numbers */
-    content: attr(value);
-    margin-left: 1em;
-    text-align: right;
-    float: right;
-    font-weight: bold;
+/* adjust spacing of decimal cover */
+#itt-panel
+    .panel-container
+    div.transcription-panel
+    .transcription
+    ol
+    li::before {
+    right: 163px;
 }
 
 .transcription li::marker {

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -227,6 +227,19 @@ section#document-list {
         }
     }
 
+    /* use pseudo marker to get transcription line numbers from snippets */
+    .transcription li {
+        direction: rtl;
+        list-style-type: none; /* hide automatic ol numbering */
+        &::before {
+            content: attr(value);
+            margin-right: -0.5rem; /* shift outside text margin */
+            text-align: right;
+            float: right;
+            font-weight: bold;
+        }
+    }
+
     /* raise tags & text over clickable pseudo content to allow selection */
     .description,
     .transcription,


### PR DESCRIPTION
## In this PR

- Per #1049:
  - Use an `HTMLParser` subclass to parse transcription html and add line number `value` attributes
  - Restore CSS to show those attributes as line numbers in search results
  - Fix admin CSS issue with line number suppression