### PR TITLE
Implement new Hebrew type styles (#1106)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -36,7 +36,8 @@
                 </dl>
 
                 {# description #}
-                <p class="description">
+                {# TODO: Adjust lang attribute logic for non-English descriptions #}
+                <p class="description" lang="en">
                     {# display keywords in context if any #}
                     {% with document_highlights=highlighting|dict_item:document.id %}
                         {% if document_highlights.description %}

--- a/sitemedia/scss/base/_global.scss
+++ b/sitemedia/scss/base/_global.scss
@@ -54,6 +54,9 @@ body {
     flex-direction: column;
     min-height: 100vh;
 }
+html[lang="he"] body {
+    @include typography.body-he;
+}
 
 // Center-align sections of main content using flexbox.
 main {
@@ -67,13 +70,22 @@ main {
 h1 {
     @include typography.headline-1;
 }
+html[lang="he"] h1 {
+    @include typography.headline-1-he;
+}
 
 h2 {
     @include typography.headline-2;
 }
+html[lang="he"] h2 {
+    @include typography.headline-2-he;
+}
 
 h3 {
     @include typography.headline-3;
+}
+html[lang="he"] h3 {
+    @include typography.headline-3-he;
 }
 
 // Any links without a class (i.e. in body text) get the default link style;

--- a/sitemedia/scss/base/_global.scss
+++ b/sitemedia/scss/base/_global.scss
@@ -56,6 +56,10 @@ body {
 }
 html[lang="he"] body {
     @include typography.body-he;
+    *[lang="en"] {
+        // override for English-language content
+        @include typography.body;
+    }
 }
 
 // Center-align sections of main content using flexbox.
@@ -66,25 +70,26 @@ main {
     flex: 1 0 auto;
 }
 
-// Apply basic typographic styles defined in the typography module
+// Apply basic typographic styles defined in the typography module,
+// including Hebrew variants (with exceptions for English content in Hebrew site)
 h1 {
     @include typography.headline-1;
 }
-html[lang="he"] h1 {
+html[lang="he"] h1:not([lang="en"]) {
     @include typography.headline-1-he;
 }
 
 h2 {
     @include typography.headline-2;
 }
-html[lang="he"] h2 {
+html[lang="he"] h2:not([lang="en"]) {
     @include typography.headline-2-he;
 }
 
 h3 {
     @include typography.headline-3;
 }
-html[lang="he"] h3 {
+html[lang="he"] h3:not([lang="en"]) {
     @include typography.headline-3-he;
 }
 

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -28,7 +28,14 @@ $text-size-5xl: 2rem; //     = 32px
     line-height: 1.5;
     @include breakpoints.for-tablet-landscape-up {
         font-size: $text-size-4xl;
-        line-height: 1.4285;
+        line-height: calc(40 / 28);
+    }
+}
+// H1 — page titles (Hebrew variant)
+@mixin headline-1-he {
+    line-height: calc(34 / 24);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(40 / 28);
     }
 }
 
@@ -42,6 +49,13 @@ $text-size-5xl: 2rem; //     = 32px
     }
     line-height: 1.5;
 }
+// H2 — section and search result titles (Hebrew variant)
+@mixin headline-2-he {
+    line-height: calc(27 / 20);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(34 / 24);
+    }
+}
 
 // H3 — sub-sections only on generic content pages
 @mixin headline-3 {
@@ -52,6 +66,13 @@ $text-size-5xl: 2rem; //     = 32px
         font-size: $text-size-xl;
     }
     line-height: 1.5;
+}
+// H3 — sub-sections only on generic content pages (Hebrew variant)
+@mixin headline-3-he {
+    line-height: calc(22 / 16);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(27 / 20);
+    }
 }
 
 // H1 - error pages
@@ -64,6 +85,13 @@ $text-size-5xl: 2rem; //     = 32px
     }
     line-height: 1.5;
 }
+// H1 - error pages (Hebrew variant)
+@mixin headline-error-he {
+    line-height: calc(25 / 18);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(27 / 20);
+    }
+}
 
 // body text — descriptions on search + doc detail,
 // citation on scholarship records, all body content
@@ -75,6 +103,13 @@ $text-size-5xl: 2rem; //     = 32px
         font-size: $text-size-xl;
     }
     line-height: 1.5;
+}
+// body text (Hebrew variant)
+@mixin body-he {
+    line-height: calc(25 / 18);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(27 / 20);
+    }
 }
 @mixin body-bold {
     @include body;
@@ -143,6 +178,13 @@ $text-size-5xl: 2rem; //     = 32px
     }
     line-height: 1.5;
 }
