### PR TITLE
Feature/ja phrases

### DIFF
--- a/geniza/corpus/ja.py
+++ b/geniza/corpus/ja.py
@@ -1,4 +1,5 @@
 import re
+from itertools import zip_longest
 
 COMPILED_ARABIC_WORDS_OR_PHRASES = re.compile(r'"[ \u0600-\u06FF]+"|[\u0600-\u06FF]+')
 
@@ -99,8 +100,6 @@ def arabic_or_ja(text, boost=True):
     ]
 
     # stitch back together
-    from itertools import zip_longest
-
     tokens = [
         tok
         for toks in zip_longest(nonarabic_wordphrases, arabic_or_ja_wordphrases)

--- a/geniza/corpus/ja.py
+++ b/geniza/corpus/ja.py
@@ -79,70 +79,25 @@ def arabic_to_ja(text):
     return re.sub(re_he_final_letters, lambda m: he_final_letters[m.group(0)], text)
 
 
-# def locate_quoted_phrases(text):
-#     import re
-#     return [m.span() for m in re.finditer(r'"[^"]*"', text)]
-
-# def extract_quoted_phrases(text):
-#     return [text[m[0]:m[1]] for m in locate_quoted_phrases(text)]
-
-# def extract_arabic_phrases(text):
-#     return [
-#         phrase for phrase in extract_quoted_phrases(text) if contains_arabic(phrase)
-#     ]
-
-
-# def extract_arabic_words_outside_phrases(text):
-#     arabic_phrases = extract_arabic_phrases(text)
-
-#     # remove those arabic phrases from original string
-#     for phrase in arabic_phrases:
-#         text = text.replace(phrase, "")
-
-#     # get remaining arabic words
-#     arabic_words = extract_arabic_words(text)
-
-#     # return words
-#     return arabic_words
-
-
-# def extract_arabic_words(text):
-#     return re_AR_letters.findall(text)
-
-
 def tokenize_words_and_phrases(text):
-    import re
-
-    return [x for x in re.findall(r'"[^"]*"|[\w]+', text) if x]
-
-
-def term_is_phrase(text):
-    text = text.strip()
-    return text and " " in text and text[0] == '"' and text[-1] == '"'
+    # Get a list of search query tokens which are each either:
+    #    - a phrase (text inside double quotes)
+    #    - a word
+    return re.findall(r'"[^"]*"|[^ "]*[^ "]', text)
 
 
 def arabic_or_ja_allowing_phrases(text, boost=True):
-    # replace arabic phrases
-    new_terms = []
-
-    for word_or_phrase in tokenize_words_and_phrases(text):
-        judeo_arabic_equivalent = arabic_to_ja(word_or_phrase)
-        if contains_arabic(word_or_phrase):
-            if term_is_phrase(word_or_phrase):
-                new_term = f"({judeo_arabic_equivalent} OR {word_or_phrase})"
-            else:
-                new_term = f"({judeo_arabic_equivalent}|{word_or_phrase})"
-        else:
-            new_term = word_or_phrase
-
-        new_terms.append(new_term)
-
-    text = " ".join(new_terms)
-
-    # fix query
-    text = text.replace("((", "(")
-    text = text.replace("))", ")")
-    return text
+    new_terms = [
+        (
+            f"({arabic_to_ja(word_or_phrase)}|{word_or_phrase})"
+            if contains_arabic(word_or_phrase)
+            else word_or_phrase
+        )
+        for word_or_phrase in tokenize_words_and_phrases(text)
+    ]
+    new_text = " ".join(new_terms)
+    new_text = new_text.replace(") )", ")").replace("( (", "(")
+    return new_text
 
 
 def arabic_or_ja(text, boost=True):

--- a/geniza/corpus/tests/test_ja.py
+++ b/geniza/corpus/tests/test_ja.py
@@ -37,45 +37,31 @@ def test_arabic_or_ja__arabic():
 
 
 def test_arabic_or_ja_exact_phrase():
-    # make sure basic or is working
-    assert arabic_or_ja('"تعطل شغله"', boost=False) in {
-        '("תעטל שגלה"|"تعطل شغله")',
-        '("تعطل شغله"|"תעטל שגלה")',
-    }
+    # make sure basic exact quote is working
+    assert arabic_or_ja('"تعطل شغله"', boost=False) == '("تعطل شغله"|"תעטל שגלה")'
 
-    # make sure broken quotes still work
-    assert arabic_or_ja('"تعطل شغله', boost=False) in {
-        '"(شغله|שגלה) (تعطل|תעטל)',
-        '"(تعطل|תעטל) (شغله|שגלה)',
-        '"(שגלה|شغله) (תעטל|تعطل)',
-        '"(תעטל|تعطل) (שגלה|شغله)',
-    }
+    # make sure broken quotes are ignored and arabic words are converted
+    assert arabic_or_ja('"تعطل شغله', boost=False) == '"(تعطل|תעטל) (شغله|שגלה)'
 
-    # need to test what would happen if we had 1+ arabic phrases (within quotation marks) and 1+ arabic words (not inside quotes)
-    assert arabic_or_ja('"تعطل شغله" etc etc شغله', boost=False) in {
-        '("תעטל שגלה"|"تعطل شغله") etc etc (شغله|שגלה)',
-        '("تعطل شغله"|"תעטל שגלה") etc etc (شغله|שגלה)',
-        '("תעטל שגלה"|"تعطل شغله") etc etc (שגלה|شغله)',
-        '("تعطل شغله"|"תעטל שגלה") etc etc (שגלה|شغله)',
-    }
+    # to test what would happen if we had 1+ arabic phrases
+    # (within quotation marks) and 1+ arabic words (not inside quotes)
+    assert (
+        arabic_or_ja('"تعطل شغله" etc etc شغله', boost=False)
+        == '("تعطل شغله"|"תעטל שגלה") etc etc (شغله|שגלה)'
+    )
 
     # proximity
-    assert arabic_or_ja('"تعطل شغله"~10', boost=False) in {
-        '("תעטל שגלה"|"تعطل شغله")~10',
-        '("تعطل شغله"|"תעטל שגלה")~10',
-    }
+    assert arabic_or_ja('"تعطل شغله"~10', boost=False) == '("تعطل شغله"|"תעטל שגלה")~10'
 
     # with boosting
-    assert arabic_or_ja("تعطل شغله", boost=True) in {"(تعطل^2.0|תעטל) (شغله^2.0|שגלה)"}
-    assert arabic_or_ja('"تعطل شغله"', boost=True) in {
-        '("תעטל שגלה"^2.0|"تعطل شغله")',
-        '("تعطل شغله"^2.0|"תעטל שגלה")',
-    }
+    assert arabic_or_ja("تعطل شغله", boost=True) == "(تعطل^2.0|תעטל) (شغله^2.0|שגלה)"
+    assert arabic_or_ja('"تعطل شغله"', boost=True) == '("تعطل شغله"^2.0|"תעטל שגלה")'
 
     # make sure query string is working
-    assert arabic_or_ja('transcription:("تعطل شغله") etc etc شغله', boost=False) in {
-        'transcription:(("תעטל שגלה"|"تعطل شغله")) etc etc (شغله|שגלה)',
-        'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (شغله|שגלה)',
-        'transcription:(("תעטל שגלה"|"تعطل شغله")) etc etc (שגלה|شغله)',
-        'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (שגלה|شغله)',
-    }
+    assert (
+        arabic_or_ja('transcription:("تعطل شغله") etc etc شغله', boost=False)
+        == 'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (شغله|שגלה)'
+    )
+
+    # make sure non-arabic field query is left unchanged
+    assert arabic_or_ja('shelfmark:"jrl series a"') == 'shelfmark:"jrl series a"'

--- a/geniza/corpus/tests/test_ja.py
+++ b/geniza/corpus/tests/test_ja.py
@@ -1,10 +1,6 @@
 from operator import contains
 
-from geniza.corpus.ja import (  # extract_arabic_phrases,; extract_arabic_words,; extract_arabic_words_outside_phrases,; extract_quoted_phrases,; locate_quoted_phrases,
-    arabic_or_ja,
-    arabic_to_ja,
-    contains_arabic,
-)
+from geniza.corpus.ja import arabic_or_ja, arabic_to_ja, contains_arabic
 
 
 def test_contains_arabic():
@@ -64,7 +60,10 @@ def test_arabic_or_ja_exact_phrase():
     }
 
     # proximity
