### PR TITLE
Revert sort listbox to <select> in search form (#1089)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -8,41 +8,6 @@ from geniza.common.utils import simplify_quotes
 from geniza.corpus.models import Document
 
 
-class SelectDisabledMixin:
-    """
-    Mixin for :class:`django.forms.RadioSelect` or :class:`django.forms.CheckboxSelect`
-    classes to set an option as disabled. To disable, the widget's choice
-    label option should be passed in as a dictionary with `disabled` set
-    to True::
-
-        {'label': 'option', 'disabled': True}.
-    """
-
-    # copied from mep-django
-
-    # Using a solution at https://djangosnippets.org/snippets/2453/
-    def create_option(
-        self, name, value, label, selected, index, subindex=None, attrs=None
-    ):
-        disabled = None
-
-        if isinstance(label, dict):
-            label, disabled = label["label"], label.get("disabled", False)
-        option_dict = super().create_option(
-            name, value, label, selected, index, subindex=subindex, attrs=attrs
-        )
-        if disabled:
-            option_dict["attrs"].update({"disabled": "disabled"})
-        return option_dict
-
-
-class RadioSelectWithDisabled(SelectDisabledMixin, forms.RadioSelect):
-    """
-    Subclass of :class:`django.forms.RadioSelect` with option to mark
-    a choice as disabled.
-    """
-
-
 class CheckboxSelectWithCount(forms.CheckboxSelectMultiple):
     # extend default CheckboxSelectMultiple to add facet counts and
     # include per-item count as a data attribute
@@ -195,7 +160,6 @@ class DocumentSearchForm(RangeForm):
             for choice in SORT_CHOICES
         ],
         required=False,
