### PR TITLE
Transcription styles (#1194) and admin fixes (#1193, #1202)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -55,7 +55,7 @@
                 {% with document_highlights=highlighting|dict_item:document.id lang=document.language_code lang_script=document.language_script %}
                     <!-- indicate language when possible, or at least change of language (if unknown) for screen readers -->
                     {% if document_highlights.transcription or document.transcription %}
-                        <div class="transcription" lang="{{ lang }}" {% if lang_script %}data-lang-script="{{ lang_script|lower }}"{% endif %}>
+                        <div class="transcription" dir="rtl" lang="{{ lang }}" {% if lang_script %}data-lang-script="{{ lang_script|lower }}"{% endif %}>
 
                             {% if document_highlights.transcription %}
                                 {% for snippet in document_highlights.transcription %}{{ snippet.strip|safe }}{% endfor %}

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -105,7 +105,11 @@ a#needsreview:target {
     white-space: pre-line;
 }
 
-/* Transcription styles in admin */
+/*
+ *
+ * Transcription styles in admin
+ *
+ */
 @media (min-width: 900px) {
     .form-row #iiif-viewer {
         padding: 10px;
@@ -114,16 +118,45 @@ a#needsreview:target {
 #iiif-viewer .transcription.no-image {
     max-width: 100%;
 }
