### PR TITLE
document search improvements

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,10 @@
 # Deploy Notes
 
+## 4.10
+
+-   Solr configuration has changed. Ensure Solr configset has been updated
+    and then reindex all content: `python manage.py index`
+
 ## 4.9.0
 
 -   Must configure **ANNOTATION_BACKUP_PATH** and **ANNOTATION_BACKUP_GITREPO** in local settings. For proper setup, the directory at **ANNOTATION_BACKUP_PATH** should not exist when first run, but the containing directory should.

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -979,7 +979,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                 # (may need splitting out and weighting based on type of scholarship)
                 "scholarship_t": [fn.display() for fn in self.footnotes.all()],
                 # transcription content as html
-                "transcription_ht": transcription_texts,
+                "text_transcription": transcription_texts,
                 "has_digital_edition_b": bool(counts[Footnote.DIGITAL_EDITION]),
                 "has_translation_b": bool(counts[Footnote.TRANSLATION]),
                 "has_discussion_b": bool(counts[Footnote.DISCUSSION]),

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -42,7 +42,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "num_discussions": "num_discussions_i",
         "scholarship_count": "scholarship_count_i",
         "scholarship": "scholarship_t",
-        "transcription": "transcription_ht",
+        "transcription": "text_transcription",
         "language_code": "language_code_ss",
         "iiif_images": "iiif_images_ss",
         "iiif_labels": "iiif_labels_ss",

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -879,7 +879,7 @@ class TestDocument:
         assert index_data["has_digital_edition_b"] == True
         assert index_data["num_translations_i"] == 2
         assert index_data["scholarship_count_i"] == 3  # unique sources
-        assert index_data["transcription_ht"] == ["transcription lines"]
+        assert index_data["text_transcription"] == ["transcription lines"]
 
         for note in [edition, edition2, translation]:
             assert note.display() in index_data["scholarship_t"]

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -770,6 +770,24 @@ class TestDocumentSearchView:
         resulting_ids = [result["pgpid"] for result in qs]
         assert document.id in resulting_ids
 
+    def test_transcription_bigram(self, empty_solr, annotation):
+        # integration test for transcription indexing with bigram search
+        # - using empty solr fixture to ensure solr is empty when this test starts
+
+        # annotation with body content "test annotation"
+        document = Document.from_manifest_uri(annotation.target_source_manifest_id)
+        SolrClient().update.index([document.index_data()], commit=True)
+
+        docsearch_view = DocumentSearchView()
+        docsearch_view.request = Mock()
+        # sort doesn't matter in this case; two characters minimum
+        docsearch_view.request.GET = {"q": "st anno"}
+        qs = docsearch_view.get_queryset()
+        # should return the document
+        assert qs.count() == 1
+        resulting_ids = [result["pgpid"] for result in qs]
+        assert document.id in resulting_ids
+
     def test_search_shelfmark_override(self, empty_solr, document):
         orig_shelfmark = document.shelfmark
         document.shelfmark_override = "foo 12.34"

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -559,6 +559,11 @@ class TestDocumentSearchView:
         """integration test for sorting by shelfmark"""
         doc2 = Document.objects.create()
         TextBlock.objects.create(document=doc2, fragment=multifragment)
