### PR TITLE
Transparent placeholders (#1039)

### DIFF
--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -41,6 +41,10 @@ main.annotating {
             margin-bottom: 2rem;
         }
     }
+    #itt-panel .img.placeholder .deep-zoom-container {
+        background-color: var(--background-gray);
+        opacity: 1;
+    }
 }
 
 span.select2-container li[class^="select2"],

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -3,6 +3,7 @@
 @use "../base/spacing";
 @use "../base/typography";
 
+// tahqiq annotation container
 div.annotate {
     display: flex;
     flex-flow: column;
@@ -25,6 +26,7 @@ div.annotate {
     }
 }
 
+// "add new transcription" --> scholarship record choice page
 main.addsource {
     h2 {
         margin-top: 1rem;
@@ -34,6 +36,7 @@ main.addsource {
     }
 }
 
+// annotation editor
 main.annotating {
     span#formatted-title {
         margin-bottom: 1rem;
@@ -41,12 +44,14 @@ main.annotating {
             margin-bottom: 2rem;
         }
     }
+    // style placeholder images with gray background in editor
     #itt-panel .img.placeholder .deep-zoom-container {
         background-color: var(--background-gray);
         opacity: 1;
     }
 }
 
+// dropdown for scholarship record choice
 span.select2-container li[class^="select2"],
 span.select2-container span[class^="select2"],
 main.addsource .select2-container--default .select2-selection--single,

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -425,6 +425,7 @@
             .img-header {
                 display: none;
             }
+            // placeholders are completely transparent in viewer
             .deep-zoom-container {
                 opacity: 0;
             }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -426,7 +426,7 @@
                 display: none;
             }
             .deep-zoom-container {
-                background-color: var(--background-gray);
+                opacity: 0;
             }
         }
         @include breakpoints.for-tablet-landscape-up {


### PR DESCRIPTION
## In this PR

- Per #1039:
  - Make missing image placeholders transparent outside of transcription editor
- Clean up css comments for transcription editor