### PR TITLE
Exempt IIIF URIs from i18n patterns (#1164)

### DIFF
--- a/geniza/annotations/tests/test_annotations_signals.py
+++ b/geniza/annotations/tests/test_annotations_signals.py
@@ -26,7 +26,8 @@ class TestCreateOrDeleteFootnote:
                     "source": {
                         "partOf": {
                             "id": reverse(
-                                "corpus:document-manifest", kwargs={"pk": document.pk}
+                                "corpus-uris:document-manifest",
+                                kwargs={"pk": document.pk},
                             )
                         }
                     }

--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -172,7 +172,9 @@ class TestAnnotationSearch:
 
     def test_search_uri(self, client, document, annotation):
         # content__target__source__id=target_uri)
-        manifest_uri = reverse("corpus:document-manifest", kwargs={"pk": document.pk})
+        manifest_uri = reverse(
+            "corpus-uris:document-manifest", kwargs={"pk": document.pk}
+        )
         target_uri = "http://example.com/target/1"
         anno1 = Annotation.objects.create(
             content={
@@ -209,7 +211,9 @@ class TestAnnotationSearch:
         self, client, annotation, document, source, twoauthor_source
     ):
         # content__contains={"dc:source": source_uri}
-        manifest_uri = reverse("corpus:document-manifest", kwargs={"pk": document.pk})
+        manifest_uri = reverse(
+            "corpus-uris:document-manifest", kwargs={"pk": document.pk}
+        )
         source_uri = source.uri
         anno1 = Annotation.objects.create(
             content={**annotation.content, "dc:source": source_uri}

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -573,7 +573,7 @@ class Document(ModelIndexable, DocumentDateMixin):
         # will raise Resolver404 if url does not resolve
         resolve_match = resolve(urlparse(uri).path)
         # it could be a valid django url resolve but not be a manifest uri;
-        if resolve_match.view_name != "corpus:document-manifest":
+        if resolve_match.view_name != "corpus-uris:document-manifest":
             # is there a more appropriate exception to raise?
             raise Resolver404("Not a document manifest URL")
         return resolve_match.kwargs["pk"]
@@ -1036,7 +1036,7 @@ class Document(ModelIndexable, DocumentDateMixin):
         # manifest uri for the current document
         return "%s%s" % (
             settings.ANNOTATION_MANIFEST_BASE_URL,
-            reverse("corpus:document-manifest", args=[self.pk]),
+            reverse("corpus-uris:document-manifest", args=[self.pk]),
         )
 
     def merge_with(self, merge_docs, rationale, user=None):

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -107,7 +107,7 @@
                 </div>
                 <div class="transcription-panel">
                     {% if edit_mode %}
-                        <div class="annotate transcription" data-manifest="{% url 'corpus:document-manifest' document.pk %}">
+                        <div class="annotate transcription" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
                             {% if forloop.first %}
                                 {# Note: editor label/instructions are content admin-only and thus not translated. #}
                                 <h2>Transcribe</h2>

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1067,13 +1067,13 @@ class TestDocument:
     def test_manifest_uri(self, document):
         assert document.manifest_uri.startswith(settings.ANNOTATION_MANIFEST_BASE_URL)
         assert document.manifest_uri.endswith(
-            reverse("corpus:document-manifest", args=[document.pk])
+            reverse("corpus-uris:document-manifest", args=[document.pk])
         )
 
     def test_id_from_manifest_uri(self, document):
         # should resolve correct manifest URI to Document id
         resolved_doc_id = Document.id_from_manifest_uri(
-            reverse("corpus:document-manifest", kwargs={"pk": document.pk})
+            reverse("corpus-uris:document-manifest", kwargs={"pk": document.pk})
         )
         assert isinstance(resolved_doc_id, int)
         assert resolved_doc_id == document.pk
@@ -1085,7 +1085,7 @@ class TestDocument:
     def test_from_manifest_uri(self, document):
         # should resolve correct manifest URI to Document object
         resolved_doc = Document.from_manifest_uri(
-            reverse("corpus:document-manifest", kwargs={"pk": document.pk})
+            reverse("corpus-uris:document-manifest", kwargs={"pk": document.pk})
         )
         assert isinstance(resolved_doc, Document)
         assert resolved_doc.pk == document.pk

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -931,7 +931,7 @@ class TestDocumentScholarshipView:
 @patch("geniza.corpus.views.IIIFPresentation")
 @patch("geniza.corpus.models.IIIFPresentation")
 class TestDocumentManifestView:
-    view_name = "corpus:document-manifest"
+    view_name = "corpus-uris:document-manifest"
 
     def test_no_images_no_transcription(
         self,
@@ -1070,7 +1070,7 @@ class TestDocumentManifestView:
         assertContains(response, "sc:AnnotationList")
         # includes url for annotation list
         assertContains(
-            response, reverse("corpus:document-annotations", args=[document.pk])
+            response, reverse("corpus-uris:document-annotations", args=[document.pk])
         )
 
     def test_get_absolute_url(

--- a/geniza/corpus/uris.py
+++ b/geniza/corpus/uris.py
@@ -1,0 +1,19 @@
+from django.urls import path
+
+from geniza.corpus import views as corpus_views
+
+app_name = "corpus"
+
+# special set for IIIF urls that should not get i18n patterns
+urlpatterns = [
+    path(
+        "documents/<int:pk>/iiif/manifest/",
+        corpus_views.DocumentManifestView.as_view(),
+        name="document-manifest",
+    ),
+    path(
+        "documents/<int:pk>/iiif/annotations/",
+        corpus_views.DocumentAnnotationListView.as_view(),
+        name="document-annotations",
+    ),
+]

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -43,15 +43,5 @@ urlpatterns = [
         corpus_views.DocumentTranscriptionText.as_view(),
         name="document-transcription-text",
     ),
-    path(
-        "documents/<int:pk>/iiif/manifest/",
-        corpus_views.DocumentManifestView.as_view(),
-        name="document-manifest",
-    ),
-    path(
-        "documents/<int:pk>/iiif/annotations/",
-        corpus_views.DocumentAnnotationListView.as_view(),
-        name="document-annotations",
-    ),
     path("export/pgp-metadata-old/", corpus_views.pgp_metadata_for_old_site),
 ]

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -450,7 +450,7 @@ class DocumentManifestView(DocumentDetailView):
     incorporating available canvases and attaching transcription
     content via annotation."""
 
-    viewname = "corpus:document-manifest"
+    viewname = "corpus-uris:document-manifest"
 
     def get(self, request, *args, **kwargs):
         document = self.get_object()
@@ -535,7 +535,7 @@ class DocumentManifestView(DocumentDetailView):
             other_content = {
                 "@context": "http://iiif.io/api/presentation/2/context.json",
                 "@id": absolutize_url(
-                    reverse("corpus:document-annotations", args=[document.pk]),
+                    reverse("corpus-uris:document-annotations", args=[document.pk]),
                     request=request,  # request is needed to avoid getting https:// urls in dev
                 ),
                 "@type": "sc:AnnotationList",
@@ -555,7 +555,7 @@ class DocumentAnnotationListView(DocumentDetailView):
     """Generate a IIIF Annotation List for a document to make transcription
     content available for inclusion in local IIIF manifest."""
 
-    viewname = "corpus:document-annotations"
+    viewname = "corpus-uris:document-annotations"
 
     def get(self, request, *args, **kwargs):
         """handle GET request: construct and return JSON annotation list"""

--- a/geniza/urls.py
+++ b/geniza/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
         name="django.contrib.sitemaps.views.sitemap",
     ),
     path("cms/", include(wagtailadmin_urls)),
+    path("", include("geniza.corpus.uris", namespace="corpus-uris")),
     path("documents/", include(wagtaildocs_urls)),
     path("_500/", lambda _: 1 / 0),
 ]


### PR DESCRIPTION
Spent some time trying to get the regex pattern matching right until I finally realized I just needed to move this url config above the `documents/` match from wagtail 😂 

## In this PR

- Per #1164:
  - Move the IIIF URIs from `corpus/urls.py` to `corpus/uris.py`
  - Add additional url pattern in global `urls.py`, moving them to namespace `corpus-uris`
  - Update all references to the old namespace