### PR TITLE
Revise admin display of non-document images (#1109)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -27,7 +27,7 @@ from geniza.corpus.models import (
     TextBlock,
 )
 from geniza.corpus.solr_queryset import DocumentSolrQuerySet
-from geniza.corpus.views import DocumentMerge
+from geniza.corpus.views import DocumentMerge, placeholder_canvas
 from geniza.footnotes.admin import DocumentFootnoteInline
 from geniza.footnotes.models import Footnote
 
@@ -388,6 +388,23 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
         # if there is an error converting the date
         obj.request = request
         super().save_model(request, obj, form, change)
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        """Customize this model's change_view to add IIIF images to context for
+        transcription viewer, then execute existing change_view"""
+        document = self.get_object(request, object_id)
+        # TODO: Make this DRY
+        images = document.iiif_images()
+        for ed in document.digital_editions().all():
+            for canvas_uri in ed.content_html.keys():
+                if canvas_uri not in images:
+                    # use placeholder image for each canvas not in iiif_images
+                    images[canvas_uri] = placeholder_canvas
+        if extra_context:
+            extra_context.update({"images": images})
+        else:
+            extra_context = {"images": images}
+        return super().change_view(request, object_id, form_url, extra_context)
 
     # CSV EXPORT -------------------------------------------------------------
 

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -136,6 +136,57 @@ a#needsreview:target {
     right: 163px;
 }
 
+/* remove overlays for non-document images in admin */
+fieldset.transcriptions-field
+    #itt-panel
+    .panel-container
+    div.img.excluded
+    .deep-zoom-container::after {
+    display: none;
+}
+
+/* Full width non-document images in admin */
+fieldset.transcriptions-field
+    #itt-panel
+    .panel-container
+    div.img.excluded
+    .deep-zoom-container {
+    width: 100%;
+    max-width: none;
+    max-height: none;
+}
+fieldset.transcriptions-field
+    #itt-panel
+    .panel-container
+    div.img.excluded
+    .deep-zoom-container
+    img {
+    width: 640px;
+    max-width: 100%;
+    max-height: none;
+}
+
+/* Selected/included images should have yellow border in admin */
+fieldset.transcriptions-field
+    #itt-panel
+    .panel-container
+    div.img:not(.excluded)
+    .deep-zoom-container
+    img {
+    box-sizing: border-box;
+    border: 5px solid var(--accent);
+}
+
+/* unhide placeholder images in admin */
+fieldset.transcriptions-field
+    #itt-panel
+    .panel-container
+    .img.placeholder
+    .deep-zoom-container {
+    background-color: var(--background-gray);
+    opacity: 1;
+}
+
 .transcription li::marker {
     direction: rtl;
 }


### PR DESCRIPTION
## In this PR

- Per #1109:
  - In admin document change form, make non-document images full-width, remove overlay from them, and add yellow outline around selected images
  - Show placeholder images as gray boxes in admin view (i.e. same as editor)
- Pass new images dict to Document admin change view (we weren't doing this yet! not sure how the ITT viewer was working in admin for others, it wouldn't work at all for me due to `images` not being in the context…)

## Questions

- I've just duplicated code from `DocumentDetailView.get_context_data` here, but that's obviously not DRY and I'd prefer if it's a method called from elsewhere. Would it make sense to add a method for this on the Document model? (and move `placeholder_canvas` there too)