+        # create a third document with shelfmark that should come after
+        # one of ours only when natural sorting is enabled
+        doc3 = Document.objects.create()
+        frag3 = Fragment.objects.create(shelfmark="T-S 16.4")
+        TextBlock.objects.create(document=doc3, fragment=frag3)
         SolrClient().update.index(
             [
                 document.index_data(),  # shelfmark = CUL Add.2586
@@ -575,6 +580,10 @@ class TestDocumentSearchView:
         assert (
             qs[0]["pgpid"] == document.id
         ), "document with shelfmark CUL Add.2586 returned first"
+        # should return 16.4 before 16.377
+        assert (
+            qs[1]["pgpid"] == doc3.id
+        ), "document with shelfmark T-S 16.4 returned before T-S 16.377"
 
     def test_input_date_sort(self, document, join, empty_solr):
         """Tests for sorting by input date, ascending and descending"""

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -54,7 +54,7 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
         "scholarship_asc": "scholarship_count_i",
         "input_date_desc": "-input_date_dt",
         "input_date_asc": "input_date_dt",
-        "shelfmark": "shelfmark_s",
+        "shelfmark": "shelfmark_natsort",
         "docdate_asc": "start_date_i",
         "docdate_desc": "-end_date_i",
     }

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -119,6 +119,23 @@
     </analyzer>
   </fieldType>
 
+  <!-- natural sort field; adapted from https://stackoverflow.com/a/39701503 -->
+  <fieldType name="natural_sort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
+    <analyzer>
+      <!-- treat field as a single token -->
+      <tokenizer class="solr.KeywordTokenizerFactory"/>
+      <!-- lower case everything for case-insensitive sort -->
+      <filter class="solr.LowerCaseFilterFactory" />
+      <!-- strip whitespace -->
+      <filter class="solr.TrimFilterFactory" />
+      <!-- Left-pad numbers with zeroes -->
+      <filter class="solr.PatternReplaceFilterFactory"
+              pattern="(\d+)" replacement="00000$1" replace="all" />
+      <!-- Left-trim zeroes to produce 6 digit numbers -->
+      <filter class="solr.PatternReplaceFilterFactory"
+              pattern="0*([0-9]{6,})" replacement="$1" replace="all" />
+    </analyzer>
+  </fieldType>
 
   <!-- A text field with defaults appropriate for English: it
          tokenizes with StandardTokenizer, removes English stop words
@@ -208,6 +225,7 @@
 
   <copyField source="shelfmark_s" dest="shelfmark_bigram" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_textnum" maxChars="30000" />
+  <copyField source="shelfmark_s" dest="shelfmark_natsort" maxChars="30000" />
   <!-- individual shelfmarks -->
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_t" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_textnum" maxChars="30000" />
@@ -215,7 +233,7 @@
   <!-- old / historic shelfmarks -->
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_t" maxChars="30000" />
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_textnum" maxChars="30000" />
-  <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_bigram" maxChars="30000" />  
+  <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_bigram" maxChars="30000" />
   
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
   <copyField source="type_s" dest="type_t" maxChars="300" />
@@ -275,4 +293,6 @@
   <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
   <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
   <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
+  <dynamicField name="*_natsort" type="natural_sort" indexed="true" stored="true" sortMissingLast="true"/>
+
 </schema>

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -100,6 +100,25 @@
     </analyzer>
   </fieldType>
 
+   <!-- custom text field for transcriptions; html stripping, bigram, etc -->
+    <fieldType name="transcription_text" class="solr.TextField" positionIncrementGap="100" multiValued="true">
+    <analyzer type="index">
+      <charFilter class="solr.HTMLStripCharFilterFactory"/>
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.ICUFoldingFilterFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
+      <filter class="solr.NGramFilterFactory" minGramSize="2" maxGramSize="20" luceneMatchVersion="4.3"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+    <analyzer type="query">
+      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <filter class="solr.ICUFoldingFilterFactory"/>
+      <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
+      <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
+    </analyzer>
+  </fieldType>
+
 
   <!-- A text field with defaults appropriate for English: it
          tokenizes with StandardTokenizer, removes English stop words
@@ -251,6 +270,7 @@
   <dynamicField name="*_l" type="long" indexed="true" stored="true"/>
   <dynamicField name="*_t" type="text_general" indexed="true" stored="true"/>
   <dynamicField name="*_ht" type="html_text_general" indexed="true" stored="true"/>  
+  <dynamicField name="*_transcription" type="transcription_text" indexed="true" stored="true"/>  
   <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
   <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
   <dynamicField name="*_d" type="double" indexed="true" stored="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -756,17 +756,17 @@
         document_date_t
       </str>
       <str name="keyword_pf">
-        description_t^500
-        description_txt_ens^200
-        shelfmark_bigram^500
-        shelfmark_textnum^140   
+        description_t^100
+        description_txt_ens^75
+        shelfmark_bigram^750
+        shelfmark_textnum^750
         old_shelfmark_t
         old_shelfmark_textnum
         old_shelfmark_bigram^100
         tags_t
         scholarship_t^80
         text_transcription^1000
-        document_date_t^500
+        document_date_t^550
       </str>
 
        <!-- admin search field for Document model (no boosting because no relevance sort) -->

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -752,21 +752,21 @@
         tags_ss_lower
         scholarship_t
         old_pgpids_is
-        transcription_ht
+        text_transcription^30
         document_date_t
       </str>
       <str name="keyword_pf">
-        description_t^50
-        description_txt_ens^20
-        shelfmark_bigram^100
+        description_t^500
+        description_txt_ens^200
+        shelfmark_bigram^500
         shelfmark_textnum^140   
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram
+        old_shelfmark_bigram^100
         tags_t
         scholarship_t^80
-        transcription_ht^80
-        document_date_t
+        text_transcription^1000
+        document_date_t^500
       </str>
 
        <!-- admin search field for Document model (no boosting because no relevance sort) -->
@@ -774,7 +774,7 @@
         type_s
         shelfmark_bigram
         shelfmark_s
-        fragment_shelfmark_ss^50
+        fragment_shelfmark_ss
         shelfmark_textnum
         tags_t
         tags_ss_lower
@@ -785,7 +785,7 @@
         pgpid_i
         old_pgpids_is
         scholarship_t
-        transcription_ht
+        text_transcription
         fragment_old_shelfmark_ss
         old_shelfmark_t
         old_shelfmark_textnum
@@ -802,7 +802,7 @@
         notes_t
         needs_review_t
         scholarship_t
-        transcription_ht
+        text_transcription
         old_shelfmark_t
         old_shelfmark_textnum
         old_shelfmark_bigram


### PR DESCRIPTION
Solr config changes in this PR:
- new custom field for transcription text, with bigram filter #1174 
- revise boosting for date text #1151 and phrase matches across the board
- natural sorting for shelfmarks #1162 