### PR TITLE
Revise transcription export directory layout

### DIFF
--- a/geniza/corpus/annotation_export.py
+++ b/geniza/corpus/annotation_export.py
@@ -199,8 +199,8 @@ class AnnotationExporter:
         """Generate path based on pgpid so records are chunked by 1000s,
         then nested by pgpid to avoid too many files in a single directory."""
 
-        # round pgpid to nearest 1000; pad with leading zeros for < 1000
-        # import match
+        # round pgpid to nearest 1000; pad with leading zeros for
+        # so all directories have 5 digits; use actual PGPID for subdirectory
         k_chunk = math.floor(int(pgpid) / 1000) * 1000
         return os.path.join(f"{k_chunk:05d}", str(pgpid))
 

--- a/geniza/corpus/management/commands/tei_to_annotation.py
+++ b/geniza/corpus/management/commands/tei_to_annotation.py
@@ -86,14 +86,15 @@ class Command(sync_transcriptions.Command):
             self.stdout.write("Clearing %d annotations" % all_annos.count())
             all_annos.delete()
 
-        # initialize annotation exporter; don't push changes until the end
-        # FIXME: override default commit message to differentiate from auto version?
+        # initialize annotation exporter; don't push changes until the end;
+        # commit message will be overridden per export to docment TEI file
         self.anno_exporter = AnnotationExporter(
             stdout=self.stdout,
             verbosity=options["verbosity"],
             push_changes=False,
             commit_msg="PGP transcription export from TEI migration",
         )
+        self.anno_exporter.setup_repo()
 
         # iterate through tei files to be migrated
         for xmlfile in xmlfiles:

--- a/geniza/corpus/tests/test_annotation_export.py
+++ b/geniza/corpus/tests/test_annotation_export.py
@@ -372,7 +372,10 @@ def test_annotation_export_cleanup(mock_repo, annotation, tmpdir):
 
 @patch("geniza.corpus.annotation_export.Repo")
 def test_document_path(mock_repo, tmpdir):
-    anno_ex = AnnotationExporter()
-    assert anno_ex.document_path(444) == "00000/444"
-    assert anno_ex.document_path(1234) == "01000/1234"
-    assert anno_ex.document_path(13539) == "13000/13539"
+    with override_settings(
+        ANNOTATION_BACKUP_PATH=str(tmpdir), ANNOTATION_BACKUP_GITREPO="git:foo"
+    ):
+        anno_ex = AnnotationExporter()
+        assert anno_ex.document_path(444) == "00000/444"
+        assert anno_ex.document_path(1234) == "01000/1234"
+        assert anno_ex.document_path(13539) == "13000/13539"

--- a/geniza/corpus/tests/test_annotation_export.py
+++ b/geniza/corpus/tests/test_annotation_export.py
@@ -296,24 +296,24 @@ def test_annotation_export(mock_repo, annotation, tmp_path):
         anno_ex.export()
 
         # should create document output dir
-        doc_annolist_dir = tmp_path.joinpath("annotations", str(doc_id), "list")
+        doc_annolist_dir = tmp_path.joinpath(
+            "annotations", anno_ex.document_path(doc_id), "list"
+        )
         assert doc_annolist_dir.is_dir()
         # should create one annotation list json file
         anno_files = list(doc_annolist_dir.glob("*.json"))
         assert len(anno_files) == 1
         # inspect contents?
 
-        # html and text directories should exist and should each have one file
-        txt_transcription_dir = tmp_path.joinpath("transcriptions", "txt")
-        assert txt_transcription_dir.is_dir()
-        txt_files = list(txt_transcription_dir.glob("*.txt"))
+        # transcription directories should be created based on pgpid
+        doc_transcription_dir = tmp_path.joinpath(anno_ex.document_path(doc_id))
+        assert doc_transcription_dir.is_dir()
+        txt_files = list(doc_transcription_dir.glob("*.txt"))
         assert len(txt_files) == 1
         # should only have the content from the annotation
         assert txt_files[0].read_text() == "Test annotation"
 
-        html_transcription_dir = tmp_path.joinpath("transcriptions", "html")
-        assert html_transcription_dir.is_dir()
-        html_files = list(html_transcription_dir.glob("*.html"))
+        html_files = list(doc_transcription_dir.glob("*.html"))
         assert len(html_files) == 1
         html_content = html_files[0].read_text()
         assert "Test annotation" in html_content
@@ -357,14 +357,22 @@ def test_annotation_export_cleanup(mock_repo, annotation, tmpdir):
         ANNOTATION_BACKUP_PATH=str(tmpdir), ANNOTATION_BACKUP_GITREPO="git:foo"
     ):
         doc_id = Document.id_from_manifest_uri(annotation.target_source_manifest_id)
-        txt_transcription_dir = tmpdir / "transcriptions" / "txt"
-        # create a stray file to be cleaned up (create parent dirs as needed)
-        extra_file = txt_transcription_dir / ("PGPID%s_extra_file.txt" % doc_id)
-        extra_file.write_text("test file", "utf-8", ensure=True)
-
         anno_ex = AnnotationExporter(pgpids=[doc_id])
+        output_dir = anno_ex.document_path(doc_id)
+        doc_transcription_dir = tmpdir / output_dir
+        # create a stray file to be cleaned up (create parent dirs as needed)
+        extra_file = doc_transcription_dir / ("PGPID%s_extra_file.txt" % doc_id)
+        extra_file.write_text("test file", "utf-8", ensure=True)
         anno_ex.export()
 
         # should remove extra file from git index and local file system
         anno_ex.repo.index.remove.assert_called()
         assert not extra_file.exists()
+
+
+@patch("geniza.corpus.annotation_export.Repo")
+def test_document_path(mock_repo, tmpdir):
+    anno_ex = AnnotationExporter()
+    assert anno_ex.document_path(444) == "00000/444"
+    assert anno_ex.document_path(1234) == "01000/1234"
+    assert anno_ex.document_path(13539) == "13000/13539"


### PR DESCRIPTION
this PR revises the directory layout for the transcription export, per conversation on https://github.com/Princeton-CDH/geniza/issues/912

here's an example of the previous directory structure:
https://github.com/Princeton-CDH/test-pgp-annotations/tree/test-tei-migration

and here is an example of what the new structure will look like:
https://github.com/Princeton-CDH/test-pgp-annotations/tree/rsk-dev2

(I only tested a few records, and it looks like I tested before I added leading zeros to make the top-level directories 5 digits)