-    # @TODO assert arabic_or_ja('"تعطل شغله"~10', boost=False) == '"(تعطل|תעטל) (شغله|שגלה)"~10'
+    assert arabic_or_ja('"تعطل شغله"~10', boost=False) in {
+        '("תעטל שגלה"|"تعطل شغله")~10',
+        '("تعطل شغله"|"תעטל שגלה")~10',
+    }
 
     # with boosting
     assert arabic_or_ja("تعطل شغله", boost=True) in {"(تعطل^2.0|תעטל) (شغله^2.0|שגלה)"}

--- a/geniza/corpus/tests/test_ja.py
+++ b/geniza/corpus/tests/test_ja.py
@@ -46,20 +46,22 @@ def test_arabic_or_ja_exact_phrase():
     # make sure basic or is working
     assert (
         arabic_or_ja_allowing_phrases('"تعطل شغله"', boost=False)
-        == '("תעטל שגלה" OR "تعطل شغله")'
+        == '("תעטל שגלה"|"تعطل شغله")'
     )
 
     # make sure broken quotes still work
-    assert (
-        arabic_or_ja_allowing_phrases('"تعطل شغله', boost=False)
-        == '"(شغله|שגלה) (تعطل|תעטל)'
-    )
+    assert arabic_or_ja_allowing_phrases('"تعطل شغله', boost=False) in {
+        "(شغله|שגלה) (تعطل|תעטל)",
+        "(تعطل|תעטל) (شغله|שגלה)",
+        "(שגלה|شغله) (תעטל|تعطل)",
+        "(תעטל|تعطل) (שגלה|شغله)",
+    }
 
     # need to test what would happen if we had 1+ arabic phrases (within quotation marks) and 1+ arabic words (not inside quotes)
