### PR TITLE
Add secondary motivation to & bump tahqiq (#1123)

### DIFF
--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -773,7 +773,8 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     ),
                     "csrf_token": csrf_token(self.request),
                     "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
-                    # secondary motivation is transcribing here; change for translations
+                    # TODO: when translations implemented, make this a data property or something
+                    # on the template; the editor will have both transcribing and translating
                     "secondary_motivation": "transcribing",
                 },
                 # TODO: Add Footnote notes to the following display, if present

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -773,6 +773,8 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     ),
                     "csrf_token": csrf_token(self.request),
                     "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
+                    # secondary motivation is transcribing here; change for translations
+                    "secondary_motivation": "transcribing",
                 },
                 # TODO: Add Footnote notes to the following display, if present
                 "source_detail": mark_safe(source.formatted_display())

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.2",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#bd12f500f853cd878a12f520ee2bbc82b9fc4c71",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c2ec44317f6169e0afc322f404cdc83a126ce996",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2887,8 +2887,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#bd12f500f853cd878a12f520ee2bbc82b9fc4c71",
-      "integrity": "sha512-5KZd7GCaNzDV3H544DAwcPLZXZS6ug2pdYdrU7Nu1s3EZ+2vglrE86ybr9Co1xmvnabm/5dBPzSoao/Wz8I5UA==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c2ec44317f6169e0afc322f404cdc83a126ce996",
+      "integrity": "sha512-kAto2VCYqbi2IeVvjMw+myNp3AWqRNQdhdUV/q7W3wtuEay9PorJjILYJabZZq4Bgd3Di6WAbClmMIwiR8zynA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
@@ -10949,9 +10949,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#bd12f500f853cd878a12f520ee2bbc82b9fc4c71",
-      "integrity": "sha512-5KZd7GCaNzDV3H544DAwcPLZXZS6ug2pdYdrU7Nu1s3EZ+2vglrE86ybr9Co1xmvnabm/5dBPzSoao/Wz8I5UA==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#bd12f500f853cd878a12f520ee2bbc82b9fc4c71",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#c2ec44317f6169e0afc322f404cdc83a126ce996",
+      "integrity": "sha512-kAto2VCYqbi2IeVvjMw+myNp3AWqRNQdhdUV/q7W3wtuEay9PorJjILYJabZZq4Bgd3Di6WAbClmMIwiR8zynA==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#c2ec44317f6169e0afc322f404cdc83a126ce996",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@recogito/annotorious-openseadragon": "^2.7.2",
     "@recogito/annotorious-toolbar": "^1.1.0",
     "angle-input": "^0.0.1",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#e1bcfe93b9e098c01bed6f627bceed046fbb57ac",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#c2ec44317f6169e0afc322f404cdc83a126ce996",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -77,6 +77,10 @@ export default class extends Controller {
         if (config.source_uri) {
             annotationServerConfig["sourceUri"] = config.source_uri;
         }
+        if (config.secondary_motivation) {
+            annotationServerConfig["secondaryMotivation"] =
+                config.secondary_motivation;
+        }
         const storagePlugin = new AnnotationServerStorage(
             anno,
             annotationServerConfig


### PR DESCRIPTION
## In this PR

- Per #1123:
  - Pass secondary motivation to tahqiq storage plugin
  - Bump tahqiq commit hash

Note: can bump tahqiq commit hash again, to the merge commit after https://github.com/Princeton-CDH/annotorious-tahqiq/pull/18 is merged, if we want to keep it on the `develop` branch