### PR TITLE
Show alert toasts on transcription editor (#1176)

### DIFF
--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -31,6 +31,9 @@
         </span>
     </a>
 
+    {# alerts container, starts empty and is popualted by stimulus controller #}
+    <div id="alerts" data-controller="alert"></div>
+
     {# viewer #}
     {% include "corpus/snippets/document_transcription.html" with edit_mode=True %}
 {% endblock main %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.6",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "^1.0.0",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#432919994ac74e39646406d780a6309cf1bc4213",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -38,7 +38,7 @@
       }
     },
     "../annotorious-tahqiq": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2945,9 +2945,10 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "node_modules/annotorious-tahqiq": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.0.0.tgz",
-      "integrity": "sha512-RHfTd+LlNH3xA38FXQ4Uiprc/CqOEdFmlEmZ1VB27JQ3h2AkRUDpmSFmpsX/xkgA9esk5cce4vE/gPKh7Flobw==",
+      "version": "1.0.1",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#432919994ac74e39646406d780a6309cf1bc4213",
+      "integrity": "sha512-CgNgSsS8pCyUSBy6bT2Rich0AzUkfUl9a8yR1Yqy3nIgfDDaOehPM0Mn5ioXhWxj/dYmGgh6EXgaixGpfTcAzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"
@@ -11095,9 +11096,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.0.0.tgz",
-      "integrity": "sha512-RHfTd+LlNH3xA38FXQ4Uiprc/CqOEdFmlEmZ1VB27JQ3h2AkRUDpmSFmpsX/xkgA9esk5cce4vE/gPKh7Flobw==",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#432919994ac74e39646406d780a6309cf1bc4213",
+      "integrity": "sha512-CgNgSsS8pCyUSBy6bT2Rich0AzUkfUl9a8yR1Yqy3nIgfDDaOehPM0Mn5ioXhWxj/dYmGgh6EXgaixGpfTcAzQ==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#432919994ac74e39646406d780a6309cf1bc4213",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@recogito/annotorious-openseadragon": "^2.7.6",
     "@recogito/annotorious-toolbar": "^1.1.0",
     "angle-input": "^0.0.1",
-    "annotorious-tahqiq": "^1.0.0",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#432919994ac74e39646406d780a6309cf1bc4213",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/js/annotation.js
+++ b/sitemedia/js/annotation.js
@@ -6,6 +6,6 @@ const application = Application.start();
 const context = require.context(
     "./controllers",
     true,
-    /annotation_controller\.js$/
+    /(annotation_controller|alert_controller)\.js$/
 );
 application.load(definitionsFromContext(context));

--- a/sitemedia/js/controllers/alert_controller.js
+++ b/sitemedia/js/controllers/alert_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    initialize() {
+        // bind "this" so we can append elements
+        this.boundAlertHandler = this.handleAlert.bind(this);
+    }
+    connect() {
+        // avoid adding a duplicate event listener, it happens sometimes(?)
+        // regardless of the number of images on the page; bound to alerts
+        // div in document_transcribe.html... TODO: figure out why
+        if (!this.element.alertListenerInitialized) {
+            document.addEventListener("tahqiq-alert", this.boundAlertHandler);
+            this.element.alertListenerInitialized = true;
+        }
+    }
+    disconnect() {
+        document.removeEventListener("tahqiq-alert", this.boundAlertHandler);
+    }
+    handleAlert(evt) {
+        // create a new div with the alert message and appropriate classes
+        const { message, status } = evt.detail;
+        const alert = document.createElement("div");
+        alert.textContent = message;
+        alert.className = "alert alert-visible";
+        if (status) {
+            alert.classList.add(`alert-${status}`);
+        }
+
+        // append the alert as child of alerts div
+        this.element.appendChild(alert);
+
+        // longer timeout for error messages for readability
+        const timeout = status === "error" ? 5000 : 3000;
+
+        // remove visible class after timeout
+        setTimeout(() => {
+            alert.classList.remove("alert-visible");
+        }, timeout);
+
+        // remove child after transition completes (+350ms)
+        setTimeout(() => {
+            this.element.removeChild(alert);
+        }, timeout + 350);
+    }
+}

--- a/sitemedia/js/controllers/alert_controller.js
+++ b/sitemedia/js/controllers/alert_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
+// Controller for handling alert events and displaying "toast" alerts with their message contents.
+// used with tahqiq for now, but could be extended to other types of alert events.
 export default class extends Controller {
     initialize() {
         // bind "this" so we can append elements

--- a/sitemedia/scss/annotation.scss
+++ b/sitemedia/scss/annotation.scss
@@ -1,2 +1,3 @@
 @use "components/iiif";
 @use "components/annotation";
+@use "components/alert";

--- a/sitemedia/scss/base/_colors.scss
+++ b/sitemedia/scss/base/_colors.scss
@@ -79,6 +79,8 @@ $off-white: #f7f7f7;
     --tag-bg: #e5eee5;
     // selected language background color
     --selected-language: #f7f7f7;
+    // alert message border/text colors
+    --alert-success: #7bac7b;
 }
 
 // Dark mode theme colors
@@ -143,6 +145,8 @@ $off-white: #f7f7f7;
     --tag-bg: rgba(195, 127, 151, 0.2);
     // selected language background color
     --selected-language: #161616;
+    // alert message border/text colors
+    --alert-success: #436043;
 }
 
 html {

--- a/sitemedia/scss/base/_colors.scss
+++ b/sitemedia/scss/base/_colors.scss
@@ -79,8 +79,10 @@ $off-white: #f7f7f7;
     --tag-bg: #e5eee5;
     // selected language background color
     --selected-language: #f7f7f7;
-    // alert message border/text colors
+    // alert message border/text/background colors
     --alert-success: #7bac7b;
+    --alert-error: #ce2029;
+    --alert-error-text: #f7f7f7;
 }
 
 // Dark mode theme colors
@@ -145,8 +147,10 @@ $off-white: #f7f7f7;
     --tag-bg: rgba(195, 127, 151, 0.2);
     // selected language background color
     --selected-language: #161616;
-    // alert message border/text colors
+    // alert message border/text/background colors
     --alert-success: #436043;
+    --alert-error: #ce2029;
+    --alert-error-text: #f7f7f7;
 }
 
 html {

--- a/sitemedia/scss/components/_alert.scss
+++ b/sitemedia/scss/components/_alert.scss
@@ -46,8 +46,8 @@ div#alerts {
             // allow copy-paste
             pointer-events: all;
             opacity: 1;
-            color: white;
-            background-color: #ce2029;
+            background-color: var(--alert-error);
+            color: var(--alert-error-text);
         }
     }
 }