-    assert (
-        arabic_or_ja_allowing_phrases('"تعطل شغله" etc etc شغله', boost=False)
-        == '("תעטל שגלה" OR "تعطل شغله") etc etc (شغله|שגלה)'
-    )
+    assert arabic_or_ja_allowing_phrases('"تعطل شغله" etc etc شغله', boost=False) in {
+        '("תעטל שגלה"|"تعطل شغله") etc etc (شغله|שגלה)',
+        '("תעטל שגלה"|"تعطل شغله") etc etc (שגלה|شغله)',
+    }
 
     # proximity
     # @TODO assert arabic_or_ja('"تعطل شغله"~10', boost=False) == '"(تعطل|תעטל) (شغله|שגלה)"~10'
@@ -69,33 +71,8 @@ def test_arabic_or_ja_exact_phrase():
     # make sure query string is working
     assert (
         arabic_or_ja_allowing_phrases('transcription:("تعطل شغله"')
-        == """transcription:("תעטל שגלה" OR "تعطل شغله")"""
+        == """transcription:("תעטל שגלה"|"تعطل شغله")"""
     )
-
-
-# def test_extract_quoted_phrases():
-#     assert extract_quoted_phrases('He said "hello world"') == ['"hello world"']
-#     assert extract_quoted_phrases('He said "hello world" and then "goodbye world"') == [
-#         '"hello world"',
-#         '"goodbye world"',
-#     ]
-
-
-# def test_locate_quoted_phrases():
-#     assert locate_quoted_phrases('He said "hello world"') == [(8,21)]
-#     assert locate_quoted_phrases('He said "hello world" and then "goodbye world"') == [(8,21), (31,46)]
-
-
-# def test_extract_arabic_phrases():
-#     assert extract_arabic_phrases('مصحف etc etc "شرح جميع"') == ['"شرح جميع"']
-
-
-# def test_extract_arabic_words():
-#     assert extract_arabic_words('مصحف etc etc "شرح جميع"') == ["مصحف", "شرح", "جميع"]
-
-
-# def test_extract_arabic_words_outside_phrases():
-#     assert extract_arabic_words_outside_phrases('مصحف etc etc "شرح جميع"') == ["مصحف"]
 
 
 def test_tokenize_words_and_phrases():

--- a/geniza/corpus/tests/test_ja.py
+++ b/geniza/corpus/tests/test_ja.py
@@ -2,10 +2,8 @@ from operator import contains
 
 from geniza.corpus.ja import (  # extract_arabic_phrases,; extract_arabic_words,; extract_arabic_words_outside_phrases,; extract_quoted_phrases,; locate_quoted_phrases,
     arabic_or_ja,
-    arabic_or_ja_allowing_phrases,
     arabic_to_ja,
     contains_arabic,
-    tokenize_words_and_phrases,
 )
 
 
@@ -44,38 +42,41 @@ def test_arabic_or_ja__arabic():
 
 def test_arabic_or_ja_exact_phrase():
     # make sure basic or is working
-    assert (
-        arabic_or_ja_allowing_phrases('"تعطل شغله"', boost=False)
-        == '("תעטל שגלה"|"تعطل شغله")'
-    )
+    assert arabic_or_ja('"تعطل شغله"', boost=False) in {
+        '("תעטל שגלה"|"تعطل شغله")',
+        '("تعطل شغله"|"תעטל שגלה")',
+    }
 
     # make sure broken quotes still work
