### PR TITLE
Restore test banner and make configurable (#1150)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -18,6 +18,7 @@ to avoid the annotation backup git repository getting into a bad state.
     update remote git repository with annotation exports generated via signal handler.
 -   Copy the new fonts `WF-037420-012177-002520.woff`, `WF-037420-012177-002520.woff2`, and all `Amiri-*` and `Hassan*` from the shared Google Drive folder "Geniza – woff files only" to `sitemedia/fonts`
 -   Copy the new versions of FrankRuhl, `FrankRuhl1924MF-Medium-Medium.woff` and `FrankRuhl1924MF-Medium-Medium.woff2` (note the dashes!) from the shared Google Drive folder "Geniza – woff files only" to `sitemedia/fonts`. There was an error with the original font's vertical metrics.
+-   To enable the new warning banner, add the `FEATURE_FLAGS` list to local settings and populate it with the string `"SHOW_WARNING_BANNER"`. To change its contents, configure `WARNING_BANNER_HEADING` and `WARNING_BANNER_MESSAGE` in local settings.
 
 ## 4.8
 

--- a/geniza/context_processors.py
+++ b/geniza/context_processors.py
@@ -9,7 +9,9 @@ def template_globals(request):
     site = Site.find_for_request(request)
     admin_language_codes = [lang[0] for lang in settings.LANGUAGES]
     context_extras = {
-        "SHOW_TEST_WARNING": getattr(settings, "SHOW_TEST_WARNING", False),
+        "FEATURE_FLAGS": getattr(settings, "FEATURE_FLAGS", []),
+        "TEST_WARNING_HEADING": getattr(settings, "TEST_WARNING_HEADING", None),
+        "TEST_WARNING_MESSAGE": getattr(settings, "TEST_WARNING_MESSAGE", None),
         "FONT_URL_PREFIX": getattr(settings, "FONT_URL_PREFIX", ""),
         "PUBLIC_SITE_LANGUAGES": getattr(
             settings, "PUBLIC_SITE_LANGUAGES", admin_language_codes

--- a/geniza/context_processors.py
+++ b/geniza/context_processors.py
@@ -10,8 +10,8 @@ def template_globals(request):
     admin_language_codes = [lang[0] for lang in settings.LANGUAGES]
     context_extras = {
         "FEATURE_FLAGS": getattr(settings, "FEATURE_FLAGS", []),
-        "TEST_WARNING_HEADING": getattr(settings, "TEST_WARNING_HEADING", None),
-        "TEST_WARNING_MESSAGE": getattr(settings, "TEST_WARNING_MESSAGE", None),
+        "WARNING_BANNER_HEADING": getattr(settings, "WARNING_BANNER_HEADING", None),
+        "WARNING_BANNER_MESSAGE": getattr(settings, "WARNING_BANNER_MESSAGE", None),
         "FONT_URL_PREFIX": getattr(settings, "FONT_URL_PREFIX", ""),
         "PUBLIC_SITE_LANGUAGES": getattr(
             settings, "PUBLIC_SITE_LANGUAGES", admin_language_codes

--- a/geniza/settings/local_settings.py.sample
+++ b/geniza/settings/local_settings.py.sample
@@ -6,11 +6,11 @@
 DEBUG = True
 
 FEATURE_FLAGS = [
-    # "SHOW_TEST_WARNING", # Uncomment this in test/QA site to show test banner
+    # "SHOW_WARNING_BANNER", # Uncomment this in test/QA site to show test banner
 ]
 # Uncomment and change these to override the default test banner message
-# TEST_WARNING_HEADING = "This is a test site"
-# TEST_WARNING_MESSAGE = "Content may change or be removed without warning"
+# WARNING_BANNER_HEADING = "This is a test site"
+# WARNING_BANNER_MESSAGE = "Content may change or be removed without warning"
 
 # Turn this on to enable google analytics in production
 # INCLUDE_ANALYTICS = True

--- a/geniza/settings/local_settings.py.sample
+++ b/geniza/settings/local_settings.py.sample
@@ -5,8 +5,12 @@
 
 DEBUG = True
 
-# Turn this on in test/QA site to show test banner
-# SHOW_TEST_WARNING = True
+FEATURE_FLAGS = [
+    # "SHOW_TEST_WARNING", # Uncomment this in test/QA site to show test banner
+]
+# Uncomment and change these to override the default test banner message
+# TEST_WARNING_HEADING = "This is a test site"
+# TEST_WARNING_MESSAGE = "Content may change or be removed without warning"
 
 # Turn this on to enable google analytics in production
 # INCLUDE_ANALYTICS = True

--- a/geniza/templates/admin/base_site.html
+++ b/geniza/templates/admin/base_site.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block extrastyle %}
-    {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
+    {% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}
         <link rel="stylesheet" type="text/css" href="{% static "css/test-banner.css" %}" />
     {% endif %}
 {% endblock %}

--- a/geniza/templates/admin/base_site.html
+++ b/geniza/templates/admin/base_site.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block extrastyle %}
-    {% if SHOW_TEST_WARNING %}
+    {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
         <link rel="stylesheet" type="text/css" href="{% static "css/test-banner.css" %}" />
     {% endif %}
 {% endblock %}

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -39,7 +39,7 @@
 
         {% block extrameta %}{% endblock extrameta %}
         <!-- styles -->
-        {% if SHOW_TEST_WARNING %}
+        {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
             <link rel="stylesheet" type="text/css" href="{% static 'css/test-banner.css' %}"/>
         {% endif %}
         <!-- resource preloading -->
@@ -83,7 +83,7 @@
     </head>
     <body>
         {% wagtailuserbar 'bottom-right' %}
-        {% if SHOW_TEST_WARNING %}
+        {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
             {% include 'snippets/test_banner.html' %}
         {% endif %}
         {% block body %}

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -39,7 +39,7 @@
 
         {% block extrameta %}{% endblock extrameta %}
         <!-- styles -->
-        {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
+        {% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}
             <link rel="stylesheet" type="text/css" href="{% static 'css/test-banner.css' %}"/>
         {% endif %}
         <!-- resource preloading -->
@@ -83,7 +83,7 @@
     </head>
     <body>
         {% wagtailuserbar 'bottom-right' %}
-        {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
+        {% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}
             {% include 'snippets/test_banner.html' %}
         {% endif %}
         {% block body %}

--- a/geniza/templates/robots.txt
+++ b/geniza/templates/robots.txt
@@ -1,5 +1,5 @@
 {# logic copied from princeton-cdh/mep-django #}
 User-agent: *
-Disallow: {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}/{% else %}/admin{% endif %}
+Disallow: {% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}/{% else %}/admin{% endif %}
 {# Link to sitemap #}
 Sitemap: http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/sitemap.xml

--- a/geniza/templates/robots.txt
+++ b/geniza/templates/robots.txt
@@ -1,5 +1,5 @@
 {# logic copied from princeton-cdh/mep-django #}
 User-agent: *
-Disallow: {% if SHOW_TEST_WARNING %}/{% else %}/admin{% endif %}
+Disallow: {% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}/{% else %}/admin{% endif %}
 {# Link to sitemap #}
 Sitemap: http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/sitemap.xml

--- a/geniza/templates/snippets/test_banner.html
+++ b/geniza/templates/snippets/test_banner.html
@@ -1,9 +1,9 @@
-{% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
+{% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}
     <div class="ribbon-box fade">
         <div class="ribbon-wrapper">
             <div class="ribbon">
-                <p class="heading">{{ TEST_WARNING_HEADING|default_if_none:"This is a <strong>TEST</strong> site" }}</p>
-                <p>{{ TEST_WARNING_MESSAGE|default_if_none:"Content may change or be removed without warning" }}</p>
+                <p class="heading">{{ WARNING_BANNER_HEADING|default_if_none:"This is a <strong>TEST</strong> site" }}</p>
+                <p>{{ WARNING_BANNER_MESSAGE|default_if_none:"Content may change or be removed without warning" }}</p>
                 <button>OK</button>
             </div>
         </div>

--- a/geniza/templates/snippets/test_banner.html
+++ b/geniza/templates/snippets/test_banner.html
@@ -1,9 +1,9 @@
-{% if SHOW_TEST_WARNING %}
+{% if "SHOW_TEST_WARNING" in FEATURE_FLAGS %}
     <div class="ribbon-box fade">
         <div class="ribbon-wrapper">
             <div class="ribbon">
-                <p class="heading">This is a <b>TEST</b> site</p>
-                <p>Content may change or be removed without warning</p>
+                <p class="heading">{{ TEST_WARNING_HEADING|default_if_none:"This is a <strong>TEST</strong> site" }}</p>
+                <p>{{ TEST_WARNING_MESSAGE|default_if_none:"Content may change or be removed without warning" }}</p>
                 <button>OK</button>
             </div>
         </div>

--- a/sitemedia/css/test-banner.css
+++ b/sitemedia/css/test-banner.css
@@ -20,16 +20,16 @@
 .ribbon-box.fade button {
     display: none;
 }
+.ribbon-box .heading {
+    font-size: 1rem;
+    font-family: "Greta Sans Regular", Arial, sans-serif;
+}
 .ribbon-box strong {
     font-weight: bold;
     font-family: "Greta Sans Regular Bold", Arial, sans-serif;
 }
 .ribbon-box p {
     padding: 5px 80px;
-}
-.ribbon-box .heading {
-    font-size: 1rem;
-    font-family: "Greta Sans Regular", Arial, sans-serif;
 }
 .ribbon-box button {
     border: #f8f8f8;

--- a/sitemedia/css/test-banner.css
+++ b/sitemedia/css/test-banner.css
@@ -6,9 +6,12 @@
     top: 0;
     z-index: 11;
     background: transparent;
-    font-size: 14px;
+    font-size: 0.875rem;
     opacity: 0.95;
     transition: opacity 0.2s;
+}
+.ribbon-box * {
+    max-width: none;
 }
 .ribbon-box.fade {
     opacity: 0.3;
@@ -17,9 +20,16 @@
 .ribbon-box.fade button {
     display: none;
 }
+.ribbon-box strong {
+    font-weight: bold;
+    font-family: "Greta Sans Regular Bold", Arial, sans-serif;
+}
+.ribbon-box p {
+    padding: 5px 80px;
+}
 .ribbon-box .heading {
     font-size: 1rem;
-    font-family: "Lyon Text Web", Georgia, serif;
+    font-family: "Greta Sans Regular", Arial, sans-serif;
 }
 .ribbon-box button {
     border: #f8f8f8;

--- a/sitemedia/js/main.js
+++ b/sitemedia/js/main.js
@@ -34,3 +34,16 @@ function restoreScrollPosition(event) {
 
 window.addEventListener("turbo:before-cache", saveScrollPosition);
 window.addEventListener("turbo:visit", restoreScrollPosition);
+
+// Test banner/ribbon dismiss functionality
+const ribbon = document.querySelector(".ribbon");
+if (ribbon) {
+    const faded = sessionStorage.getItem("fade-test-banner", true);
+    if (!faded) {
+        document.querySelector(".ribbon-box").classList.remove("fade");
+    }
+    ribbon.addEventListener("click", function () {
+        document.querySelector(".ribbon-box").classList.add("fade");
+        sessionStorage.setItem("fade-test-banner", true);
+    });
+}


### PR DESCRIPTION
## In this PR

- Per #1150:
  - Restore test banner JS and update CSS (replace unused font; `max-width` and padding on `p` prevent viewport overflow issue)
  - Make test banner body/header text configurable
  - Use feature flag string instead of boolean

## Questions

- Do the config options need any documentation beyond just being present with comments in `local_settings.py.sample`? (e.g. deploy notes)