### PR TITLE
Fixing semicolon problem in iiif_urls

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -460,12 +460,9 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
                 # to make the download as efficient as possible, don't use
                 # absolutize_url, reverse, or get_absolute_url methods
                 f"{url_scheme}{site_domain}/documents/{doc.id}/",  # public site url
-                sep_within_cells.join(iiif_urls)
-                if any(iiif_urls)
-                else "",  # we're not omitting empty strings in the lists so that (in theory) you can match up the ones that go together across the different cells
-                sep_within_cells.join(view_urls)
-                if any(view_urls)
-                else "",  # same as in prev line
+                # we're not omitting empty strings in the lists so that (in theory) you can match up the ones that go together across the different cells
+                sep_within_cells.join(iiif_urls) if any(iiif_urls) else "",
+                sep_within_cells.join(view_urls) if any(view_urls) else "",
                 doc.shelfmark,  # shelfmark
                 sep_within_cells.join(s for s in multifrag if s),
                 sep_within_cells.join(s for s in side if s),  # side (recto/verso)

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -460,16 +460,16 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
                 # to make the download as efficient as possible, don't use
                 # absolutize_url, reverse, or get_absolute_url methods
                 f"{url_scheme}{site_domain}/documents/{doc.id}/",  # public site url
-                ";".join(iiif_urls) if any(iiif_urls) else "",
-                ";".join(view_urls) if any(view_urls) else "",
+                "; ".join(x for x in iiif_urls if x),
+                "; ".join(x for x in view_urls if x),
                 doc.shelfmark,  # shelfmark
-                ";".join([s for s in multifrag if s]),
-                ";".join([s for s in side if s]),  # side (recto/verso)
-                ";".join([r for r in region if r]),  # text block region
+                "; ".join(s for s in multifrag if s),
+                "; ".join(s for s in side if s),  # side (recto/verso)
+                "; ".join(r for r in region if r),  # text block region
                 doc.doctype,
                 doc.all_tags(),
                 doc.description,
-                ";".join([os for os in old_shelfmarks if os]),
+                "; ".join(os for os in old_shelfmarks if os),
                 doc.all_languages(),
                 doc.all_secondary_languages(),
                 doc.language_note,
@@ -482,12 +482,12 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
                 # default sort is most recent first, so initial input is last
                 all_log_entries.last().action_time if all_log_entries else "",
                 doc.last_modified,
-                ";".join(
+                "; ".join(
                     set([user.get_full_name() or user.username for user in input_users])
                 ),  # input by
                 doc.get_status_display(),
-                ";".join(libraries) if any(libraries) else "",
-                ";".join(collections) if any(collections) else "",
+                "; ".join(libraries) if any(libraries) else "",
+                "; ".join(collections) if any(collections) else "",
             ]
 
     csv_fields = [

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -406,7 +406,7 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
         """Generate filename for CSV download"""
         return f'geniza-documents-{timezone.now().strftime("%Y%m%dT%H%M%S")}.csv'
 
-    def tabulate_queryset(self, queryset):
+    def tabulate_queryset(self, queryset, sep_within_cells="; "):
         """Generator for data in tabular form, including custom fields"""
 
         script_user = settings.SCRIPT_USERNAME
@@ -460,16 +460,20 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
                 # to make the download as efficient as possible, don't use
                 # absolutize_url, reverse, or get_absolute_url methods
                 f"{url_scheme}{site_domain}/documents/{doc.id}/",  # public site url
-                "; ".join(x for x in iiif_urls if x),
-                "; ".join(x for x in view_urls if x),
+                sep_within_cells.join(iiif_urls)
+                if any(iiif_urls)
+                else "",  # we're not omitting empty strings in the lists so that (in theory) you can match up the ones that go together across the different cells
+                sep_within_cells.join(view_urls)
+                if any(view_urls)
+                else "",  # same as in prev line
                 doc.shelfmark,  # shelfmark
-                "; ".join(s for s in multifrag if s),
-                "; ".join(s for s in side if s),  # side (recto/verso)
-                "; ".join(r for r in region if r),  # text block region
+                sep_within_cells.join(s for s in multifrag if s),
+                sep_within_cells.join(s for s in side if s),  # side (recto/verso)
+                sep_within_cells.join(r for r in region if r),  # text block region
                 doc.doctype,
                 doc.all_tags(),
                 doc.description,
-                "; ".join(os for os in old_shelfmarks if os),
+                sep_within_cells.join(os for os in old_shelfmarks if os),
                 doc.all_languages(),
                 doc.all_secondary_languages(),
                 doc.language_note,
@@ -482,12 +486,12 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
                 # default sort is most recent first, so initial input is last
                 all_log_entries.last().action_time if all_log_entries else "",
                 doc.last_modified,
-                "; ".join(
+                sep_within_cells.join(
                     set([user.get_full_name() or user.username for user in input_users])
                 ),  # input by
                 doc.get_status_display(),
-                "; ".join(libraries) if any(libraries) else "",
-                "; ".join(collections) if any(collections) else "",
+                sep_within_cells.join(libraries) if any(libraries) else "",
+                sep_within_cells.join(collections) if any(collections) else "",
             ]
 
     csv_fields = [


### PR DESCRIPTION
This should be a fix for issue #883.

Switching join string from ';' to '; ' within fields of CSV export.

Currently the fix does this for all fields (IMO this looks cleaner and is more consistent) and not only the "iiif_urls" field.

The code also switches a few list comprehensions to safer (checks against empty strings) and generator version.