-    assert arabic_or_ja_allowing_phrases('"تعطل شغله', boost=False) in {
-        "(شغله|שגלה) (تعطل|תעטל)",
-        "(تعطل|תעטל) (شغله|שגלה)",
-        "(שגלה|شغله) (תעטל|تعطل)",
-        "(תעטל|تعطل) (שגלה|شغله)",
+    assert arabic_or_ja('"تعطل شغله', boost=False) in {
+        '"(شغله|שגלה) (تعطل|תעטל)',
+        '"(تعطل|תעטל) (شغله|שגלה)',
+        '"(שגלה|شغله) (תעטל|تعطل)',
+        '"(תעטל|تعطل) (שגלה|شغله)',
     }
 
     # need to test what would happen if we had 1+ arabic phrases (within quotation marks) and 1+ arabic words (not inside quotes)
-    assert arabic_or_ja_allowing_phrases('"تعطل شغله" etc etc شغله', boost=False) in {
+    assert arabic_or_ja('"تعطل شغله" etc etc شغله', boost=False) in {
         '("תעטל שגלה"|"تعطل شغله") etc etc (شغله|שגלה)',
+        '("تعطل شغله"|"תעטל שגלה") etc etc (شغله|שגלה)',
         '("תעטל שגלה"|"تعطل شغله") etc etc (שגלה|شغله)',
+        '("تعطل شغله"|"תעטל שגלה") etc etc (שגלה|شغله)',
     }
 
     # proximity
     # @TODO assert arabic_or_ja('"تعطل شغله"~10', boost=False) == '"(تعطل|תעטל) (شغله|שגלה)"~10'
+
     # with boosting
-    # @TODO assert arabic_or_ja('"تعطل شغله"') == '"(تعطل^2.0|תעטל) (شغله^2.0|שגלה)"'
+    assert arabic_or_ja("تعطل شغله", boost=True) in {"(تعطل^2.0|תעטל) (شغله^2.0|שגלה)"}
+    assert arabic_or_ja('"تعطل شغله"', boost=True) in {
+        '("תעטל שגלה"^2.0|"تعطل شغله")',
+        '("تعطل شغله"^2.0|"תעטל שגלה")',
+    }
 
     # make sure query string is working
-    assert (
-        arabic_or_ja_allowing_phrases('transcription:("تعطل شغله"')
-        == """transcription:("תעטל שגלה"|"تعطل شغله")"""
-    )
-
-
-def test_tokenize_words_and_phrases():
-    assert tokenize_words_and_phrases(
-        'He said "hello world" and "goodbye world" and "goodbye'
-    ) == ["He", "said", '"hello world"', "and", '"goodbye world"', "and", "goodbye"]
+    assert arabic_or_ja('transcription:("تعطل شغله") etc etc شغله', boost=False) in {
+        'transcription:(("תעטל שגלה"|"تعطل شغله")) etc etc (شغله|שגלה)',
+        'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (شغله|שגלה)',
+        'transcription:(("תעטל שגלה"|"تعطل شغله")) etc etc (שגלה|شغله)',
+        'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (שגלה|شغله)',
+    }


### PR DESCRIPTION
Fix to https://github.com/Princeton-CDH/geniza/issues/1034. 

The solution relies on having a tokenizer for the query which separates the string into a list of words OR phrases:

```python
def tokenize_words_and_phrases(text):
    import re
    return [x for x in re.findall(r'"[^"]*"|[\w]+', text) if x]
```

Then the arabic_to_ja code can be run on each token in that list:

```python
def arabic_or_ja_allowing_phrases(text, boost=True):
    new_terms = []
    for word_or_phrase in tokenize_words_and_phrases(text):
        judeo_arabic_equivalent = arabic_to_ja(word_or_phrase)
        if contains_arabic(word_or_phrase):
            if term_is_phrase(word_or_phrase):
                new_term = f"({judeo_arabic_equivalent} OR {word_or_phrase})"
            else:
                new_term = f"({judeo_arabic_equivalent}|{word_or_phrase})"
        else:
            new_term = word_or_phrase

        new_terms.append(new_term)

    text = " ".join(new_terms)

    # fix query
    text = text.replace("((", "(")
    text = text.replace("))", ")")
    return text
```

The problem is some of my tests are failing in a bizarre way. Here is what the test is:

```python
# make sure broken quotes still work
assert (
    arabic_or_ja_allowing_phrases('"تعطل شغله', boost=False)
    == '"(شغله|שגלה) (تعطل|תעטל)'
)
```

Note that the Judeo-Arabic is *before* the Arabic.

Now see what Python thinks the test was:

* What I see in my terminal (note Judeo-Arabic is *after* the Arabic):
<img width="1028" alt="Screen Shot 2022-09-28 at 12 01 06" src="https://user-images.githubusercontent.com/733853/192828745-056f0c31-cb59-42a7-b7d1-0faaf25191d8.png">

* What I see pasting that identical text (note Judeo-Arabic is before Arabic again!?):
```
        # make sure broken quotes still work
>       assert arabic_or_ja_allowing_phrases('"تعطل شغله', boost=False) == '(شغله|שגלה) (تعطل|תעטל)'
E       AssertionError: assert '(תעטל|تعطل) (שגלה|شغله)' == '(شغله|שגלה) (تعطل|תעטל)'
E         - (شغله|שגלה) (تعطل|תעטל)
E         + (תעטל|تعطل) (שגלה|شغله)
```

tldr I have a fix but going a bit crazy with word/character order issues.