--- a/sitemedia/scss/components/_alert.scss
+++ b/sitemedia/scss/components/_alert.scss
@@ -1,0 +1,53 @@
+/* styles for transcription/annotation alerts, success/error messages */
+
+// alert container: fixed position in bottom middle of screen
+div#alerts {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    z-index: 50;
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+
+    // alerts appear from the bottom up
+    div.alert {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        min-width: 20rem;
+        height: 1rem;
+        padding: 1.25rem;
+        margin-bottom: 0.25rem;
+        background-color: var(--background-gray);
+        color: var(--on-background-light);
+        border: 2px solid var(--on-background-alt);
+        border-radius: 5px;
+        visibility: hidden;
+        opacity: 0;
+        flex-grow: 1;
+        // fade away in 300ms
+        transition: opacity 300ms, visibility 300ms;
+        // show alert; remove this class when time to hide
+        &.alert-visible {
+            opacity: 0.75;
+            visibility: visible;
+        }
+        // success msg
+        &.alert-success {
+            background-color: var(--alert-success);
+        }
+        // error msg, keeping this the same cross-theme to ensure it stands out
+        &.alert-error {
+            // allow copy-paste
+            pointer-events: all;
+            opacity: 1;
+            color: white;
+            background-color: #ce2029;
+        }
+    }
+}


### PR DESCRIPTION
## In this PR

see also https://github.com/Princeton-CDH/annotorious-tahqiq/pull/26

- Per #1176:
  - Add a new div for alerts bound to a new stimulus controller
  - In the new stimulus controller, listen for `tahqiq-alert` events, in order to populate div with alerts
  - Add basic styles for different alert statuses
  - Bump tahqiq commit hash

## Questions

- Please test locally, is the overall look and feel OK?
- Should we add publishing the new tahqiq + bumping the version number in PGP (if applicable) to the release checklist?