### PR TITLE
Fix duplicate menu IDs (#1088)

### DIFF
--- a/geniza/templates/snippets/sub_menu.html
+++ b/geniza/templates/snippets/sub_menu.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailcore_tags %}
 
-<ul class="sub-menu" id="{{ top_level_page.slug }}-menu" role="menu" aria-label="{{ top_level_page.localized.slug }}">
+<ul class="sub-menu" id="{% if in_header != "true" %}footer-{% endif %}{{ top_level_page.slug }}-menu" role="menu" aria-label="{{ top_level_page.localized.slug }}">
     {% if in_header == "true" %}
         <li class="menu-button" role="none">
             <a id="back-to-main-menu" href="#menu" role="button" data-turbo="false">


### PR DESCRIPTION
## In this PR

- Per #1088:
  - Add prefix "footer-" to all menu IDs in footer

I checked all reused template snippets and that's the only way it would have resulted in a duplicated ID, as far as I can tell.