-/* rtl is controlled thru html "dir=" attribute */
-.transcription {
-    direction: rtl;
-    text-align: right;
+.form-row .transcription {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
 }
-.transcription h3,
-.transcription section h1 {
-    text-align: left;
-    direction: ltr;
-    font-size: 115%;
+/* need to apply these manually for overriding purposes */
+.form-row .transcription p,
+.form-row .transcription li {
+    font-size: 22px;
+}
+/* headers */
+.form-row .transcription h3 {
+    font-family: "Greta Sans Regular Bold", "Greta Sans Hebrew Bold",
+        "HassanLTBold", "arial-bold", sans-serif;
+}
+/* no script or hebrew script */
+.form-row .transcription p,
+.form-row .transcription li,
+.form-row .transcription[lang="he"] p,
+.form-row .transcription[lang="he"] li,
+.form-row .transcription[lang="jrb"] p,
+.form-row .transcription[lang="jrb"] li,
+.form-row .transcription[data-lang-script="hebrew"] p,
+.form-row .transcription[data-lang-script="hebrew"] li {
+    font-family: "FrankRuhl 1924 MF Medium", serif;
+    line-height: 32px;
+}
+/* arabic script */
+.form-row .transcription[lang="ar"] p,
+.form-row .transcription[lang="ar"] li,
+.form-row .transcription[data-lang-script="arabic"] p,
+.form-row .transcription[data-lang-script="arabic"] li {
+    font-family: "Amiri", serif;
+}
+.form-row .transcription h3 {
+    font-size: 20px;
+}
+
+.form-row .transcription-select ul {
+    margin-left: 0;
 }
 
 /* adjust spacing of decimal cover */

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -131,44 +131,21 @@ a#needsreview:target {
 .form-row .transcription h3 {
     font-family: "Greta Sans Regular Bold", "Greta Sans Hebrew Bold",
         "HassanLTBold", "arial-bold", sans-serif;
+    font-size: 20px;
 }
-/* no script or hebrew script */
 .form-row .transcription p,
-.form-row .transcription li,
-.form-row .transcription[lang="he"] p,
-.form-row .transcription[lang="he"] li,
-.form-row .transcription[lang="jrb"] p,
-.form-row .transcription[lang="jrb"] li,
-.form-row .transcription[data-lang-script="hebrew"] p,
-.form-row .transcription[data-lang-script="hebrew"] li {
-    font-family: "FrankRuhl 1924 MF Medium", serif;
+.form-row .transcription li {
+    font-family: "FrankRuhl 1924 MF Medium", "Amiri", "Times New Roman", serif;
     line-height: 32px;
 }
-/* arabic script */
 .form-row .transcription[lang="ar"] p,
 .form-row .transcription[lang="ar"] li,
 .form-row .transcription[data-lang-script="arabic"] p,
 .form-row .transcription[data-lang-script="arabic"] li {
-    font-family: "Amiri", serif;
+    line-height: 34px;
 }
-.form-row .transcription h3 {
-    font-size: 20px;
-}
-
 .form-row .transcription-select ul {
     margin-left: 0;
-}
-
-/* adjust spacing of decimal cover */
-#itt-panel
-    .panel-container
-    div.transcription-panel
-    .transcription
-    ol
-    li::before {
-    right: -38px;
-    line-height: 24px;
-    font-size: 35px;
 }
 
 /* remove overlays for non-document images in admin */

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -133,7 +133,9 @@ a#needsreview:target {
     .transcription
     ol
     li::before {
-    right: 163px;
+    right: -38px;
+    line-height: 24px;
+    font-size: 35px;
 }
 
 /* remove overlays for non-document images in admin */

--- a/sitemedia/js/annotation.js
+++ b/sitemedia/js/annotation.js
@@ -2,10 +2,10 @@ import { Application } from "@hotwired/stimulus";
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
 
 const application = Application.start();
-// only require annotation_controller.js
 const context = require.context(
     "./controllers",
     true,
-    /(annotation_controller|alert_controller)\.js$/
+    // only require annotation and alert controllers
+    /(annotation|alert)_controller\.js$/
 );
 application.load(definitionsFromContext(context));

--- a/sitemedia/js/controllers/alert_controller.js
+++ b/sitemedia/js/controllers/alert_controller.js
@@ -8,13 +8,7 @@ export default class extends Controller {
         this.boundAlertHandler = this.handleAlert.bind(this);
     }
     connect() {
-        // avoid adding a duplicate event listener, it happens sometimes(?)
-        // regardless of the number of images on the page; bound to alerts
-        // div in document_transcribe.html... TODO: figure out why
-        if (!this.element.alertListenerInitialized) {
-            document.addEventListener("tahqiq-alert", this.boundAlertHandler);
-            this.element.alertListenerInitialized = true;
-        }
+        document.addEventListener("tahqiq-alert", this.boundAlertHandler);
     }
     disconnect() {
         document.removeEventListener("tahqiq-alert", this.boundAlertHandler);

--- a/sitemedia/js/iiif.js
+++ b/sitemedia/js/iiif.js
@@ -2,10 +2,10 @@ import { Application } from "@hotwired/stimulus";
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
 
 const application = Application.start();
-// only require iiif_controller.js
 const context = require.context(
     "./controllers",
     true,
-    /(iiif_controller|transcription_controller)\.js$/
+    // only require iiif and transcription controllers
+    /(iiif|transcription)_controller\.js$/
 );
 application.load(definitionsFromContext(context));

--- a/sitemedia/js/iiif.js
+++ b/sitemedia/js/iiif.js
@@ -3,5 +3,9 @@ import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
 
 const application = Application.start();
 // only require iiif_controller.js
-const context = require.context("./controllers", true, /iiif_controller\.js$/);
+const context = require.context(
+    "./controllers",
+    true,
+    /(iiif_controller|transcription_controller)\.js$/
+);
 application.load(definitionsFromContext(context));

--- a/sitemedia/js/main.js
+++ b/sitemedia/js/main.js
@@ -3,11 +3,12 @@ import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
 import * as Turbo from "@hotwired/turbo";
 
 const application = Application.start();
-// exclude iiif_controller.js
+// NOTE: Any new controllers that should not be part of this bundle must be explicitly excluded
 const context = require.context(
     "./controllers",
     true,
-    /^.*\/(?!iiif_controller)(?!annotation_controller)(?!alert_controller)(?!transcription_controller).*\.js$/
+    // exclude alert, annotation, iiif, and transcription controllers using negative lookahead
+    /^.*\/(?!iiif)(?!annotation)(?!alert)(?!transcription).*_controller.*\.js$/
 );
 application.load(definitionsFromContext(context));
 

--- a/sitemedia/js/main.js
+++ b/sitemedia/js/main.js
@@ -7,7 +7,7 @@ const application = Application.start();
 const context = require.context(
     "./controllers",
     true,
-    /^.*\/(?!iiif_controller)(?!annotation_controller).*\.js$/
+    /^.*\/(?!iiif_controller)(?!annotation_controller)(?!alert_controller)(?!transcription_controller).*\.js$/
 );
 application.load(definitionsFromContext(context));
 

--- a/sitemedia/scss/base/_fonts.scss
+++ b/sitemedia/scss/base/_fonts.scss
@@ -87,17 +87,6 @@
         font-display: swap;
     }
 
-    // Frank Ruhl1924 MF Medium for Hebrew text (transcriptions)
-    @font-face {
-        font-family: "FrankRuhl 1924 MF Medium";
-        font-style: normal;
-        src: url("#{$base_url}/FrankRuhl1924MF-Medium-Medium.woff2")
-                format("woff2"),
-            url("#{$base_url}/FrankRuhl1924MF-Medium-Medium.woff")
-                format("woff");
-        font-display: swap;
-    }
-
     // HassanLTLight for Arabic text
     @font-face {
         font-family: "HassanLTLight";
@@ -120,6 +109,22 @@
         font-display: swap;
     }
 
+    // Frank Ruhl1924 MF Medium for Hebrew text (transcriptions)
+    @font-face {
+        font-family: "FrankRuhl 1924 MF Medium";
+        font-style: normal;
+        src: url("#{$base_url}/FrankRuhl1924MF-Medium-Medium.woff2")
+                format("woff2"),
+            url("#{$base_url}/FrankRuhl1924MF-Medium-Medium.woff")
+                format("woff");
+        font-display: swap;
+        unicode-range:
+            // Hebrew
+            U+0590-05FF,
+            // Hebrew presentation forms
+            U+FB1D-FB4F;
+    }
+
     // Amiri for Arabic text (transcriptions)
     @font-face {
         font-family: "Amiri";
@@ -127,6 +132,29 @@
         src: url("#{$base_url}/Amiri-Regular.woff2") format("woff2"),
             url("#{$base_url}/Amiri-Regular.woff") format("woff");
         font-display: swap;
+        unicode-range:
+            // Arabic
+            U+600-6FF,
+            // Arabic Supplement
+            U+750-77F,
+            // Arabic Extended-A
+            U+08A0-08FF,
+            // Arabic Extended-B
+            U+0870-089F,
+            // Arabic Extended-C
+            U+10EC0-10EFF,
+            // Arabic Presentation Forms-A
+            U+FB50-FDFF,
+            // Arabic Presentation Forms-B
+            U+FE70-FEFF,
+            // Rumi Numeral Symbols
+            U+10E60-10E7F,
+            // Indic Siyaq Numbers
+            U+1EC70-1ECBF,
+            // Ottoman Siyaq Numbers
+            U+1ED00-1ED4F,
+            // Arabic Mathematical Alphabetic Symbols
+            U+1EE00-1EEFF;
     }
 }
 
@@ -191,8 +219,6 @@ $primary-semibold: (
 );
 $primary-italic: ("Greta Sans Regular Italic", "arial-italic", sans-serif);
 
-// Hebrew transcriptions
-$hebrew: ("FrankRuhl 1924 MF Medium", serif);
-
-// Arabic transcriptions
-$arabic: ("Amiri", serif);
+// Transcriptions (Combined Hebrew and Arabic, chosen by Unicode character,
+// with Times New Roman for missing glyphs)
+$transcription: ("FrankRuhl 1924 MF Medium", "Amiri", "Times New Roman", serif);

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -422,7 +422,7 @@ $text-size-5xl: 2rem; //     = 32px
     }
 }
 @mixin language-switch-he {
-    font-family: "FrankRuhl 1924 MF Medium";
+    font-family: fonts.$transcription;
     font-size: $text-size-xl;
     @include breakpoints.for-tablet-landscape-up {
         font-size: calc(26rem / 16);

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -286,24 +286,24 @@ $text-size-5xl: 2rem; //     = 32px
 // hebrew, arabic transcriptions on search results +
 // doc detail
 @mixin transcription {
-    font-family: fonts.$primary;
+    font-family: fonts.$transcription;
     font-size: $text-size-xl;
-    @include breakpoints.for-tablet-landscape-up {
-        font-size: $text-size-2xl;
-    }
-}
-@mixin hebrew-transcription {
-    font-family: fonts.$hebrew;
     line-height: calc(27 / 20);
     @include breakpoints.for-tablet-landscape-up {
         line-height: calc(32 / 22);
+        font-size: $text-size-2xl;
     }
 }
 @mixin arabic-transcription {
-    font-family: fonts.$arabic;
-    line-height: calc(27 / 20);
     @include breakpoints.for-tablet-landscape-up {
         line-height: calc(34 / 22);
+    }
+}
+@mixin transcription-numerals {
+    font-family: fonts.$primary-semibold;
+    font-size: $text-size-md;
+    @include breakpoints.for-tablet-landscape-up {
+        font-size: $text-size-xl;
     }
 }
 
@@ -422,7 +422,7 @@ $text-size-5xl: 2rem; //     = 32px
     }
 }
 @mixin language-switch-he {
-    @include hebrew-transcription;
+    font-family: "FrankRuhl 1924 MF Medium";
     font-size: $text-size-xl;
     @include breakpoints.for-tablet-landscape-up {
         font-size: calc(26rem / 16);

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -283,7 +283,7 @@ $text-size-5xl: 2rem; //     = 32px
     }
 }
 