+// metadata (Hebrew variant)
+@mixin meta-he {
+    line-height: calc(22 / 16);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(25 / 18);
+    }
+}
 @mixin meta-bold {
     @include meta;
     font-family: fonts.$primary-bold;
@@ -203,15 +245,19 @@ $text-size-5xl: 2rem; //     = 32px
 // doc detail
 @mixin transcription {
     font-family: fonts.$primary;
-    font-size: $text-size-lg;
+    font-size: $text-size-xl;
     @include breakpoints.for-tablet-landscape-up {
-        font-size: $text-size-xl;
+        font-size: $text-size-2xl;
     }
-    line-height: 1.4;
 }
 // TODO: Use classes to only use this on hebrew transcriptions
+// (currently used on all transcriptions)
 @mixin hebrew {
     font-family: fonts.$hebrew;
+    line-height: calc(27 / 20);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(32 / 22);
+    }
 }
 
 // most form elements
@@ -261,6 +307,15 @@ $text-size-5xl: 2rem; //     = 32px
         font-size: $text-size-lg;
     }
 }
+// Mobile nav menu (Hebrew variant)
+@mixin mobile-menu-he {
+    font-size: $text-size-3xl;
+    line-height: calc(32 / 24);
+    @include breakpoints.for-tablet-landscape-up {
+        font-size: $text-size-lg;
+        line-height: calc(27 / 20);
+    }
+}
 
 // Icon buttons
 @mixin icon-button {
@@ -294,7 +349,7 @@ $text-size-5xl: 2rem; //     = 32px
     line-height: 1.5;
     @include breakpoints.for-tablet-landscape-up {
         font-size: $text-size-lg;
-        line-height: 1.388;
+        line-height: calc(25 / 18);
     }
 }
 @mixin permissions-statement-bold {

--- a/sitemedia/scss/components/_docheader.scss
+++ b/sitemedia/scss/components/_docheader.scss
@@ -24,6 +24,10 @@ span#formatted-title {
         margin: spacing.$spacing-3xl spacing.$spacing-md spacing.$spacing-2xl;
     }
 }
+// Hebrew variant
+html[lang="he"] span#formatted-title {
+    @include typography.headline-1-he;
+}
 
 // Edit link for admins
 .edit-link-container {

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -439,6 +439,6 @@ html[dir="rtl"].dark-mode footer {
 }
 
 // Hebrew variant
-html[lange="he"] footer {
+html[lang="he"] footer {
     @include typography.meta-he;
 }

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -437,3 +437,8 @@ html[dir="rtl"].light-mode footer {
 html[dir="rtl"].dark-mode footer {
     @include dark-footer-rtl;
 }
+
+// Hebrew variant
+html[lange="he"] footer {
+    @include typography.meta-he;
+}

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -441,4 +441,8 @@ html[dir="rtl"].dark-mode footer {
 // Hebrew variant
 html[lang="he"] footer {
     @include typography.meta-he;
+    *[lang="en"] {
+        // handle any nav links in English
+        @include typography.meta;
+    }
 }

--- a/sitemedia/scss/components/_footnote.scss
+++ b/sitemedia/scss/components/_footnote.scss
@@ -54,3 +54,11 @@
         color: var(--on-background-alt);
     }
 }
+
+// Hebrew variant
+html[lang="he"] .citation {
+    @include typography.body-he;
+    dd.relation {
+        @include typography.meta-he;
+    }
+}

--- a/sitemedia/scss/components/_footnote.scss
+++ b/sitemedia/scss/components/_footnote.scss
@@ -58,7 +58,10 @@
 // Hebrew variant
 html[lang="he"] .citation {
     @include typography.body-he;
-    dd.relation {
+    *[lang="en"] {
+        @include typography.body;
+    }
+    dd.relation:not([lang="en"]) {
         @include typography.meta-he;
     }
 }

--- a/sitemedia/scss/components/_iiif.scss
+++ b/sitemedia/scss/components/_iiif.scss
@@ -92,6 +92,10 @@
             @include typography.headline-3;
             direction: ltr;
         }
+        h1[lang="he"],
+        h2[lang="he"] {
+            @include typography.headline-3-he;
+        }
         h1,
         h3 {
             text-align: left;

--- a/sitemedia/scss/components/_metadata.scss
+++ b/sitemedia/scss/components/_metadata.scss
@@ -17,4 +17,8 @@ dl.metadata-list {
 // Hebrew variant
 html[lang="he"] dl.metadata-list {
     @include typography.meta-he;
+    *[lang="en"] {
+        // handle any dt/dd in English
+        @include typography.meta;
+    }
 }

--- a/sitemedia/scss/components/_metadata.scss
+++ b/sitemedia/scss/components/_metadata.scss
@@ -13,3 +13,8 @@ dl.metadata-list {
         word-break: break-word;
     }
 }
+
+// Hebrew variant
+html[lang="he"] dl.metadata-list {
+    @include typography.meta-he;
+}

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -724,4 +724,8 @@ html[lang="he"] #site-nav {
     ul.sub-menu li.menu-label {
         @include typography.mobile-menu-he;
     }
+    *[lang="en"] {
+        // handle any nav links/menu items in English
+        @include typography.mobile-menu;
+    }
 }

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -714,3 +714,14 @@ html[dir="rtl"].dark-mode #site-nav {
         @include dark-hover-rtl;
     }
 }