-        widget=RadioSelectWithDisabled,
     )
     # Translators: label for filter documents by date range
     docdate = RangeField(

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -8,6 +8,40 @@ from geniza.common.utils import simplify_quotes
 from geniza.corpus.models import Document
 
 
+class SelectDisabledMixin:
+    """
+    Mixin for :class:`django.forms.RadioSelect` or :class:`django.forms.CheckboxSelect`
+    classes to set an option as disabled. To disable, the widget's choice
+    label option should be passed in as a dictionary with `disabled` set
+    to True::
+        {'label': 'option', 'disabled': True}.
+    """
+
+    # copied from mep-django
+
+    # Using a solution at https://djangosnippets.org/snippets/2453/
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        disabled = None
+
+        if isinstance(label, dict):
+            label, disabled = label["label"], label.get("disabled", False)
+        option_dict = super().create_option(
+            name, value, label, selected, index, subindex=subindex, attrs=attrs
+        )
+        if disabled:
+            option_dict["attrs"].update({"disabled": "disabled"})
+        return option_dict
+
+
+class SelectWithDisabled(SelectDisabledMixin, forms.Select):
+    """
+    Subclass of :class:`django.forms.Select` with option to mark
+    a choice as disabled.
+    """
+
+
 class CheckboxSelectWithCount(forms.CheckboxSelectMultiple):
     # extend default CheckboxSelectMultiple to add facet counts and
     # include per-item count as a data attribute
@@ -155,11 +189,9 @@ class DocumentSearchForm(RangeForm):
     sort = forms.ChoiceField(
         # Translators: label for form sort field
         label=_("Sort by"),
-        choices=[
-            (choice[0], mark_safe(f"<span>{choice[1]}</span>"))
-            for choice in SORT_CHOICES
-        ],
+        choices=SORT_CHOICES,
         required=False,
+        widget=SelectWithDisabled,
     )
     # Translators: label for filter documents by date range
     docdate = RangeField(
@@ -198,6 +230,19 @@ class DocumentSearchForm(RangeForm):
         "has_translation": "has_translation",
         "has_discussion": "has_discussion",
     }
+
+    def __init__(self, data=None, *args, **kwargs):
+        """
+        Override to set choices dynamically based on form kwargs.
+        """
+        super().__init__(data=data, *args, **kwargs)
+
+        # if a keyword search term is not present, relevance sort is disabled
+        if not data or not data.get("q", None):
+            self.fields["sort"].widget.choices[0] = (
+                self.SORT_CHOICES[0][0],
+                {"label": self.SORT_CHOICES[0][1], "disabled": True},
+            )
 
     def filters_active(self):
         """Check if any filters are active; returns true if form fields other than sort or q are set"""

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -6,7 +6,7 @@
 
 {% block main %}
     <h1 class="sr-only">{{ page_title }}</h1>
-    <form data-controller="search" data-turbo-frame="main" data-turbo-action="advance" data-action="click@document->search#clickCloseSort">
+    <form data-controller="search" data-turbo-frame="main" data-turbo-action="advance">
         <fieldset id="query">
             {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
 
@@ -65,21 +65,9 @@
             <label for="{{ form.sort.html_name }}">
                 {{ form.sort.label }}
             </label>
-            <details class="sort-select" aria-expanded="false" data-search-target="sortDetails">
-                <summary class="sort-select-trigger" data-search-target="sortLabel" data-action="keydown->search#shiftTabCloseSort">
-                    {% for choice in form.sort.field.choices %}
-                        {% if form.sort.value == choice.0 %}
-                            {{ choice.1 }}
-                        {% endif %}
-                    {% endfor %}
-                    {# Translators: Button to open or close sort options menu #}
-                    {% translate 'Toggle sort options menu' as toggle_label %}
-                    <div role="button" tabindex="-1" aria-pressed="false" aria-expanded="false" aria-label="{{ toggle_label }}">
-                        <span class="sr-only" >{{ toggle_label }}</span>
-                    </div>
-                </summary>
-                {% render_field form.sort data-search-target="sort" data-action="input->search#changeSort input->search#update keydown->search#keyboardCloseSort" %}
-            </details>
+            {% render_field form.sort data-search-target="sort" data-action="input->search#update" %}
+            {# caret icon for <select>; since we also have the select element, role=presentation #}
+            <i class="ph-caret-down" role="presentation"></i>
         </fieldset>
 
         {% if form.errors %}

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from django import forms
 
 from geniza.corpus.forms import (
     CheckboxSelectWithCount,
@@ -8,8 +9,31 @@ from geniza.corpus.forms import (
     DocumentMergeForm,
     DocumentSearchForm,
     FacetChoiceField,
+    SelectWithDisabled,
 )
 from geniza.corpus.models import Document
+
+
+class TestSelectedWithDisabled:
+    # test adapted from ppa-django/mep-django
+
+    class TestForm(forms.Form):
+        """Build a test form use the widget"""
+
+        CHOICES = (
+            ("no", {"label": "no select", "disabled": True}),
+            ("yes", "yes can select"),
+        )
+
+        yes_no = forms.ChoiceField(choices=CHOICES, widget=SelectWithDisabled)
+
+    def test_create_option(self):
+        form = self.TestForm()
+        rendered = form.as_p()
+        print(rendered)
+        # no is disabled
+        assert '<option value="no" disabled="disabled"' in rendered
+        assert '<option value="yes">' in rendered
 
 
 class TestFacetChoiceField:
@@ -33,6 +57,28 @@ class TestFacetChoiceField:
 
 class TestDocumentSearchForm:
     # test adapted from ppa-django
+
+    def test_init(self):
+        data = {"q": "illness"}
+        # has query, relevance enabled
+        form = DocumentSearchForm(data)
+        assert form.fields["sort"].widget.choices[0] == form.SORT_CHOICES[0]
+
+        # empty query, relevance disabled
+        data["q"] = ""
+        form = DocumentSearchForm(data)
+        assert form.fields["sort"].widget.choices[0] == (
+            "relevance",
+            {"label": "Relevance", "disabled": True},
+        )
+
+        # no query, also relevance disabled
+        del data["q"]
+        form = DocumentSearchForm(data)
+        assert form.fields["sort"].widget.choices[0] == (
+            "relevance",
+            {"label": "Relevance", "disabled": True},
+        )
 
     def test_choices_from_facets(self):
         """A facet dict should produce correct choice labels"""

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -1,8 +1,6 @@
-import re
 from unittest.mock import Mock
 
 import pytest
-from django import forms
 
 from geniza.corpus.forms import (
     CheckboxSelectWithCount,
@@ -10,36 +8,8 @@ from geniza.corpus.forms import (
     DocumentMergeForm,
     DocumentSearchForm,
     FacetChoiceField,
-    RadioSelectWithDisabled,
 )
 from geniza.corpus.models import Document
-
-
-class TestSelectedWithDisabled:
-    # test adapted from ppa-django/mep-django
-
-    class SampleForm(forms.Form):
-        """Build a test form use the widget"""
-
-        CHOICES = (
-            ("no", {"label": "no select", "disabled": True}),
-            ("yes", "yes can select"),
-        )
-
-        yes_no = forms.ChoiceField(choices=CHOICES, widget=RadioSelectWithDisabled)
-
-    def test_create_option(self):
-        form = self.SampleForm()
-        rendered = form.as_p()
-        # no is disabled
-        no_input = re.search(
-            r"\<[ A-Za-z0-9\=\"\_\-]+value=\"no\"[ A-Za-z0-9\=\"\_\-]+>", rendered
-        )
-        yes_input = re.search(
-            r"\<[ A-Za-z0-9\=\"\_\-]+value=\"yes\"[ A-Za-z0-9\=\"\_\-]+>", rendered
-        )
-        assert 'disabled="disabled"' in no_input.group()
-        assert 'disabled="disabled"' not in yes_input.group()
 
 
 class TestFacetChoiceField:

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -125,8 +125,25 @@ main.search form {
     // sort field and label
     fieldset#sort {
         order: 4;
-        // sort options select (uses details/summary)
-        details.sort-select {
+        display: flex;
+        select {
+            // A reset of styles, including removing the default dropdown arrow
+            // @link https://moderncss.dev/custom-select-styles-with-pure-css/
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            appearance: none;
+            border: none;
+            font-family: inherit;
+            font-size: inherit;
+            border-radius: 0;
+            // Remove dropdown arrow in IE10 & IE11
+            // @link https://www.filamentgroup.com/lab/select-css.html
+            &::-ms-expand {
+                display: none;
+            }
+
+            @include typography.form-option-sm;
+            @include form-drop-shadow;
             position: relative;
             flex: 1 1 auto;
             min-height: 2.5rem;
@@ -135,116 +152,24 @@ main.search form {
                 min-width: auto;
                 max-width: 23rem;
             }
-            summary {
-                display: flex;
-                min-height: 2.5rem;
-                cursor: pointer;
-                margin-top: spacing.$spacing-sm;
-                // Suppress default details marker
-                &::-webkit-details-marker {
-                    display: none;
-                }
-                span,
-                button {
-                    cursor: pointer;
-                    background-color: var(--background-light);
-                    color: var(--on-background-light);
-                }
-                span {
-                    flex: 1 1 auto;
-                    display: flex;
-                    max-width: 100%;
-                    align-items: center;
-                    padding: spacing.$spacing-2xs 0.7rem;
-                    margin-right: spacing.$spacing-sm;
-                    @include typography.form-option-sm;
-                    @include form-drop-shadow;
-                }
-                div[role="button"] {
-                    @include form-button-colors;
-                    flex: 1 1 2.0625rem;
-                    width: auto;
-                    max-width: 2.0625rem;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    &::after {
-                        content: "\f0c2"; // phosphor caret-down icon
-                        @include typography.icon-button-md;
-                    }
-                }
-                &:focus {
-                    outline: none;
-                }
-                // Focus styles using box-shadow
-                &:focus span,
-                &:focus div[role="button"],
-                &:focus-within span,
-                &:focus-within div[role="button"],
-                &:focus + ul,
-                &:focus-within + ul {
-                    @include box-shadow(var(--secondary-80));
-                }
-                &:focus-within + ul:active {
-                    @include box-shadow(var(--primary-80));
-                }
-            }
-            // List of sort options
-            ul {
-                position: absolute;
-                z-index: 20;
-                width: calc(100% - 2.0625rem - #{spacing.$spacing-sm});
-                max-width: calc(100% - 2.0625rem - #{spacing.$spacing-sm});
-                padding: spacing.$spacing-sm 0;
-                @include form-drop-shadow;
-                background-color: var(--background-light);
-                li {
-                    display: flex;
-                    label {
-                        width: 100%;
-                        flex: 0 1 100%;
-                        display: flex;
-                        cursor: pointer;
-                        span {
-                            display: flex;
-                            align-items: center;
-                            width: 100%;
-                            flex: 0 1 100%;
-                            padding: spacing.$spacing-sm;
-                            transition: background-color 0.15s ease,
-                                color 0.15s ease;
-                        }
-                        &:hover,
-                        &:focus-within {
-                            background-color: var(--background-gray);
-                            color: var(--on-background-gray);
-                        }
-                        &:hover input[name="sort"]:focus + span {
-                            background-color: var(--tertiary);
-                            color: var(--on-tertiary);
-                        }
-                        // Checkboxes only visible to screen readers
-                        input[name="sort"] {
-                            @include a11y.sr-only;
-                            // Selected option
-                            &:checked + span {
-                                @include typography.form-option-sm-bold;
-                            }
-                            &:active + span {
-                                background-color: var(--secondary);
-                                color: var(--on-secondary);
-                            }
-                            &:disabled + span {
-                                color: var(--disabled);
-                                cursor: default;
-                                background-color: var(--background-light);
-                            }
-                        }
-                        // Non-selected options
-                        @include typography.form-option-sm;
-                    }
-                }
-            }
+            margin-top: spacing.$spacing-sm;
+            cursor: pointer;
+            background-color: var(--background-light);
+            color: var(--on-background-light);
+            padding: 0.55rem 0.75rem;
+            margin-right: spacing.$spacing-3xs;
+        }
+        i.ph-caret-down {
+            @include typography.icon-button-md;
+            margin-left: -37px;
+            margin-top: 8px;
+            z-index: 1;
+            pointer-events: none;
+        }
+        // Focus styles using box-shadow
+        &:focus select,
+        &:focus-within select {
+            @include box-shadow(var(--secondary-80));
         }
         label[for="sort"] {
             max-width: 100%;


### PR DESCRIPTION
## In this PR

- Per #1089:
  - Remove `SelectDisabledMixin` and `RadioSelectWithDisabled`, and revert form widget to default `select` element
  - Remove details/summary/button from HTML and revert to form default widget; add icon for caret-down (presentation only)
  - Remove Stimulus logic for control of the custom listbox, and adapt Stimulus logic for "relevance" option enabling/disabling
  - Adapt CSS for `select` element and Phosphor icon