-// hebrew transcriptions on search results +
+// hebrew, arabic transcriptions on search results +
 // doc detail
 @mixin transcription {
     font-family: fonts.$primary;
@@ -292,13 +292,18 @@ $text-size-5xl: 2rem; //     = 32px
         font-size: $text-size-2xl;
     }
 }
-// TODO: Use classes to only use this on hebrew transcriptions
-// (currently used on all transcriptions)
-@mixin hebrew {
+@mixin hebrew-transcription {
     font-family: fonts.$hebrew;
     line-height: calc(27 / 20);
     @include breakpoints.for-tablet-landscape-up {
         line-height: calc(32 / 22);
+    }
+}
+@mixin arabic-transcription {
+    font-family: fonts.$arabic;
+    line-height: calc(27 / 20);
+    @include breakpoints.for-tablet-landscape-up {
+        line-height: calc(34 / 22);
     }
 }
 
@@ -417,7 +422,7 @@ $text-size-5xl: 2rem; //     = 32px
     }
 }
 @mixin language-switch-he {
-    @include hebrew;
+    @include hebrew-transcription;
     font-size: $text-size-xl;
     @include breakpoints.for-tablet-landscape-up {
         font-size: calc(26rem / 16);

--- a/sitemedia/scss/base/_typography.scss
+++ b/sitemedia/scss/base/_typography.scss
@@ -301,10 +301,6 @@ $text-size-5xl: 2rem; //     = 32px
 }
 @mixin transcription-numerals {
     font-family: fonts.$primary-semibold;
-    font-size: $text-size-md;
-    @include breakpoints.for-tablet-landscape-up {
-        font-size: $text-size-xl;
-    }
 }
 
 // most form elements

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -231,12 +231,15 @@ section#document-list {
     .transcription li {
         direction: rtl;
         list-style-type: none; /* hide automatic ol numbering */
+        display: flex;
+        align-items: flex-end;
         &::before {
+            @include typography.transcription-numerals;
             content: attr(value);
             margin-right: -2rem; /* shift outside text margin */
+            margin-left: 1.5rem;
             text-align: right;
             float: right;
-            font-weight: bold;
         }
     }
 

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -231,15 +231,13 @@ section#document-list {
     .transcription li {
         direction: rtl;
         list-style-type: none; /* hide automatic ol numbering */
-        display: flex;
-        align-items: flex-end;
         &::before {
             @include typography.transcription-numerals;
             content: attr(value);
             margin-right: -2rem; /* shift outside text margin */
-            margin-left: 1.5rem;
             text-align: right;
             float: right;
+            height: 100%;
         }
     }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -934,7 +934,25 @@ a.editor-navigation {
 // appear in ITT viewer and in search results
 .transcription {
     @include typography.transcription;
-    @include typography.hebrew;
+
+    // hebrew by default, in case there are no lang/script attributes
+    @include typography.hebrew-transcription;
+
+    // hebrew script
+    &[lang="he"],
+    &[lang="jrb"],
+    &[data-lang-script="hebrew"] {
+        @include typography.hebrew-transcription;
+    }
+
+    // arabic script
+    &[lang="ar"],
+    &[data-lang-script="arabic"] {
+        @include typography.arabic-transcription;
+    }
+
+    overflow: hidden; // prevent scroll trap in transcription div
+
     align-self: flex-end;
 
     text-align: right;
@@ -1006,6 +1024,19 @@ a.editor-navigation {
         @include breakpoints.for-tablet-landscape-up {
             line-height: 24px;
             right: -38.5px;
+        }
+    }
+
+    // decimal cover adjustments for arabic
+    &[lang="ar"] ol li:not([value])::before,
+    &[data-lang-script="arabic"] ol li:not([value])::before {
+        font-size: 37px;
+        width: 37px;
+        line-height: 19px;
+        right: -41px;
+        @include breakpoints.for-tablet-landscape-up {
+            line-height: 27px;
+            right: -41.5px;
         }
     }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -991,8 +991,7 @@ a.editor-navigation {
         font-weight: bold;
         text-align: left;
         position: absolute;
-        width: 32px;
-        right: -37px;
+        width: 34px;
         /* text color should match background, rendering period invisible */
         color: var(--background-light);
         /* uncomment to debug positioning
@@ -1000,11 +999,13 @@ a.editor-navigation {
 
         /* make font larger than list number font to cover completely;
            shrink line height to adjust placement */
-        font-size: 32px;
-        line-height: 23px;
+        font-size: 34px;
+        line-height: 16px;
+        right: -37.5px;
 
         @include breakpoints.for-tablet-landscape-up {
-            line-height: 28px; /* smaller line height to adjust */
+            line-height: 24px;
+            right: -38.5px;
         }
     }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -792,6 +792,9 @@
         div.editions {
             display: flex;
             overflow-x: hidden;
+            overflow-y: clip; // prevent overflow-y scrollbar
+            // NOTE: setting different properties for overflow-x and y does not work in Safari.
+            // carousel still works, but overflow-y scrollbar may remain.
             & > div {
                 flex: 1 0 100%;
                 align-self: flex-start;
@@ -935,18 +938,6 @@ a.editor-navigation {
 .transcription {
     @include typography.transcription;
 
-    // hebrew by default, in case there are no lang/script attributes
-    @include typography.hebrew-transcription;
-
-    // hebrew script
-    &[lang="he"],
-    &[lang="jrb"],
-    &[data-lang-script="hebrew"],
-    span[lang="he"],
-    span[lang="jrb"] {
-        @include typography.hebrew-transcription;
-    }
-
     // arabic script
     &[lang="ar"],
     &[data-lang-script="arabic"],
@@ -1004,10 +995,10 @@ a.editor-navigation {
 
     /* don't apply to li with value attribute in search results */
     ol li:not([value])::before {
+        @include typography.transcription-numerals;
         /* content is a copy of ONLY the period we want to hide
            to avoid obscuring anything else should position be off */
         content: ".";
-        font-weight: bold;
         text-align: left;
         position: absolute;
         width: 35px;
@@ -1018,34 +1009,22 @@ a.editor-navigation {
 
         /* make font larger than list number font to cover completely;
            shrink line height to adjust placement */
-        font-size: 35px;
-        line-height: 16px;
-        right: -37.5px;
-
-        @include breakpoints.for-tablet-landscape-up {
-            line-height: 24px;
-            right: -39.5px;
-        }
-    }
-
-    // decimal cover adjustments for arabic
-    &[lang="ar"] ol li:not([value])::before,
-    &[data-lang-script="arabic"] ol li:not([value])::before {
+        right: -35.5px;
         font-size: 37px;
-        width: 37px;
-        line-height: 19px;
-        right: -41px;
+        line-height: 22px;
+
         @include breakpoints.for-tablet-landscape-up {
-            line-height: 27px;
-            right: -41.5px;
+            font-size: 38px;
+            line-height: 26px;
+            right: -36.5px;
         }
     }
 
     // NOTE: Broken in stable Safari for now, but fixed in Safari preview release.
     li::marker {
+        @include typography.transcription-numerals;
         text-align: right;
         float: right;
-        font-weight: bold;
     }
 }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1025,6 +1025,10 @@ a.editor-navigation {
         @include typography.transcription-numerals;
         text-align: right;
         float: right;
+        font-size: typography.$text-size-md;
+        @include breakpoints.for-tablet-landscape-up {
+            font-size: typography.$text-size-xl;
+        }
     }
 }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -941,17 +941,18 @@ a.editor-navigation {
     // hebrew script
     &[lang="he"],
     &[lang="jrb"],
-    &[data-lang-script="hebrew"] {
+    &[data-lang-script="hebrew"],
+    span[lang="he"],
+    span[lang="jrb"] {
         @include typography.hebrew-transcription;
     }
 
     // arabic script
     &[lang="ar"],
-    &[data-lang-script="arabic"] {
+    &[data-lang-script="arabic"],
+    span[lang="ar"] {
         @include typography.arabic-transcription;
     }
-
-    overflow: hidden; // prevent scroll trap in transcription div
 
     align-self: flex-end;
 
@@ -1009,7 +1010,7 @@ a.editor-navigation {
         font-weight: bold;
         text-align: left;
         position: absolute;
-        width: 34px;
+        width: 35px;
         /* text color should match background, rendering period invisible */
         color: var(--background-light);
         /* uncomment to debug positioning
@@ -1017,13 +1018,13 @@ a.editor-navigation {
 
         /* make font larger than list number font to cover completely;
            shrink line height to adjust placement */
-        font-size: 34px;
+        font-size: 35px;
         line-height: 16px;
         right: -37.5px;
 
         @include breakpoints.for-tablet-landscape-up {
             line-height: 24px;
-            right: -38.5px;
+            right: -39.5px;
         }
     }
 
@@ -1040,6 +1041,7 @@ a.editor-navigation {
         }
     }
 
+    // NOTE: Broken in stable Safari for now, but fixed in Safari preview release.
     li::marker {
         text-align: right;
         float: right;


### PR DESCRIPTION
## In this PR

- Per #1194:
  - Apply Arabic type styles, and conditional type styles using inline lang attributes, to transcriptions
  - Adjust decimal cover
- Per #1193:
  - Apply proper fonts, sizes, line heights, decimal cover to transcription viewer in admin
- Per #1202:
  - Add digital edition switcher to admin (move it to `iiif` bundle from `main`)
- Ensure `alert_controller` excluded from `main` bundle (it should only be in `annotation`; this is why I was getting double `connect`s in Stimulus)

## Questions

- Should this include what we discussed with [`dir` attributes in the HTML](https://www.w3.org/International/questions/qa-html-dir)? If so, should I just apply RTL to all transcriptions for now, or do we want logic to determine it based on language direction?