+
+// Hebrew variant
+html[lang="he"] #site-nav {
+    li.menu-item a,
+    li.menu-item a[aria-current="page"],
+    ul.sub-menu li.menu-item a,
+    ul.sub-menu li.menu-item a[aria-current="page"],
+    ul.sub-menu li.menu-label {
+        @include typography.mobile-menu-he;
+    }
+}

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -392,3 +392,14 @@ html[dir="rtl"] .search-result {
         align-self: flex-start;
     }
 }
+
+// Hebrew variant
+html[lang="he"] {
+    .search-result .counter {
+        @include typography.headline-2-he;
+    }
+    .search-result section:first-of-type .scholarship,
+    a.view-link > span {
+        @include typography.meta-he;
+    }
+}

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -636,3 +636,15 @@ html[dir="rtl"] main.search form {
         }
     }
 }
+
+// Hebrew variant
+html[lang="he"] main.search form {
+    a#filters-button,
+    a#close-filters-button {
+        @include typography.body-he;
+    }
+    fieldset#filters > label:not(.date-range-label) span.count,
+    ul#search-errors li {
+        @include typography.meta-he;
+    }
+}

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -639,8 +639,8 @@ html[dir="rtl"] main.search form {
 
 // Hebrew variant
 html[lang="he"] main.search form {
-    a#filters-button,
-    a#close-filters-button {
+    a#filters-button:not([lang="en"]),
+    a#close-filters-button:not([lang="en"]) {
         @include typography.body-he;
     }
     fieldset#filters > label:not(.date-range-label) span.count,

--- a/sitemedia/scss/pages/_content.scss
+++ b/sitemedia/scss/pages/_content.scss
@@ -122,8 +122,8 @@ main.homepage {
 // Hebrew variant
 html[lang="he"] main.content-page,
 html[lang="he"] main.homepage {
-    p b,
-    p i {
+    p:not([lang="en"]) b,
+    p:not([lang="en"]) i {
         @include typography.body-he;
     }
 }

--- a/sitemedia/scss/pages/_content.scss
+++ b/sitemedia/scss/pages/_content.scss
@@ -122,6 +122,7 @@ main.homepage {
 // Hebrew variant
 html[lang="he"] main.content-page,
 html[lang="he"] main.homepage {
+    // TODO: Wagtail content should get lang attribute by block
     p:not([lang="en"]) b,
     p:not([lang="en"]) i {
         @include typography.body-he;

--- a/sitemedia/scss/pages/_content.scss
+++ b/sitemedia/scss/pages/_content.scss
@@ -118,3 +118,12 @@ main.homepage {
         }
     }
 }
+
+// Hebrew variant
+html[lang="he"] main.content-page,
+html[lang="he"] main.homepage {
+    p b,
+    p i {
+        @include typography.body-he;
+    }
+}

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -175,7 +175,7 @@ main.document {
 
 // Hebrew variant
 html[lang="he"] main.document {
-    .container section.description h3 {
+    .container section.description:not([lang="en"]) h3 {
         @include typography.body-he;
     }
     .container dl.metadata-list,

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -172,3 +172,15 @@ main.document {
         }
     }
 }
+
+// Hebrew variant
+html[lang="he"] main.document {
+    .container section.description h3 {
+        @include typography.body-he;
+    }
+    .container dl.metadata-list,
+    .container section.input-date,
+    dl.metadata-list.tertiary dt#permalink {
+        @include typography.meta-he;
+    }
+}

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -175,12 +175,17 @@ main.document {
 
 // Hebrew variant
 html[lang="he"] main.document {
-    .container section.description:not([lang="en"]) h3 {
+    .container section.description h3 {
+        // "Description" label is always translated
         @include typography.body-he;
     }
     .container dl.metadata-list,
     .container section.input-date,
     dl.metadata-list.tertiary dt#permalink {
         @include typography.meta-he;
+    }
+    dl *[lang="en"] {
+        // handle any dt/dd in English
+        @include typography.meta;
     }
 }

--- a/sitemedia/scss/pages/_error.scss
+++ b/sitemedia/scss/pages/_error.scss
@@ -64,3 +64,10 @@ main.error {
         padding: 0 spacing.$spacing-xs;
     }
 }
+
+// Hebrew variant
+html[lang="he"] {
+    main.error h1 {
+        @include typography.headline-error-he;
+    }
+}


### PR DESCRIPTION
## In this PR

- Per #1106:
  - Implement all new Hebrew type styles from Figma, using new mixins and specifying new rules for `html[lang="he"]`
- Use `calc()` for calculating line height proportions, instead of manual calculation (using proportions instead of pixels for scaling)
