### PR TITLE
Move nav outside, and theme toggle inside, header (#1090)

### DIFF
--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -81,9 +81,9 @@
                 <div class="controls">
                     {% include "snippets/language_switcher.html" %}
                 </div>
-                {% include "nav.html" %}
+                {% include "snippets/theme_toggle.html" %}
             </header>
-            {% include "snippets/theme_toggle.html" %}
+            {% include "nav.html" %}
 
             <turbo-frame id="main" data-turbo-action="advance">
                 <main id="main-content"  class="{{ page_type }}{% block page_type %}{% endblock page_type %}">{% block main %}{% endblock main %}</main>

--- a/sitemedia/scss/components/_controls.scss
+++ b/sitemedia/scss/components/_controls.scss
@@ -39,7 +39,7 @@ div.controls {
 // light/dark mode toggle
 label#theme-toggle {
     position: absolute;
-    z-index: 5;
+    z-index: 7;
     display: block;
     cursor: pointer;
     top: spacing.$spacing-md;

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -7,10 +7,7 @@
 @use "../base/spacing";
 @use "../base/typography";
 
-header {
-    z-index: 5;
-}
-#site-nav {
+nav#site-nav {
     display: flex;
     flex-flow: row wrap;
     z-index: 6;


### PR DESCRIPTION
## In this PR

- Per #1090:
  - Move light/dark toggle into `header` landmark so that there is no page content outside landmarks
  - Following [these recommendations](https://dequeuniversity.com/rules/axe/4.1/region), separate `nav` and `header` into adjacent landmarks

I also tested z-index to make sure all still works as expected with the nav, light/dark toggle, and language switcher.