### PR TITLE
Add ISSN to footer (#1195)

### DIFF
--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-10-14 11:19-0400\n"
+"POT-Creation-Date: 2022-10-14 12:15-0400\n"
 "PO-Revision-Date: 2022-09-22 19:18\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -19,146 +19,143 @@ msgstr ""
 "X-Crowdin-File-ID: 12\n"
 
 #. Translators: placeholder for keyword search input
-#: geniza/corpus/forms.py:161
+#: corpus/forms.py:161
 msgid "search by keyword"
 msgstr "البحث بواسطة الكلمة المفتاحية"
 
 #. Translators: accessible label for keyword search input
-#: geniza/corpus/forms.py:163
+#: corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr "الكلمة المفتاحية أو العبارة"
 
 #. Translators: label for sort by relevance
-#: geniza/corpus/forms.py:172
+#: corpus/forms.py:172
 msgid "Relevance"
 msgstr "الصلة"
 
 #. Translators: label for sort in random order
-#: geniza/corpus/forms.py:174
+#: corpus/forms.py:174
 msgid "Random"
 msgstr "عشوائي"
 
 #. Translators: label for sort by document date (most recent first)
-#: geniza/corpus/forms.py:176
+#: corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr "تاريخ المستند (الأحدث - الأقدم)"
 
 #. Translators: label for sort by document date (oldest first)
-#: geniza/corpus/forms.py:178
+#: corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr "تاريخ المستند (الأقدم - الأحدث)"
 
 #. Translators: label for alphabetical sort by shelfmark
-#: geniza/corpus/forms.py:180
+#: corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr "علامة الرف (أ-ي)"
 
 #. Translators: label for descending sort by number of scholarship records
-#: geniza/corpus/forms.py:182
+#: corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr "ثبت المراجع والمصادر (أكثر - أقل)"
 
 #. Translators: label for ascending sort by number of scholarship records
-#: geniza/corpus/forms.py:184
+#: corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr "ثبت المراجع والمصادر (أقل - أكثر)"
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: geniza/corpus/forms.py:186
+#: corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr "تاريخ الإدخال (الأحدث - الأقدم)"
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: geniza/corpus/forms.py:188
+#: corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr "تاريخ إدخال PGP (الأقدم - الأحدث)"
 
 #. Translators: label for start year when filtering by date range
-#: geniza/corpus/forms.py:191
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:191 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr "من عام"
 
 #. Translators: label for end year when filtering by date range
-#: geniza/corpus/forms.py:193
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:193 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr "إلى عام"
 
 #. Translators: label for form sort field
-#: geniza/corpus/forms.py:201
+#: corpus/forms.py:201
 msgid "Sort by"
 msgstr "الترتيب حسب"
 
-#: geniza/corpus/forms.py:208
+#: corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr "تواريخ المستند (التقويم الميلادي)"
 
 #. Translators: label for document type search form filter
-#: geniza/corpus/forms.py:217
+#: corpus/forms.py:217
 msgid "Document Type"
 msgstr "نوع المستند"
 
 #. Translators: label for "has image" search form filter
-#: geniza/corpus/forms.py:221
+#: corpus/forms.py:221
 msgid "Has Image"
 msgstr "لديه صورة"
 
 #. Translators: label for "has transcription" search form filter
-#: geniza/corpus/forms.py:225
+#: corpus/forms.py:225
 msgid "Has Transcription"
 msgstr "لديه نسخ"
 
 #. Translators: label for "has translation" search form filter
-#: geniza/corpus/forms.py:229
+#: corpus/forms.py:229
 msgid "Has Translation"
 msgstr "لديه ترجمة"
 
 #. Translators: label for "has discussion" search form filter
-#: geniza/corpus/forms.py:233
+#: corpus/forms.py:233
 msgid "Has Discussion"
 msgstr "لديه مناقشة"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
-#: geniza/corpus/templates/corpus/snippets/document_header.html:17
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+#: corpus/forms.py:279 corpus/solr_queryset.py:152
+#: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:95
 msgid "Unknown type"
 msgstr "نوع غير معروف"
 
-#: geniza/corpus/forms.py:311
+#: corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث بواسطة كلمة مفتاحية."
 
-#: geniza/corpus/models.py:911 geniza/templates/base.html:21
+#: corpus/models.py:911 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: geniza/corpus/models.py:913
+#: corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "تجميع بواسطة %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: geniza/corpus/models.py:916
+#: corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "التجميع والنسخ بواسطة %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/models.py:918
+#: corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr "قد تطبق قيود إضافية."
 
 #. Translators: label for 'home' link in footer navigation
-#: geniza/corpus/templates/admin/corpus/app_index.html:9
-#: geniza/templates/footer.html:12
+#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
 msgid "Home"
 msgstr "الصفحة الرئيسية"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
+#: corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] "مستندات أخرى على هذه العلامة"
@@ -169,8 +166,8 @@ msgstr[4] "مستندات أخرى على هذه العلامات"
 msgstr[5] "مستندات أخرى على هذه العلامات"
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:17
-#: geniza/corpus/templates/corpus/document_detail.html:50
+#: corpus/templates/corpus/document_detail.html:17
+#: corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] "محرر"
@@ -181,22 +178,22 @@ msgstr[4] "المحررون"
 msgstr[5] "المحررون"
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr "بيانات التعريف"
 
-#: geniza/corpus/templates/corpus/document_detail.html:45
+#: corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr "علامة الرف"
 
 #. Translators: label for date of this document, if known
-#: geniza/corpus/templates/corpus/document_detail.html:69
-#: geniza/corpus/templates/corpus/snippets/document_result.html:22
+#: corpus/templates/corpus/document_detail.html:69
+#: corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr "تاريخ الوثيقة"
 
 #. Translators: Primary language label
-#: geniza/corpus/templates/corpus/document_detail.html:80
+#: corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "اللغة الأساسية"
@@ -207,7 +204,7 @@ msgstr[4] "اللغات الأساسية"
 msgstr[5] "اللغات الأساسية"
 
 #. Translators: Secondary language label
-#: geniza/corpus/templates/corpus/document_detail.html:93
+#: corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "اللغة الثانوية"
@@ -218,18 +215,18 @@ msgstr[4] "اللغات الثانوية"
 msgstr[5] "اللغات الثانوية"
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:109
-#: geniza/corpus/templates/corpus/snippets/document_result.html:112
+#: corpus/templates/corpus/document_detail.html:109
+#: corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr "العلامات"
 
 #. Translators: Label for date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:122
+#: corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "تاريخ الإدخال"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:124
+#: corpus/templates/corpus/document_detail.html:124
 #, python-format
 msgid ""
 "\n"
@@ -241,36 +238,36 @@ msgstr ""
 "            "
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:132
+#: corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr "الوصف"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:146
+#: corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr "رابط دائم"
 
 #. Translators: Search submit button
-#: geniza/corpus/templates/corpus/document_list.html:14
+#: corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr "إرسال البحث"
 
-#: geniza/corpus/templates/corpus/document_list.html:19
-#: geniza/corpus/templates/corpus/document_list.html:30
+#: corpus/templates/corpus/document_list.html:19
+#: corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr "عوامل التصفية"
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: geniza/corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr "إغلاق خيارات التصفية"
 
-#: geniza/corpus/templates/corpus/document_list.html:60
+#: corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr "تطبيق"
 
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:87
+#: corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -282,55 +279,55 @@ msgstr[4] "%(count_humanized)s نتائج"
 msgstr[5] "%(count_humanized)s مجموع النتائج"
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: geniza/corpus/templates/corpus/document_scholarship.html:21
+#: corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr "الاقتباس المرجعي"
 
 #. Translators: label for included document relations for a single footnote
-#: geniza/corpus/templates/corpus/document_scholarship.html:28
+#: corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr "يشمل"
 
 #. Translators: label for document relations in list of footnotes
-#: geniza/corpus/templates/corpus/document_scholarship.html:31
+#: corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr "لرؤية %(relation)s"
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: geniza/corpus/templates/corpus/document_scholarship.html:36
+#: corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr "يشمل %(relation)s"
 
 #. Translators: Document edit link for admins
-#: geniza/corpus/templates/corpus/snippets/document_header.html:9
+#: corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr "تحرير"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
+#: corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr "بيان أذونات الصورة"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
+#: corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr "لم يتم ملاحظة أي إسناد أو ترخيص."
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
+#: corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr "الصفحة الرئيسية Jewish Theological Seminary"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
+#: corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr "شعار Jewish Theological Seminary"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/snippets/document_result.html:31
+#: corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr "في PGP منذ"
 
 #. Translators: number of editions for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:77
+#: corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -342,7 +339,7 @@ msgstr[4] "%(counter)s نسخ"
 msgstr[5] "%(counter)s نسخ"
 
 #. Translators: number of translations for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:87
+#: corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -354,7 +351,7 @@ msgstr[4] "%(counter)s ترجمات"
 msgstr[5] "%(counter)s ترجمات"
 
 #. Translators: number of sources that discuss this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:97
+#: corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -365,60 +362,60 @@ msgstr[3] "%(counter)s مناقشات"
 msgstr[4] "%(counter)s مناقشات"
 msgstr[5] "%(counter)s مناقشات"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:105
+#: corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr "لا توجد ثبت المراجع والمصادر"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:119
+#: corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr "المزيد"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:138
+#: corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr "عرض تفاصيل المستند"
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
+#: corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr "علامات التبويب"
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
+#: corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr "تفاصيل المستند"
 
 #. Translators: n_records is number of scholarship records
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
+#: corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr "ثبت المراجع والمصادر (%(n_records)s)"
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
+#: corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr "المستندات ذات الصلة %(n_reldocs)s)"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
+#: corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr "عرض الصور"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
+#: corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr "عرض النسخ"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
+#: corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr "عرض الترجمة"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
+#: corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr "تكبير و تدوير"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
+#: corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "عرض %(related_doc)s"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+#: corpus/templates/corpus/snippets/document_transcription.html:128
 #, fuzzy
 #| msgid "1 Transcription"
 #| msgid_plural "%(counter)s Transcriptions"
@@ -426,43 +423,43 @@ msgid "Transcription"
 msgstr "%(counter)s نسخ"
 
 #. Translators: label for a link to a resource with no named location
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
+#: corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr "مورد عبر الإنترنت"
 
 #. Translators: Label for "previous page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:5
+#: corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr "السابق"
 
 #. Translators: Title for link to page number in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:19
+#: corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr "صفحة %(number)s"
 
 #. Translators: Label for "next page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:60
+#: corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr "التالي"
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:42
+#: corpus/views.py:42
 msgid "Search Documents"
 msgstr "البحث في المستندات"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:44
+#: corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:350
+#: corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "منحة في %(doc)s"
 
-#: geniza/corpus/views.py:357
+#: corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -474,12 +471,12 @@ msgstr[4] "%(count)d سجلات منح دراسية"
 msgstr[5] "%(count)d سجلات منح دراسية"
 
 #. Translators: title of related documents page
-#: geniza/corpus/views.py:398
+#: corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "المستندات ذات الصلة لـ %(doc)s"
 
-#: geniza/corpus/views.py:405
+#: corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -491,29 +488,29 @@ msgstr[4] "%(count)d مستندات ذات صلة"
 msgstr[5] "%(count)d مستندات ذات صلة"
 
 #. Translators: Placeholder for when a work has no title available
-#: geniza/footnotes/models.py:211
+#: footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr "[طبعة وثيقة جينيزا رقمية]"
 
-#: geniza/footnotes/models.py:438
+#: footnotes/models.py:438
 msgid "Edition"
 msgstr "الطبعة"
 
-#: geniza/footnotes/models.py:439
+#: footnotes/models.py:439
 msgid "Translation"
 msgstr "الترجمة"
 
-#: geniza/footnotes/models.py:440
+#: footnotes/models.py:440
 msgid "Discussion"
 msgstr "المناقشة"
 
-#: geniza/footnotes/models.py:441
+#: footnotes/models.py:441
 #, fuzzy
 #| msgid "Edition"
 msgid "Digital Edition"
 msgstr "الطبعة"
 
-#: geniza/pages/models.py:13
+#: pages/models.py:13
 msgid ""
 "Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
@@ -521,7 +518,7 @@ msgstr ""
 "نص بديل للمستخدمين ضعاف البصر\n"
 "لإيصال الرسالة المقصودة للصورة في هذا السياق بإيجاز."
 
-#: geniza/pages/models.py:44
+#: pages/models.py:44
 msgid ""
 "This text will only be read to     non-sighted users and should describe the "
 "major insights or     takeaways from the graphic. Multiple paragraphs are "
@@ -531,131 +528,131 @@ msgstr ""
 "الرئيسية من الرسوم. يسمح بفقرات متعددة."
 
 #. Translators: title for Not Found (404) error page
-#: geniza/templates/404.html:5 geniza/templates/404.html:13
+#: templates/404.html:5 templates/404.html:13
 msgid "Not Found"
 msgstr "لم يتم العثور عليه"
 
 #. Translators: description for Not Found (404) error page
-#: geniza/templates/404.html:7 geniza/templates/404.html:14
+#: templates/404.html:7 templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr "عفواً، لقد أصبت فراغ! لم يتم العثور على الصفحة."
 
 #. Translators: title for Internal Server Error (500) error page
-#: geniza/templates/500.html:5 geniza/templates/500.html:19
+#: templates/500.html:5 templates/500.html:19
 msgid "Server Error"
 msgstr "خطأ في الخادم"
 
 #. Translators: description for Internal Server Error (500) error page
-#: geniza/templates/500.html:7 geniza/templates/500.html:20
+#: templates/500.html:7 templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr "حدث خطأ في وضع هذه الصفحة معا."
 
-#: geniza/templates/admin/base_site.html:4
+#: templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr "مسؤول موقع Django"
 
-#: geniza/templates/base.html:91
+#: templates/base.html:91
 msgid "Skip to main content"
 msgstr "تخطي إلى المحتوى الرئيسي"
 
 #. Translators: accessibility text label for footer site navigation
-#: geniza/templates/footer.html:4
+#: templates/footer.html:4
 msgid "footer navigation"
 msgstr "التنقل في التذييل"
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: geniza/templates/footer.html:21
+#: templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr "الصفحة الرئيسية لـ Princeton Geniza Lab"
 
-#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
+#: templates/footer.html:28 templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: geniza/templates/footer.html:35
+#: templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr "الصفحة الرئيسية لـ Princeton Center for Digital Humanities"
 
-#: geniza/templates/footer.html:46
+#: templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: geniza/templates/footer.html:56
+#: templates/footer.html:56
 msgid "Accessibility"
 msgstr "إمكانية الوصول"
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: geniza/templates/footer.html:61
+#: templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr "The Trustees of Princeton University"
 
 #. Translators: Creative Commons license text, for footer
-#: geniza/templates/footer.html:65
+#: templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr "ترخيص Creative Commons CC-BY"
 
 #. Translators: International Standard Serial Number (ISSN), for footer
-#: geniza/templates/footer.html:72
+#: templates/footer.html:72
 msgid "ISSN: 2834-4146"
 msgstr ""
 
 #. Translators: software version, for footer
-#: geniza/templates/footer.html:76
+#: templates/footer.html:76
 msgid "software version"
 msgstr "إصدار البرنامج"
 
 #. Translators: official name of Princeton University, for footer
-#: geniza/templates/footer.html:83
+#: templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr "الصفحة الرئيسية لـ Princeton University"
 
 #. Translators: accessibility text label for site navigation
-#: geniza/templates/nav.html:4
+#: templates/nav.html:4
 msgid "main navigation"
 msgstr "التنقل الرئيسي"
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: geniza/templates/nav.html:11
+#: templates/nav.html:11
 msgid "home"
 msgstr "الصفحة الرئيسية"
 
 #. Translators: site name label for 'home' button in main navigation
-#: geniza/templates/nav.html:13
+#: templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr "The Princeton Geniza Project"
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: geniza/templates/nav.html:24
+#: templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr "فتح قائمة التنقل الرئيسية"
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: geniza/templates/nav.html:32
+#: templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr "إغلاق قائمة التنقل الرئيسية"
 
 #. Translators: label for language choices in navigation
-#: geniza/templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "قراءة هذه الصفحة في %(language_name)s (%(language_code)s)"
 
 #. Translators: label for link to 'Search' page in main navigation
-#: geniza/templates/snippets/menu.html:7
+#: templates/snippets/menu.html:7
 msgid "Search"
 msgstr "بحث"
 
 #. Translators: label for main menu back button for mobile navigation
-#: geniza/templates/snippets/sub_menu.html:8
+#: templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr "العودة إلى القائمة الرئيسية"
 
 #. Translators: label for dark mode/light mode theme switcher
-#: geniza/templates/snippets/theme_toggle.html:5
+#: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
 

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-08 11:23-0400\n"
+"Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
+"POT-Creation-Date: 2022-10-14 11:19-0400\n"
 "PO-Revision-Date: 2022-09-22 19:18\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: ar\n"
@@ -18,143 +19,146 @@ msgstr ""
 "X-Crowdin-File-ID: 12\n"
 
 #. Translators: placeholder for keyword search input
-#: corpus/forms.py:152
+#: geniza/corpus/forms.py:161
 msgid "search by keyword"
 msgstr "البحث بواسطة الكلمة المفتاحية"
 
 #. Translators: accessible label for keyword search input
-#: corpus/forms.py:154
+#: geniza/corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr "الكلمة المفتاحية أو العبارة"
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:163
+#: geniza/corpus/forms.py:172
 msgid "Relevance"
 msgstr "الصلة"
 
 #. Translators: label for sort in random order
-#: corpus/forms.py:165
+#: geniza/corpus/forms.py:174
 msgid "Random"
 msgstr "عشوائي"
 
 #. Translators: label for sort by document date (most recent first)
-#: corpus/forms.py:167
+#: geniza/corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr "تاريخ المستند (الأحدث - الأقدم)"
 
 #. Translators: label for sort by document date (oldest first)
-#: corpus/forms.py:169
+#: geniza/corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr "تاريخ المستند (الأقدم - الأحدث)"
 
 #. Translators: label for alphabetical sort by shelfmark
-#: corpus/forms.py:171
+#: geniza/corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr "علامة الرف (أ-ي)"
 
 #. Translators: label for descending sort by number of scholarship records
-#: corpus/forms.py:173
+#: geniza/corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr "ثبت المراجع والمصادر (أكثر - أقل)"
 
 #. Translators: label for ascending sort by number of scholarship records
-#: corpus/forms.py:175
+#: geniza/corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr "ثبت المراجع والمصادر (أقل - أكثر)"
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: corpus/forms.py:177
+#: geniza/corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr "تاريخ الإدخال (الأحدث - الأقدم)"
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: corpus/forms.py:179
+#: geniza/corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr "تاريخ إدخال PGP (الأقدم - الأحدث)"
 
 #. Translators: label for start year when filtering by date range
-#: corpus/forms.py:182 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:191
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr "من عام"
 
 #. Translators: label for end year when filtering by date range
-#: corpus/forms.py:184 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:193
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr "إلى عام"
 
 #. Translators: label for form sort field
-#: corpus/forms.py:192
+#: geniza/corpus/forms.py:201
 msgid "Sort by"
 msgstr "الترتيب حسب"
 
-#: corpus/forms.py:202
+#: geniza/corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr "تواريخ المستند (التقويم الميلادي)"
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:211
+#: geniza/corpus/forms.py:217
 msgid "Document Type"
 msgstr "نوع المستند"
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:215
+#: geniza/corpus/forms.py:221
 msgid "Has Image"
 msgstr "لديه صورة"
 
 #. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:219
+#: geniza/corpus/forms.py:225
 msgid "Has Transcription"
 msgstr "لديه نسخ"
 
 #. Translators: label for "has translation" search form filter
-#: corpus/forms.py:223
+#: geniza/corpus/forms.py:229
 msgid "Has Translation"
 msgstr "لديه ترجمة"
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:227
+#: geniza/corpus/forms.py:233
 msgid "Has Discussion"
 msgstr "لديه مناقشة"
 
-#: corpus/forms.py:277
+#. Translators: Default label when document does not have a type
+#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
+#: geniza/corpus/templates/corpus/snippets/document_header.html:17
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+msgid "Unknown type"
+msgstr "نوع غير معروف"
+
+#: geniza/corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث بواسطة كلمة مفتاحية."
 
-#: corpus/models.py:799 templates/base.html:21
+#: geniza/corpus/models.py:911 geniza/templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:801
+#: geniza/corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "تجميع بواسطة %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:804
+#: geniza/corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "التجميع والنسخ بواسطة %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:806
+#: geniza/corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr "قد تطبق قيود إضافية."
 
-#. Translators: Default label when document does not have a type
-#: corpus/models.py:858
-#: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:77
-msgid "Unknown type"
-msgstr "نوع غير معروف"
-
 #. Translators: label for 'home' link in footer navigation
-#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
+#: geniza/corpus/templates/admin/corpus/app_index.html:9
+#: geniza/templates/footer.html:12
 msgid "Home"
 msgstr "الصفحة الرئيسية"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: corpus/templates/admin/corpus/document/change_form.html:41
+#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] "مستندات أخرى على هذه العلامة"
@@ -165,8 +169,8 @@ msgstr[4] "مستندات أخرى على هذه العلامات"
 msgstr[5] "مستندات أخرى على هذه العلامات"
 
 #. Translators: Editor label
-#: corpus/templates/corpus/document_detail.html:17
-#: corpus/templates/corpus/document_detail.html:50
+#: geniza/corpus/templates/corpus/document_detail.html:17
+#: geniza/corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] "محرر"
@@ -177,22 +181,22 @@ msgstr[4] "المحررون"
 msgstr[5] "المحررون"
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr "بيانات التعريف"
 
-#: corpus/templates/corpus/document_detail.html:45
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr "علامة الرف"
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:69
-#: corpus/templates/corpus/snippets/document_result.html:22
+#: geniza/corpus/templates/corpus/document_detail.html:69
+#: geniza/corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr "تاريخ الوثيقة"
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:80
+#: geniza/corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "اللغة الأساسية"
@@ -203,7 +207,7 @@ msgstr[4] "اللغات الأساسية"
 msgstr[5] "اللغات الأساسية"
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:93
+#: geniza/corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "اللغة الثانوية"
@@ -214,62 +218,59 @@ msgstr[4] "اللغات الثانوية"
 msgstr[5] "اللغات الثانوية"
 
 #. Translators: label for tags on a document
-#: corpus/templates/corpus/document_detail.html:109
-#: corpus/templates/corpus/snippets/document_result.html:107
+#: geniza/corpus/templates/corpus/document_detail.html:109
+#: geniza/corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr "العلامات"
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:122
+#: geniza/corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "تاريخ الإدخال"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:124
+#: geniza/corpus/templates/corpus/document_detail.html:124
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                In PGP since %(date)s\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "                في PGP منذ %(date)s\n"
 "            "
 
 #. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:132
+#: geniza/corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr "الوصف"
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:161
+#: geniza/corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr "رابط دائم"
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:14
+#: geniza/corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr "إرسال البحث"
 
-#: corpus/templates/corpus/document_list.html:19
-#: corpus/templates/corpus/document_list.html:30
+#: geniza/corpus/templates/corpus/document_list.html:19
+#: geniza/corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr "عوامل التصفية"
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:25
+#: geniza/corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr "إغلاق خيارات التصفية"
 
-#: corpus/templates/corpus/document_list.html:60
+#: geniza/corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr "تطبيق"
 
-#. Translators: Button to open or close sort options menu
-#: corpus/templates/corpus/document_list.html:76
-msgid "Toggle sort options menu"
-msgstr "تبديل قائمة خيارات الترتيب"
-
 #. Translators: number of search results
-#: corpus/templates/corpus/document_list.html:99
+#: geniza/corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -281,55 +282,55 @@ msgstr[4] "%(count_humanized)s نتائج"
 msgstr[5] "%(count_humanized)s مجموع النتائج"
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: corpus/templates/corpus/document_scholarship.html:21
+#: geniza/corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr "الاقتباس المرجعي"
 
 #. Translators: label for included document relations for a single footnote
-#: corpus/templates/corpus/document_scholarship.html:28
+#: geniza/corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr "يشمل"
 
 #. Translators: label for document relations in list of footnotes
-#: corpus/templates/corpus/document_scholarship.html:31
+#: geniza/corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr "لرؤية %(relation)s"
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: corpus/templates/corpus/document_scholarship.html:36
+#: geniza/corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr "يشمل %(relation)s"
 
 #. Translators: Document edit link for admins
-#: corpus/templates/corpus/snippets/document_header.html:9
+#: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr "تحرير"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:4
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr "بيان أذونات الصورة"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:21
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr "لم يتم ملاحظة أي إسناد أو ترخيص."
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:38
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr "الصفحة الرئيسية Jewish Theological Seminary"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:40
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr "شعار Jewish Theological Seminary"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:31
+#: geniza/corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr "في PGP منذ"
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:72
+#: geniza/corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -341,7 +342,7 @@ msgstr[4] "%(counter)s نسخ"
 msgstr[5] "%(counter)s نسخ"
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:82
+#: geniza/corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -353,7 +354,7 @@ msgstr[4] "%(counter)s ترجمات"
 msgstr[5] "%(counter)s ترجمات"
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:92
+#: geniza/corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -364,97 +365,104 @@ msgstr[3] "%(counter)s مناقشات"
 msgstr[4] "%(counter)s مناقشات"
 msgstr[5] "%(counter)s مناقشات"
 
-#: corpus/templates/corpus/snippets/document_result.html:100
+#: geniza/corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr "لا توجد ثبت المراجع والمصادر"
 
-#: corpus/templates/corpus/snippets/document_result.html:114
+#: geniza/corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr "المزيد"
 
-#: corpus/templates/corpus/snippets/document_result.html:133
+#: geniza/corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr "عرض تفاصيل المستند"
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: corpus/templates/corpus/snippets/document_tabs.html:4
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr "علامات التبويب"
 
-#: corpus/templates/corpus/snippets/document_tabs.html:7
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr "تفاصيل المستند"
 
 #. Translators: n_records is number of scholarship records
-#: corpus/templates/corpus/snippets/document_tabs.html:10
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr "ثبت المراجع والمصادر (%(n_records)s)"
 
-#: corpus/templates/corpus/snippets/document_tabs.html:17
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr "المستندات ذات الصلة %(n_reldocs)s)"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:6
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr "عرض الصور"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:10
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr "عرض النسخ"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:14
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr "عرض الترجمة"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:56
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr "تكبير و تدوير"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:80
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "عرض %(related_doc)s"
 
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Transcription"
+msgstr "%(counter)s نسخ"
+
 #. Translators: label for a link to a resource with no named location
-#: corpus/templates/corpus/snippets/footnote_location.html:9
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr "مورد عبر الإنترنت"
 
 #. Translators: Label for "previous page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:5
+#: geniza/corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr "السابق"
 
 #. Translators: Title for link to page number in search results
-#: corpus/templates/corpus/snippets/pagination.html:19
+#: geniza/corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr "صفحة %(number)s"
 
 #. Translators: Label for "next page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:60
+#: geniza/corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr "التالي"
 
 #. Translators: title of document search page
-#: corpus/views.py:36
+#: geniza/corpus/views.py:42
 msgid "Search Documents"
 msgstr "البحث في المستندات"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:38
+#: geniza/corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:339
+#: geniza/corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "منحة في %(doc)s"
 
-#: corpus/views.py:346
+#: geniza/corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -466,12 +474,12 @@ msgstr[4] "%(count)d سجلات منح دراسية"
 msgstr[5] "%(count)d سجلات منح دراسية"
 
 #. Translators: title of related documents page
-#: corpus/views.py:387
+#: geniza/corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "المستندات ذات الصلة لـ %(doc)s"
 
-#: corpus/views.py:394
+#: geniza/corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -483,159 +491,177 @@ msgstr[4] "%(count)d مستندات ذات صلة"
 msgstr[5] "%(count)d مستندات ذات صلة"
 
 #. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:201
+#: geniza/footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr "[طبعة وثيقة جينيزا رقمية]"
 
-#: footnotes/models.py:410
+#: geniza/footnotes/models.py:438
 msgid "Edition"
 msgstr "الطبعة"
 
-#: footnotes/models.py:411
+#: geniza/footnotes/models.py:439
 msgid "Translation"
 msgstr "الترجمة"
 
-#: footnotes/models.py:412
+#: geniza/footnotes/models.py:440
 msgid "Discussion"
 msgstr "المناقشة"
 
-#: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+#: geniza/footnotes/models.py:441
+#, fuzzy
+#| msgid "Edition"
+msgid "Digital Edition"
+msgstr "الطبعة"
+
+#: geniza/pages/models.py:13
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "نص بديل للمستخدمين ضعاف البصر\n"
+msgstr ""
+"نص بديل للمستخدمين ضعاف البصر\n"
 "لإيصال الرسالة المقصودة للصورة في هذا السياق بإيجاز."
 
-#: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار الرئيسية من الرسوم. يسمح بفقرات متعددة."
+#: geniza/pages/models.py:44
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار "
+"الرئيسية من الرسوم. يسمح بفقرات متعددة."
 
 #. Translators: title for Not Found (404) error page
-#: templates/404.html:5 templates/404.html:13
+#: geniza/templates/404.html:5 geniza/templates/404.html:13
 msgid "Not Found"
 msgstr "لم يتم العثور عليه"
 
 #. Translators: description for Not Found (404) error page
-#: templates/404.html:7 templates/404.html:14
+#: geniza/templates/404.html:7 geniza/templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr "عفواً، لقد أصبت فراغ! لم يتم العثور على الصفحة."
 
 #. Translators: title for Internal Server Error (500) error page
-#: templates/500.html:5 templates/500.html:19
+#: geniza/templates/500.html:5 geniza/templates/500.html:19
 msgid "Server Error"
 msgstr "خطأ في الخادم"
 
 #. Translators: description for Internal Server Error (500) error page
-#: templates/500.html:7 templates/500.html:20
+#: geniza/templates/500.html:7 geniza/templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr "حدث خطأ في وضع هذه الصفحة معا."
 
-#: templates/admin/base_site.html:4
+#: geniza/templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr "مسؤول موقع Django"
 
-#: templates/base.html:80
+#: geniza/templates/base.html:91
 msgid "Skip to main content"
 msgstr "تخطي إلى المحتوى الرئيسي"
 
 #. Translators: accessibility text label for footer site navigation
-#: templates/footer.html:4
+#: geniza/templates/footer.html:4
 msgid "footer navigation"
 msgstr "التنقل في التذييل"
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: templates/footer.html:21
+#: geniza/templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr "الصفحة الرئيسية لـ Princeton Geniza Lab"
 
-#: templates/footer.html:28 templates/footer.html:42
+#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: templates/footer.html:35
+#: geniza/templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr "الصفحة الرئيسية لـ Princeton Center for Digital Humanities"
 
-#: templates/footer.html:46
+#: geniza/templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: templates/footer.html:56
+#: geniza/templates/footer.html:56
 msgid "Accessibility"
 msgstr "إمكانية الوصول"
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: templates/footer.html:61
+#: geniza/templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr "The Trustees of Princeton University"
 
 #. Translators: Creative Commons license text, for footer
-#: templates/footer.html:65
+#: geniza/templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr "ترخيص Creative Commons CC-BY"
 
+#. Translators: International Standard Serial Number (ISSN), for footer
+#: geniza/templates/footer.html:72
+msgid "ISSN: 2834-4146"
+msgstr ""
+
 #. Translators: software version, for footer
-#: templates/footer.html:72
+#: geniza/templates/footer.html:76
 msgid "software version"
 msgstr "إصدار البرنامج"
 
 #. Translators: official name of Princeton University, for footer
-#: templates/footer.html:79
+#: geniza/templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr "الصفحة الرئيسية لـ Princeton University"
 
 #. Translators: accessibility text label for site navigation
-#: templates/nav.html:4
+#: geniza/templates/nav.html:4
 msgid "main navigation"
 msgstr "التنقل الرئيسي"
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: templates/nav.html:11
+#: geniza/templates/nav.html:11
 msgid "home"
 msgstr "الصفحة الرئيسية"
 
 #. Translators: site name label for 'home' button in main navigation
-#: templates/nav.html:13
+#: geniza/templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr "The Princeton Geniza Project"
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: templates/nav.html:24
+#: geniza/templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr "فتح قائمة التنقل الرئيسية"
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: templates/nav.html:32
+#: geniza/templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr "إغلاق قائمة التنقل الرئيسية"
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:15
+#: geniza/templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "قراءة هذه الصفحة في %(language_name)s (%(language_code)s)"
 
-#. Translators: button on language chooser in navigation
-#: templates/snippets/language_switcher.html:24
-msgctxt "choose this option"
-msgid "go"
-msgstr "تنقل"
-
 #. Translators: label for link to 'Search' page in main navigation
-#: templates/snippets/menu.html:7
+#: geniza/templates/snippets/menu.html:7
 msgid "Search"
 msgstr "بحث"
 
 #. Translators: label for main menu back button for mobile navigation
-#: templates/snippets/sub_menu.html:8
+#: geniza/templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr "العودة إلى القائمة الرئيسية"
 
 #. Translators: label for dark mode/light mode theme switcher
-#: templates/snippets/theme_toggle.html:5
+#: geniza/templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
 
+#~ msgid "Toggle sort options menu"
+#~ msgstr "تبديل قائمة خيارات الترتيب"
+
+#~ msgctxt "choose this option"
+#~ msgid "go"
+#~ msgstr "تنقل"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-10-14 11:19-0400\n"
+"POT-Creation-Date: 2022-10-14 12:15-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -18,201 +18,198 @@ msgstr ""
 "X-Crowdin-File-ID: 28\n"
 
 #. Translators: placeholder for keyword search input
-#: geniza/corpus/forms.py:161
+#: corpus/forms.py:161
 msgid "search by keyword"
 msgstr ""
 
 #. Translators: accessible label for keyword search input
-#: geniza/corpus/forms.py:163
+#: corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr ""
 
 #. Translators: label for sort by relevance
-#: geniza/corpus/forms.py:172
+#: corpus/forms.py:172
 msgid "Relevance"
 msgstr ""
 
 #. Translators: label for sort in random order
-#: geniza/corpus/forms.py:174
+#: corpus/forms.py:174
 msgid "Random"
 msgstr ""
 
 #. Translators: label for sort by document date (most recent first)
-#: geniza/corpus/forms.py:176
+#: corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr ""
 
 #. Translators: label for sort by document date (oldest first)
-#: geniza/corpus/forms.py:178
+#: corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr ""
 
 #. Translators: label for alphabetical sort by shelfmark
-#: geniza/corpus/forms.py:180
+#: corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr ""
 
 #. Translators: label for descending sort by number of scholarship records
-#: geniza/corpus/forms.py:182
+#: corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr ""
 
 #. Translators: label for ascending sort by number of scholarship records
-#: geniza/corpus/forms.py:184
+#: corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr ""
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: geniza/corpus/forms.py:186
+#: corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr ""
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: geniza/corpus/forms.py:188
+#: corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr ""
 
 #. Translators: label for start year when filtering by date range
-#: geniza/corpus/forms.py:191
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:191 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr ""
 
 #. Translators: label for end year when filtering by date range
-#: geniza/corpus/forms.py:193
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:193 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr ""
 
 #. Translators: label for form sort field
-#: geniza/corpus/forms.py:201
+#: corpus/forms.py:201
 msgid "Sort by"
 msgstr ""
 
-#: geniza/corpus/forms.py:208
+#: corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr ""
 
 #. Translators: label for document type search form filter
-#: geniza/corpus/forms.py:217
+#: corpus/forms.py:217
 msgid "Document Type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: geniza/corpus/forms.py:221
+#: corpus/forms.py:221
 msgid "Has Image"
 msgstr ""
 
 #. Translators: label for "has transcription" search form filter
-#: geniza/corpus/forms.py:225
+#: corpus/forms.py:225
 msgid "Has Transcription"
 msgstr ""
 
 #. Translators: label for "has translation" search form filter
-#: geniza/corpus/forms.py:229
+#: corpus/forms.py:229
 msgid "Has Translation"
 msgstr ""
 
 #. Translators: label for "has discussion" search form filter
-#: geniza/corpus/forms.py:233
+#: corpus/forms.py:233
 msgid "Has Discussion"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
-#: geniza/corpus/templates/corpus/snippets/document_header.html:17
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+#: corpus/forms.py:279 corpus/solr_queryset.py:152
+#: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:95
 msgid "Unknown type"
 msgstr ""
 
-#: geniza/corpus/forms.py:311
+#: corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
-#: geniza/corpus/models.py:911 geniza/templates/base.html:21
+#: corpus/models.py:911 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests
-#: geniza/corpus/models.py:913
+#: corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: geniza/corpus/models.py:916
+#: corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr ""
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/models.py:918
+#: corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr ""
 
 #. Translators: label for 'home' link in footer navigation
-#: geniza/corpus/templates/admin/corpus/app_index.html:9
-#: geniza/templates/footer.html:12
+#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
 msgid "Home"
 msgstr "Home"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
+#: corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:17
-#: geniza/corpus/templates/corpus/document_detail.html:50
+#: corpus/templates/corpus/document_detail.html:17
+#: corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/document_detail.html:45
+#: corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr ""
 
 #. Translators: label for date of this document, if known
-#: geniza/corpus/templates/corpus/document_detail.html:69
-#: geniza/corpus/templates/corpus/snippets/document_result.html:22
+#: corpus/templates/corpus/document_detail.html:69
+#: corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr ""
 
 #. Translators: Primary language label
-#: geniza/corpus/templates/corpus/document_detail.html:80
+#: corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Secondary language label
-#: geniza/corpus/templates/corpus/document_detail.html:93
+#: corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:109
-#: geniza/corpus/templates/corpus/snippets/document_result.html:112
+#: corpus/templates/corpus/document_detail.html:109
+#: corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr ""
 
 #. Translators: Label for date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:122
+#: corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:124
+#: corpus/templates/corpus/document_detail.html:124
 #, python-format
 msgid ""
 "\n"
@@ -221,36 +218,36 @@ msgid ""
 msgstr ""
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:132
+#: corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr ""
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:146
+#: corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr ""
 
 #. Translators: Search submit button
-#: geniza/corpus/templates/corpus/document_list.html:14
+#: corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/document_list.html:19
-#: geniza/corpus/templates/corpus/document_list.html:30
+#: corpus/templates/corpus/document_list.html:19
+#: corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr ""
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: geniza/corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/document_list.html:60
+#: corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr ""
 
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:87
+#: corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -258,55 +255,55 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: geniza/corpus/templates/corpus/document_scholarship.html:21
+#: corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr ""
 
 #. Translators: label for included document relations for a single footnote
-#: geniza/corpus/templates/corpus/document_scholarship.html:28
+#: corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr ""
 
 #. Translators: label for document relations in list of footnotes
-#: geniza/corpus/templates/corpus/document_scholarship.html:31
+#: corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr ""
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: geniza/corpus/templates/corpus/document_scholarship.html:36
+#: corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr ""
 
 #. Translators: Document edit link for admins
-#: geniza/corpus/templates/corpus/snippets/document_header.html:9
+#: corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
+#: corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
+#: corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
+#: corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
+#: corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr ""
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/snippets/document_result.html:31
+#: corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr ""
 
 #. Translators: number of editions for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:77
+#: corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -314,7 +311,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of translations for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:87
+#: corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -322,108 +319,108 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of sources that discuss this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:97
+#: corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:105
+#: corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:119
+#: corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:138
+#: corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr ""
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
+#: corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
+#: corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr ""
 
 #. Translators: n_records is number of scholarship records
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
+#: corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
+#: corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
+#: corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
+#: corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
+#: corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
+#: corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
+#: corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr ""
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+#: corpus/templates/corpus/snippets/document_transcription.html:128
 msgid "Transcription"
 msgstr ""
 
 #. Translators: label for a link to a resource with no named location
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
+#: corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr ""
 
 #. Translators: Label for "previous page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:5
+#: corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr ""
 
 #. Translators: Title for link to page number in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:19
+#: corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr ""
 
 #. Translators: Label for "next page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:60
+#: corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr ""
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:42
+#: corpus/views.py:42
 msgid "Search Documents"
 msgstr "Search Documents"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:44
+#: corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:350
+#: corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr ""
 
-#: geniza/corpus/views.py:357
+#: corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -431,12 +428,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of related documents page
-#: geniza/corpus/views.py:398
+#: corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr ""
 
-#: geniza/corpus/views.py:405
+#: corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -444,33 +441,33 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Placeholder for when a work has no title available
-#: geniza/footnotes/models.py:211
+#: footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr ""
 
-#: geniza/footnotes/models.py:438
+#: footnotes/models.py:438
 msgid "Edition"
 msgstr ""
 
-#: geniza/footnotes/models.py:439
+#: footnotes/models.py:439
 msgid "Translation"
 msgstr ""
 
-#: geniza/footnotes/models.py:440
+#: footnotes/models.py:440
 msgid "Discussion"
 msgstr ""
 
-#: geniza/footnotes/models.py:441
+#: footnotes/models.py:441
 msgid "Digital Edition"
 msgstr ""
 
-#: geniza/pages/models.py:13
+#: pages/models.py:13
 msgid ""
 "Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
 msgstr ""
 
-#: geniza/pages/models.py:44
+#: pages/models.py:44
 msgid ""
 "This text will only be read to     non-sighted users and should describe the "
 "major insights or     takeaways from the graphic. Multiple paragraphs are "
@@ -478,130 +475,130 @@ msgid ""
 msgstr ""
 
 #. Translators: title for Not Found (404) error page
-#: geniza/templates/404.html:5 geniza/templates/404.html:13
+#: templates/404.html:5 templates/404.html:13
 msgid "Not Found"
 msgstr ""
 
 #. Translators: description for Not Found (404) error page
-#: geniza/templates/404.html:7 geniza/templates/404.html:14
+#: templates/404.html:7 templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr ""
 
 #. Translators: title for Internal Server Error (500) error page
-#: geniza/templates/500.html:5 geniza/templates/500.html:19
+#: templates/500.html:5 templates/500.html:19
 msgid "Server Error"
 msgstr ""
 
 #. Translators: description for Internal Server Error (500) error page
-#: geniza/templates/500.html:7 geniza/templates/500.html:20
+#: templates/500.html:7 templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr ""
 
-#: geniza/templates/admin/base_site.html:4
+#: templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr ""
 
-#: geniza/templates/base.html:91
+#: templates/base.html:91
 msgid "Skip to main content"
 msgstr ""
 
 #. Translators: accessibility text label for footer site navigation
-#: geniza/templates/footer.html:4
+#: templates/footer.html:4
 msgid "footer navigation"
 msgstr ""
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: geniza/templates/footer.html:21
+#: templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr ""
 
-#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
+#: templates/footer.html:28 templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: geniza/templates/footer.html:35
+#: templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr ""
 
-#: geniza/templates/footer.html:46
+#: templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: geniza/templates/footer.html:56
+#: templates/footer.html:56
 msgid "Accessibility"
 msgstr ""
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: geniza/templates/footer.html:61
+#: templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr ""
 
 #. Translators: Creative Commons license text, for footer
-#: geniza/templates/footer.html:65
+#: templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr ""
 
 #. Translators: International Standard Serial Number (ISSN), for footer
-#: geniza/templates/footer.html:72
+#: templates/footer.html:72
 msgid "ISSN: 2834-4146"
 msgstr ""
 
 #. Translators: software version, for footer
-#: geniza/templates/footer.html:76
+#: templates/footer.html:76
 msgid "software version"
 msgstr ""
 
 #. Translators: official name of Princeton University, for footer
-#: geniza/templates/footer.html:83
+#: templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr ""
 
 #. Translators: accessibility text label for site navigation
-#: geniza/templates/nav.html:4
+#: templates/nav.html:4
 msgid "main navigation"
 msgstr ""
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: geniza/templates/nav.html:11
+#: templates/nav.html:11
 msgid "home"
 msgstr ""
 
 #. Translators: site name label for 'home' button in main navigation
-#: geniza/templates/nav.html:13
+#: templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr ""
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: geniza/templates/nav.html:24
+#: templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr ""
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: geniza/templates/nav.html:32
+#: templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr ""
 
 #. Translators: label for language choices in navigation
-#: geniza/templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr ""
 
 #. Translators: label for link to 'Search' page in main navigation
-#: geniza/templates/snippets/menu.html:7
+#: templates/snippets/menu.html:7
 msgid "Search"
 msgstr ""
 
 #. Translators: label for main menu back button for mobile navigation
-#: geniza/templates/snippets/sub_menu.html:8
+#: templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr ""
 
 #. Translators: label for dark mode/light mode theme switcher
-#: geniza/templates/snippets/theme_toggle.html:5
+#: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr ""

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-08 11:23-0400\n"
+"Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
+"POT-Creation-Date: 2022-10-14 11:19-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -18,198 +18,201 @@ msgstr ""
 "X-Crowdin-File-ID: 28\n"
 
 #. Translators: placeholder for keyword search input
-#: corpus/forms.py:152
+#: geniza/corpus/forms.py:161
 msgid "search by keyword"
 msgstr ""
 
 #. Translators: accessible label for keyword search input
-#: corpus/forms.py:154
+#: geniza/corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr ""
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:163
+#: geniza/corpus/forms.py:172
 msgid "Relevance"
 msgstr ""
 
 #. Translators: label for sort in random order
-#: corpus/forms.py:165
+#: geniza/corpus/forms.py:174
 msgid "Random"
 msgstr ""
 
 #. Translators: label for sort by document date (most recent first)
-#: corpus/forms.py:167
+#: geniza/corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr ""
 
 #. Translators: label for sort by document date (oldest first)
-#: corpus/forms.py:169
+#: geniza/corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr ""
 
 #. Translators: label for alphabetical sort by shelfmark
-#: corpus/forms.py:171
+#: geniza/corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr ""
 
 #. Translators: label for descending sort by number of scholarship records
-#: corpus/forms.py:173
+#: geniza/corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr ""
 
 #. Translators: label for ascending sort by number of scholarship records
-#: corpus/forms.py:175
+#: geniza/corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr ""
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: corpus/forms.py:177
+#: geniza/corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr ""
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: corpus/forms.py:179
+#: geniza/corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr ""
 
 #. Translators: label for start year when filtering by date range
-#: corpus/forms.py:182 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:191
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr ""
 
 #. Translators: label for end year when filtering by date range
-#: corpus/forms.py:184 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:193
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr ""
 
 #. Translators: label for form sort field
-#: corpus/forms.py:192
+#: geniza/corpus/forms.py:201
 msgid "Sort by"
 msgstr ""
 
-#: corpus/forms.py:202
+#: geniza/corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr ""
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:211
+#: geniza/corpus/forms.py:217
 msgid "Document Type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:215
+#: geniza/corpus/forms.py:221
 msgid "Has Image"
 msgstr ""
 
 #. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:219
+#: geniza/corpus/forms.py:225
 msgid "Has Transcription"
 msgstr ""
 
 #. Translators: label for "has translation" search form filter
-#: corpus/forms.py:223
+#: geniza/corpus/forms.py:229
 msgid "Has Translation"
 msgstr ""
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:227
+#: geniza/corpus/forms.py:233
 msgid "Has Discussion"
 msgstr ""
 
-#: corpus/forms.py:277
+#. Translators: Default label when document does not have a type
+#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
+#: geniza/corpus/templates/corpus/snippets/document_header.html:17
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+msgid "Unknown type"
+msgstr ""
+
+#: geniza/corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
-#: corpus/models.py:799 templates/base.html:21
+#: geniza/corpus/models.py:911 geniza/templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:801
+#: geniza/corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:804
+#: geniza/corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr ""
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:806
+#: geniza/corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr ""
 
-#. Translators: Default label when document does not have a type
-#: corpus/models.py:858
-#: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:77
-msgid "Unknown type"
-msgstr ""
-
 #. Translators: label for 'home' link in footer navigation
-#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
+#: geniza/corpus/templates/admin/corpus/app_index.html:9
+#: geniza/templates/footer.html:12
 msgid "Home"
 msgstr "Home"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: corpus/templates/admin/corpus/document/change_form.html:41
+#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Editor label
-#: corpus/templates/corpus/document_detail.html:17
-#: corpus/templates/corpus/document_detail.html:50
+#: geniza/corpus/templates/corpus/document_detail.html:17
+#: geniza/corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr ""
 
-#: corpus/templates/corpus/document_detail.html:45
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr ""
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:69
-#: corpus/templates/corpus/snippets/document_result.html:22
+#: geniza/corpus/templates/corpus/document_detail.html:69
+#: geniza/corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr ""
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:80
+#: geniza/corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:93
+#: geniza/corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for tags on a document
-#: corpus/templates/corpus/document_detail.html:109
-#: corpus/templates/corpus/snippets/document_result.html:107
+#: geniza/corpus/templates/corpus/document_detail.html:109
+#: geniza/corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr ""
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:122
+#: geniza/corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:124
+#: geniza/corpus/templates/corpus/document_detail.html:124
 #, python-format
 msgid ""
 "\n"
@@ -218,41 +221,36 @@ msgid ""
 msgstr ""
 
 #. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:132
+#: geniza/corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr ""
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:161
+#: geniza/corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr ""
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:14
+#: geniza/corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr ""
 
-#: corpus/templates/corpus/document_list.html:19
-#: corpus/templates/corpus/document_list.html:30
+#: geniza/corpus/templates/corpus/document_list.html:19
+#: geniza/corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr ""
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:25
+#: geniza/corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr ""
 
-#: corpus/templates/corpus/document_list.html:60
+#: geniza/corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr ""
 
-#. Translators: Button to open or close sort options menu
-#: corpus/templates/corpus/document_list.html:76
-msgid "Toggle sort options menu"
-msgstr ""
-
 #. Translators: number of search results
-#: corpus/templates/corpus/document_list.html:99
+#: geniza/corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -260,55 +258,55 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: corpus/templates/corpus/document_scholarship.html:21
+#: geniza/corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr ""
 
 #. Translators: label for included document relations for a single footnote
-#: corpus/templates/corpus/document_scholarship.html:28
+#: geniza/corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr ""
 
 #. Translators: label for document relations in list of footnotes
-#: corpus/templates/corpus/document_scholarship.html:31
+#: geniza/corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr ""
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: corpus/templates/corpus/document_scholarship.html:36
+#: geniza/corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr ""
 
 #. Translators: Document edit link for admins
-#: corpus/templates/corpus/snippets/document_header.html:9
+#: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:4
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:21
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:38
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:40
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr ""
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:31
+#: geniza/corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr ""
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:72
+#: geniza/corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -316,7 +314,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:82
+#: geniza/corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -324,104 +322,108 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:92
+#: geniza/corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: corpus/templates/corpus/snippets/document_result.html:100
+#: geniza/corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:114
+#: geniza/corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:133
+#: geniza/corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr ""
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: corpus/templates/corpus/snippets/document_tabs.html:4
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_tabs.html:7
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr ""
 
 #. Translators: n_records is number of scholarship records
-#: corpus/templates/corpus/snippets/document_tabs.html:10
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_tabs.html:17
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:6
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:10
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:14
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:56
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:80
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr ""
 
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+msgid "Transcription"
+msgstr ""
+
 #. Translators: label for a link to a resource with no named location
-#: corpus/templates/corpus/snippets/footnote_location.html:9
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr ""
 
 #. Translators: Label for "previous page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:5
+#: geniza/corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr ""
 
 #. Translators: Title for link to page number in search results
-#: corpus/templates/corpus/snippets/pagination.html:19
+#: geniza/corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr ""
 
 #. Translators: Label for "next page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:60
+#: geniza/corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr ""
 
 #. Translators: title of document search page
-#: corpus/views.py:36
+#: geniza/corpus/views.py:42
 msgid "Search Documents"
 msgstr "Search Documents"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:38
+#: geniza/corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:339
+#: geniza/corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr ""
 
-#: corpus/views.py:346
+#: geniza/corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -429,12 +431,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of related documents page
-#: corpus/views.py:387
+#: geniza/corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr ""
 
-#: corpus/views.py:394
+#: geniza/corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -442,29 +444,33 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:201
+#: geniza/footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr ""
 
-#: footnotes/models.py:410
+#: geniza/footnotes/models.py:438
 msgid "Edition"
 msgstr ""
 
-#: footnotes/models.py:411
+#: geniza/footnotes/models.py:439
 msgid "Translation"
 msgstr ""
 
-#: footnotes/models.py:412
+#: geniza/footnotes/models.py:440
 msgid "Discussion"
 msgstr ""
 
-#: pages/models.py:13
+#: geniza/footnotes/models.py:441
+msgid "Digital Edition"
+msgstr ""
+
+#: geniza/pages/models.py:13
 msgid ""
 "Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
 msgstr ""
 
-#: pages/models.py:44
+#: geniza/pages/models.py:44
 msgid ""
 "This text will only be read to     non-sighted users and should describe the "
 "major insights or     takeaways from the graphic. Multiple paragraphs are "
@@ -472,131 +478,130 @@ msgid ""
 msgstr ""
 
 #. Translators: title for Not Found (404) error page
-#: templates/404.html:5 templates/404.html:13
+#: geniza/templates/404.html:5 geniza/templates/404.html:13
 msgid "Not Found"
 msgstr ""
 
 #. Translators: description for Not Found (404) error page
-#: templates/404.html:7 templates/404.html:14
+#: geniza/templates/404.html:7 geniza/templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr ""
 
 #. Translators: title for Internal Server Error (500) error page
-#: templates/500.html:5 templates/500.html:19
+#: geniza/templates/500.html:5 geniza/templates/500.html:19
 msgid "Server Error"
 msgstr ""
 
 #. Translators: description for Internal Server Error (500) error page
-#: templates/500.html:7 templates/500.html:20
+#: geniza/templates/500.html:7 geniza/templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr ""
 
-#: templates/admin/base_site.html:4
+#: geniza/templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr ""
 
-#: templates/base.html:80
+#: geniza/templates/base.html:91
 msgid "Skip to main content"
 msgstr ""
 
 #. Translators: accessibility text label for footer site navigation
-#: templates/footer.html:4
+#: geniza/templates/footer.html:4
 msgid "footer navigation"
 msgstr ""
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: templates/footer.html:21
+#: geniza/templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr ""
 
-#: templates/footer.html:28 templates/footer.html:42
+#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: templates/footer.html:35
+#: geniza/templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr ""
 
-#: templates/footer.html:46
+#: geniza/templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: templates/footer.html:56
+#: geniza/templates/footer.html:56
 msgid "Accessibility"
 msgstr ""
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: templates/footer.html:61
+#: geniza/templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr ""
 
 #. Translators: Creative Commons license text, for footer
-#: templates/footer.html:65
+#: geniza/templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr ""
 
+#. Translators: International Standard Serial Number (ISSN), for footer
+#: geniza/templates/footer.html:72
+msgid "ISSN: 2834-4146"
+msgstr ""
+
 #. Translators: software version, for footer
-#: templates/footer.html:72
+#: geniza/templates/footer.html:76
 msgid "software version"
 msgstr ""
 
 #. Translators: official name of Princeton University, for footer
-#: templates/footer.html:79
+#: geniza/templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr ""
 
 #. Translators: accessibility text label for site navigation
-#: templates/nav.html:4
+#: geniza/templates/nav.html:4
 msgid "main navigation"
 msgstr ""
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: templates/nav.html:11
+#: geniza/templates/nav.html:11
 msgid "home"
 msgstr ""
 
 #. Translators: site name label for 'home' button in main navigation
-#: templates/nav.html:13
+#: geniza/templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr ""
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: templates/nav.html:24
+#: geniza/templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr ""
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: templates/nav.html:32
+#: geniza/templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr ""
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:15
+#: geniza/templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr ""
 
-#. Translators: button on language chooser in navigation
-#: templates/snippets/language_switcher.html:24
-msgctxt "choose this option"
-msgid "go"
-msgstr ""
-
 #. Translators: label for link to 'Search' page in main navigation
-#: templates/snippets/menu.html:7
+#: geniza/templates/snippets/menu.html:7
 msgid "Search"
 msgstr ""
 
 #. Translators: label for main menu back button for mobile navigation
-#: templates/snippets/sub_menu.html:8
+#: geniza/templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr ""
 
 #. Translators: label for dark mode/light mode theme switcher
-#: templates/snippets/theme_toggle.html:5
+#: geniza/templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr ""

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-08 11:23-0400\n"
+"Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
+"POT-Creation-Date: 2022-10-14 11:19-0400\n"
 "PO-Revision-Date: 2022-09-08 16:11\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3;\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: he\n"
@@ -18,143 +19,146 @@ msgstr ""
 "X-Crowdin-File-ID: 12\n"
 
 #. Translators: placeholder for keyword search input
-#: corpus/forms.py:152
+#: geniza/corpus/forms.py:161
 msgid "search by keyword"
 msgstr "חיפוש לפי מילת מפתח"
 
 #. Translators: accessible label for keyword search input
-#: corpus/forms.py:154
+#: geniza/corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr "מילת מפתח או ביטוי"
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:163
+#: geniza/corpus/forms.py:172
 msgid "Relevance"
 msgstr "רלוונטיות"
 
 #. Translators: label for sort in random order
-#: corpus/forms.py:165
+#: geniza/corpus/forms.py:174
 msgid "Random"
 msgstr "אקראי"
 
 #. Translators: label for sort by document date (most recent first)
-#: corpus/forms.py:167
+#: geniza/corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr "תאריך המסמך (מאוחר ביותר - מוקדם ביותר)"
 
 #. Translators: label for sort by document date (oldest first)
-#: corpus/forms.py:169
+#: geniza/corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr "תאריך המסמך (מוקדם ביותר - מאוחר ביותר)"
 
 #. Translators: label for alphabetical sort by shelfmark
-#: corpus/forms.py:171
+#: geniza/corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr "מספר מדף (A-Z)"
 
 #. Translators: label for descending sort by number of scholarship records
-#: corpus/forms.py:173
+#: geniza/corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr "רשומות קשורות (מהגדול לקטן)"
 
 #. Translators: label for ascending sort by number of scholarship records
-#: corpus/forms.py:175
+#: geniza/corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr "רשומות קשורות (מהקטן לגדול)"
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: corpus/forms.py:177
+#: geniza/corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr "תאריך הוספה (מאוחר ביותר - מוקדם ביותר)"
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: corpus/forms.py:179
+#: geniza/corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr "תאריך הוספה (מוקדם ביותר - מאוחר ביותר)"
 
 #. Translators: label for start year when filtering by date range
-#: corpus/forms.py:182 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:191
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr "משנת"
 
 #. Translators: label for end year when filtering by date range
-#: corpus/forms.py:184 corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: geniza/corpus/forms.py:193
+#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr "עד שנת"
 
 #. Translators: label for form sort field
-#: corpus/forms.py:192
+#: geniza/corpus/forms.py:201
 msgid "Sort by"
 msgstr "מיון לפי"
 
-#: corpus/forms.py:202
+#: geniza/corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr "תאריכי המסמך (CE)"
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:211
+#: geniza/corpus/forms.py:217
 msgid "Document Type"
 msgstr "סוג המסמך"
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:215
+#: geniza/corpus/forms.py:221
 msgid "Has Image"
 msgstr "קיים תצלום"
 
 #. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:219
+#: geniza/corpus/forms.py:225
 msgid "Has Transcription"
 msgstr "קיים תיעתוק"
 
 #. Translators: label for "has translation" search form filter
-#: corpus/forms.py:223
+#: geniza/corpus/forms.py:229
 msgid "Has Translation"
 msgstr "קיים תרגום"
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:227
+#: geniza/corpus/forms.py:233
 msgid "Has Discussion"
 msgstr "קיים דיון"
 
-#: corpus/forms.py:277
+#. Translators: Default label when document does not have a type
+#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
+#: geniza/corpus/templates/corpus/snippets/document_header.html:17
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+msgid "Unknown type"
+msgstr "סוג לא ידוע"
+
+#: geniza/corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת מפתח לחיפוש."
 
-#: corpus/models.py:799 templates/base.html:21
+#: geniza/corpus/models.py:911 geniza/templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:801
+#: geniza/corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "קובץ על-ידי %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:804
+#: geniza/corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "קובץ ותועתק על-ידי %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:806
+#: geniza/corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr "ייתכנו מגבלות נוספות."
 
-#. Translators: Default label when document does not have a type
-#: corpus/models.py:858
-#: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:77
-msgid "Unknown type"
-msgstr "סוג לא ידוע"
-
 #. Translators: label for 'home' link in footer navigation
-#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
+#: geniza/corpus/templates/admin/corpus/app_index.html:9
+#: geniza/templates/footer.html:12
 msgid "Home"
 msgstr "דף הבית"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: corpus/templates/admin/corpus/document/change_form.html:41
+#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] "מסמכים נוספים עם מספר מדף זה"
@@ -163,8 +167,8 @@ msgstr[2] "מסמכים נוספים עם מספרי מדף אלו"
 msgstr[3] "מסמכים נוספים עם מספרי מדף אלו"
 
 #. Translators: Editor label
-#: corpus/templates/corpus/document_detail.html:17
-#: corpus/templates/corpus/document_detail.html:50
+#: geniza/corpus/templates/corpus/document_detail.html:17
+#: geniza/corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] "עורך"
@@ -173,22 +177,22 @@ msgstr[2] "עורכים"
 msgstr[3] "עורכים"
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: corpus/templates/corpus/document_detail.html:41
+#: geniza/corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr "מטא-דאטא"
 
-#: corpus/templates/corpus/document_detail.html:45
+#: geniza/corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr "מספר מדף"
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:69
-#: corpus/templates/corpus/snippets/document_result.html:22
+#: geniza/corpus/templates/corpus/document_detail.html:69
+#: geniza/corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr "תאריך המסמך"
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:80
+#: geniza/corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "שפה עיקרית"
@@ -197,7 +201,7 @@ msgstr[2] "שפות עיקריות"
 msgstr[3] "שפות עיקריות"
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:93
+#: geniza/corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "שפה משנית"
@@ -206,62 +210,59 @@ msgstr[2] "שפות משניות"
 msgstr[3] "שפות משניות"
 
 #. Translators: label for tags on a document
-#: corpus/templates/corpus/document_detail.html:109
-#: corpus/templates/corpus/snippets/document_result.html:107
+#: geniza/corpus/templates/corpus/document_detail.html:109
+#: geniza/corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr "תגים"
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:122
+#: geniza/corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:124
+#: geniza/corpus/templates/corpus/document_detail.html:124
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                In PGP since %(date)s\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "נמצא בPGP מאז %(date)s\n"
 "            "
 
 #. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:132
+#: geniza/corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr "תיאור"
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:161
+#: geniza/corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr "קישור קבוע"
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:14
+#: geniza/corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr "חיפוש"
 
-#: corpus/templates/corpus/document_list.html:19
-#: corpus/templates/corpus/document_list.html:30
+#: geniza/corpus/templates/corpus/document_list.html:19
+#: geniza/corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr "מסננים"
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:25
+#: geniza/corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr "סגור אפשרויות סינון"
 
-#: corpus/templates/corpus/document_list.html:60
+#: geniza/corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr "החל"
 
-#. Translators: Button to open or close sort options menu
-#: corpus/templates/corpus/document_list.html:76
-msgid "Toggle sort options menu"
-msgstr "פתח/סגור תפריט אפשרויות מיון"
-
 #. Translators: number of search results
-#: corpus/templates/corpus/document_list.html:99
+#: geniza/corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -271,55 +272,55 @@ msgstr[2] "%(count_humanized)s תוצאות"
 msgstr[3] "%(count_humanized)s תוצאות"
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: corpus/templates/corpus/document_scholarship.html:21
+#: geniza/corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr "ציטוט"
 
 #. Translators: label for included document relations for a single footnote
-#: corpus/templates/corpus/document_scholarship.html:28
+#: geniza/corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr "כלול"
 
 #. Translators: label for document relations in list of footnotes
-#: corpus/templates/corpus/document_scholarship.html:31
+#: geniza/corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr "ל%(relation)s ראה"
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: corpus/templates/corpus/document_scholarship.html:36
+#: geniza/corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr "כולל %(relation)s"
 
 #. Translators: Document edit link for admins
-#: corpus/templates/corpus/snippets/document_header.html:9
+#: geniza/corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr "עריכה"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:4
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr "תנאי היתר שימוש בתצלום"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:21
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr "לא מצוין ייחוס או רישיון."
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:38
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr "עמוד הבית  Jewish Theological Seminary"
 
-#: corpus/templates/corpus/snippets/document_image_rights.html:40
+#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr "סמל Jewish Theological Seminary"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:31
+#: geniza/corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr "נמצא בPGP מאז"
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:72
+#: geniza/corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -329,7 +330,7 @@ msgstr[2] "%(counter)s תעתוקים"
 msgstr[3] "%(counter)s תעתוקים"
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:82
+#: geniza/corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -339,7 +340,7 @@ msgstr[2] "%(counter)s תרגומים"
 msgstr[3] "%(counter)s תרגומים"
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:92
+#: geniza/corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -348,97 +349,104 @@ msgstr[1] "%(counter)s דיונים"
 msgstr[2] "%(counter)s דיונים"
 msgstr[3] "%(counter)s דיונים"
 
-#: corpus/templates/corpus/snippets/document_result.html:100
+#: geniza/corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr "אין רשומות קשורות"
 
-#: corpus/templates/corpus/snippets/document_result.html:114
+#: geniza/corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr "עוד"
 
-#: corpus/templates/corpus/snippets/document_result.html:133
+#: geniza/corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr "הצגת פרטי מסמך"
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: corpus/templates/corpus/snippets/document_tabs.html:4
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr "כרטיסיות"
 
-#: corpus/templates/corpus/snippets/document_tabs.html:7
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr "פרטי מסמך"
 
 #. Translators: n_records is number of scholarship records
-#: corpus/templates/corpus/snippets/document_tabs.html:10
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr "רשומות קשורות (%(n_records)s)"
 
-#: corpus/templates/corpus/snippets/document_tabs.html:17
+#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr "מסמכים קשורים (%(n_reldocs)s)"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:6
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr "הצג תמונות"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:10
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr "הצג תעתוק"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:14
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr "הצג תרגום"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:56
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr "הגדל וסובב"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:80
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "ראה %(related_doc)s"
 
+#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+#, fuzzy
+#| msgid "1 Transcription"
+#| msgid_plural "%(counter)s Transcriptions"
+msgid "Transcription"
+msgstr "תעתוק אחד"
+
 #. Translators: label for a link to a resource with no named location
-#: corpus/templates/corpus/snippets/footnote_location.html:9
+#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr "מקור אינטרנטי"
 
 #. Translators: Label for "previous page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:5
+#: geniza/corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr "הקודם"
 
 #. Translators: Title for link to page number in search results
-#: corpus/templates/corpus/snippets/pagination.html:19
+#: geniza/corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr "%(number)s עמודים"
 
 #. Translators: Label for "next page" button in search results
-#: corpus/templates/corpus/snippets/pagination.html:60
+#: geniza/corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr "הבא"
 
 #. Translators: title of document search page
-#: corpus/views.py:36
+#: geniza/corpus/views.py:42
 msgid "Search Documents"
 msgstr "חיפוש מסמכים"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:38
+#: geniza/corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:339
+#: geniza/corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "רשומה קשורה ל-%(doc)s"
 
-#: corpus/views.py:346
+#: geniza/corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -448,12 +456,12 @@ msgstr[2] "%(count)d רשומות קשורות"
 msgstr[3] "%(count)d רשומות קשורות"
 
 #. Translators: title of related documents page
-#: corpus/views.py:387
+#: geniza/corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "מסמכים קשורים %(doc)s"
 
-#: corpus/views.py:394
+#: geniza/corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -463,158 +471,177 @@ msgstr[2] "%(count)d מסמכים קשורים"
 msgstr[3] "%(count)d מסמכים קשורים"
 
 #. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:201
+#: geniza/footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr "[גרסת מסמך גניזה דיגיטלי]"
 
-#: footnotes/models.py:410
+#: geniza/footnotes/models.py:438
 msgid "Edition"
 msgstr "מהדורה"
 
-#: footnotes/models.py:411
+#: geniza/footnotes/models.py:439
 msgid "Translation"
 msgstr "תרגום"
 
-#: footnotes/models.py:412
+#: geniza/footnotes/models.py:440
 msgid "Discussion"
 msgstr "דיון"
 
-#: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
-"briefly communicate the intended message of the image in this context."
-msgstr "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום בהקשר זה."
+#: geniza/footnotes/models.py:441
+#, fuzzy
+#| msgid "Edition"
+msgid "Digital Edition"
+msgstr "מהדורה"
 
-#: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
+#: geniza/pages/models.py:13
+msgid ""
+"Alternative text for visually impaired users to\n"
+"briefly communicate the intended message of the image in this context."
+msgstr ""
+"טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
+"בהקשר זה."
+
+#: geniza/pages/models.py:44
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים "
+"שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
-#: templates/404.html:5 templates/404.html:13
+#: geniza/templates/404.html:5 geniza/templates/404.html:13
 msgid "Not Found"
 msgstr "לא נמצא"
 
 #. Translators: description for Not Found (404) error page
-#: templates/404.html:7 templates/404.html:14
+#: geniza/templates/404.html:7 geniza/templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr "אופס, נתקלת בלאקונה! העמוד המבוקש לא נמצא."
 
 #. Translators: title for Internal Server Error (500) error page
-#: templates/500.html:5 templates/500.html:19
+#: geniza/templates/500.html:5 geniza/templates/500.html:19
 msgid "Server Error"
 msgstr "שגיאת שרת"
 
 #. Translators: description for Internal Server Error (500) error page
-#: templates/500.html:7 templates/500.html:20
+#: geniza/templates/500.html:7 geniza/templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr "דבר מה השתבש בהפקת עמוד זה."
 
-#: templates/admin/base_site.html:4
+#: geniza/templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr "ניהול האתר"
 
-#: templates/base.html:80
+#: geniza/templates/base.html:91
 msgid "Skip to main content"
 msgstr "דילוג לתוכן"
 
 #. Translators: accessibility text label for footer site navigation
-#: templates/footer.html:4
+#: geniza/templates/footer.html:4
 msgid "footer navigation"
 msgstr "ניווט בתחתית העמוד"
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: templates/footer.html:21
+#: geniza/templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr "עמוד הבית Princeton Geniza Lab"
 
-#: templates/footer.html:28 templates/footer.html:42
+#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: templates/footer.html:35
+#: geniza/templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr "Princeton Center for Digital Humanities עמוד הבית"
 
-#: templates/footer.html:46
+#: geniza/templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: templates/footer.html:56
+#: geniza/templates/footer.html:56
 msgid "Accessibility"
 msgstr "נגישות"
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: templates/footer.html:61
+#: geniza/templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr "The Trustees of Princeton University"
 
 #. Translators: Creative Commons license text, for footer
-#: templates/footer.html:65
+#: geniza/templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr "דרישת ייחוס על פי רישיון ״קריאייטיב קומונס״ (CC-BY)"
 
+#. Translators: International Standard Serial Number (ISSN), for footer
+#: geniza/templates/footer.html:72
+msgid "ISSN: 2834-4146"
+msgstr ""
+
 #. Translators: software version, for footer
-#: templates/footer.html:72
+#: geniza/templates/footer.html:76
 msgid "software version"
 msgstr "גרסת תוכנה"
 
 #. Translators: official name of Princeton University, for footer
-#: templates/footer.html:79
+#: geniza/templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr "עמוד הבית Princeton University"
 
 #. Translators: accessibility text label for site navigation
-#: templates/nav.html:4
+#: geniza/templates/nav.html:4
 msgid "main navigation"
 msgstr "ניווט"
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: templates/nav.html:11
+#: geniza/templates/nav.html:11
 msgid "home"
 msgstr "דף הבית"
 
 #. Translators: site name label for 'home' button in main navigation
-#: templates/nav.html:13
+#: geniza/templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr "The Princeton Geniza Project"
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: templates/nav.html:24
+#: geniza/templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr "פתיחת תפריט ניווט"
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: templates/nav.html:32
+#: geniza/templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr "סגירת תפריט ניווט"
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:15
+#: geniza/templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "קריאת העמוד ב-%(language_name)s (%(language_code)s)"
 
-#. Translators: button on language chooser in navigation
-#: templates/snippets/language_switcher.html:24
-msgctxt "choose this option"
-msgid "go"
-msgstr "שינוי שפה"
-
 #. Translators: label for link to 'Search' page in main navigation
-#: templates/snippets/menu.html:7
+#: geniza/templates/snippets/menu.html:7
 msgid "Search"
 msgstr "חיפוש"
 
 #. Translators: label for main menu back button for mobile navigation
-#: templates/snippets/sub_menu.html:8
+#: geniza/templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr "חזרה לתפריט הראשי"
 
 #. Translators: label for dark mode/light mode theme switcher
-#: templates/snippets/theme_toggle.html:5
+#: geniza/templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
 
+#~ msgid "Toggle sort options menu"
+#~ msgstr "פתח/סגור תפריט אפשרויות מיון"
+
+#~ msgctxt "choose this option"
+#~ msgid "go"
+#~ msgstr "שינוי שפה"

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2022-10-14 11:19-0400\n"
+"POT-Creation-Date: 2022-10-14 12:15-0400\n"
 "PO-Revision-Date: 2022-09-08 16:11\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -19,146 +19,143 @@ msgstr ""
 "X-Crowdin-File-ID: 12\n"
 
 #. Translators: placeholder for keyword search input
-#: geniza/corpus/forms.py:161
+#: corpus/forms.py:161
 msgid "search by keyword"
 msgstr "חיפוש לפי מילת מפתח"
 
 #. Translators: accessible label for keyword search input
-#: geniza/corpus/forms.py:163
+#: corpus/forms.py:163
 msgid "Keyword or Phrase"
 msgstr "מילת מפתח או ביטוי"
 
 #. Translators: label for sort by relevance
-#: geniza/corpus/forms.py:172
+#: corpus/forms.py:172
 msgid "Relevance"
 msgstr "רלוונטיות"
 
 #. Translators: label for sort in random order
-#: geniza/corpus/forms.py:174
+#: corpus/forms.py:174
 msgid "Random"
 msgstr "אקראי"
 
 #. Translators: label for sort by document date (most recent first)
-#: geniza/corpus/forms.py:176
+#: corpus/forms.py:176
 msgid "Document Date (Latest–Earliest)"
 msgstr "תאריך המסמך (מאוחר ביותר - מוקדם ביותר)"
 
 #. Translators: label for sort by document date (oldest first)
-#: geniza/corpus/forms.py:178
+#: corpus/forms.py:178
 msgid "Document Date (Earliest–Latest)"
 msgstr "תאריך המסמך (מוקדם ביותר - מאוחר ביותר)"
 
 #. Translators: label for alphabetical sort by shelfmark
-#: geniza/corpus/forms.py:180
+#: corpus/forms.py:180
 msgid "Shelfmark (A–Z)"
 msgstr "מספר מדף (A-Z)"
 
 #. Translators: label for descending sort by number of scholarship records
-#: geniza/corpus/forms.py:182
+#: corpus/forms.py:182
 msgid "Scholarship Records (Most–Least)"
 msgstr "רשומות קשורות (מהגדול לקטן)"
 
 #. Translators: label for ascending sort by number of scholarship records
-#: geniza/corpus/forms.py:184
+#: corpus/forms.py:184
 msgid "Scholarship Records (Least–Most)"
 msgstr "רשומות קשורות (מהקטן לגדול)"
 
 #. Translators: label for sort by when document was added to PGP (most recent first)
-#: geniza/corpus/forms.py:186
+#: corpus/forms.py:186
 msgid "PGP Input Date (Latest–Earliest)"
 msgstr "תאריך הוספה (מאוחר ביותר - מוקדם ביותר)"
 
 #. Translators: label for sort by when document was added to PGP (oldest first)
-#: geniza/corpus/forms.py:188
+#: corpus/forms.py:188
 msgid "PGP Input Date (Earliest–Latest)"
 msgstr "תאריך הוספה (מוקדם ביותר - מאוחר ביותר)"
 
 #. Translators: label for start year when filtering by date range
-#: geniza/corpus/forms.py:191
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:191 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "From year"
 msgstr "משנת"
 
 #. Translators: label for end year when filtering by date range
-#: geniza/corpus/forms.py:193
-#: geniza/corpus/templates/corpus/widgets/yearrangewidget.html:5
+#: corpus/forms.py:193 corpus/templates/corpus/widgets/yearrangewidget.html:5
 msgid "To year"
 msgstr "עד שנת"
 
 #. Translators: label for form sort field
-#: geniza/corpus/forms.py:201
+#: corpus/forms.py:201
 msgid "Sort by"
 msgstr "מיון לפי"
 
-#: geniza/corpus/forms.py:208
+#: corpus/forms.py:208
 msgid "Document Dates (CE)"
 msgstr "תאריכי המסמך (CE)"
 
 #. Translators: label for document type search form filter
-#: geniza/corpus/forms.py:217
+#: corpus/forms.py:217
 msgid "Document Type"
 msgstr "סוג המסמך"
 
 #. Translators: label for "has image" search form filter
-#: geniza/corpus/forms.py:221
+#: corpus/forms.py:221
 msgid "Has Image"
 msgstr "קיים תצלום"
 
 #. Translators: label for "has transcription" search form filter
-#: geniza/corpus/forms.py:225
+#: corpus/forms.py:225
 msgid "Has Transcription"
 msgstr "קיים תיעתוק"
 
 #. Translators: label for "has translation" search form filter
-#: geniza/corpus/forms.py:229
+#: corpus/forms.py:229
 msgid "Has Translation"
 msgstr "קיים תרגום"
 
 #. Translators: label for "has discussion" search form filter
-#: geniza/corpus/forms.py:233
+#: corpus/forms.py:233
 msgid "Has Discussion"
 msgstr "קיים דיון"
 
 #. Translators: Default label when document does not have a type
-#: geniza/corpus/forms.py:279 geniza/corpus/solr_queryset.py:152
-#: geniza/corpus/templates/corpus/snippets/document_header.html:17
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:95
+#: corpus/forms.py:279 corpus/solr_queryset.py:152
+#: corpus/templates/corpus/snippets/document_header.html:17
+#: corpus/templates/corpus/snippets/document_transcription.html:95
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
 
-#: geniza/corpus/forms.py:311
+#: corpus/forms.py:311
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת מפתח לחיפוש."
 
-#: geniza/corpus/models.py:911 geniza/templates/base.html:21
+#: corpus/models.py:911 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: geniza/corpus/models.py:913
+#: corpus/models.py:913
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "קובץ על-ידי %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: geniza/corpus/models.py:916
+#: corpus/models.py:916
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "קובץ ותועתק על-ידי %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: geniza/corpus/models.py:918
+#: corpus/models.py:918
 msgid "Additional restrictions may apply."
 msgstr "ייתכנו מגבלות נוספות."
 
 #. Translators: label for 'home' link in footer navigation
-#: geniza/corpus/templates/admin/corpus/app_index.html:9
-#: geniza/templates/footer.html:12
+#: corpus/templates/admin/corpus/app_index.html:9 templates/footer.html:12
 msgid "Home"
 msgstr "דף הבית"
 
 #. Translators: Other documents on the same fragment/shelfmark
-#: geniza/corpus/templates/admin/corpus/document/change_form.html:41
+#: corpus/templates/admin/corpus/document/change_form.html:41
 msgid "Other documents on this shelfmark"
 msgid_plural "Other documents on these shelfmarks"
 msgstr[0] "מסמכים נוספים עם מספר מדף זה"
@@ -167,8 +164,8 @@ msgstr[2] "מסמכים נוספים עם מספרי מדף אלו"
 msgstr[3] "מסמכים נוספים עם מספרי מדף אלו"
 
 #. Translators: Editor label
-#: geniza/corpus/templates/corpus/document_detail.html:17
-#: geniza/corpus/templates/corpus/document_detail.html:50
+#: corpus/templates/corpus/document_detail.html:17
+#: corpus/templates/corpus/document_detail.html:50
 msgid "Editor"
 msgid_plural "Editors"
 msgstr[0] "עורך"
@@ -177,22 +174,22 @@ msgstr[2] "עורכים"
 msgstr[3] "עורכים"
 
 #. Translators: label for document metadata section (editor, date, input date)
-#: geniza/corpus/templates/corpus/document_detail.html:41
+#: corpus/templates/corpus/document_detail.html:41
 msgid "Metadata"
 msgstr "מטא-דאטא"
 
-#: geniza/corpus/templates/corpus/document_detail.html:45
+#: corpus/templates/corpus/document_detail.html:45
 msgid "Shelfmark"
 msgstr "מספר מדף"
 
 #. Translators: label for date of this document, if known
-#: geniza/corpus/templates/corpus/document_detail.html:69
-#: geniza/corpus/templates/corpus/snippets/document_result.html:22
+#: corpus/templates/corpus/document_detail.html:69
+#: corpus/templates/corpus/snippets/document_result.html:22
 msgid "Document Date"
 msgstr "תאריך המסמך"
 
 #. Translators: Primary language label
-#: geniza/corpus/templates/corpus/document_detail.html:80
+#: corpus/templates/corpus/document_detail.html:80
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "שפה עיקרית"
@@ -201,7 +198,7 @@ msgstr[2] "שפות עיקריות"
 msgstr[3] "שפות עיקריות"
 
 #. Translators: Secondary language label
-#: geniza/corpus/templates/corpus/document_detail.html:93
+#: corpus/templates/corpus/document_detail.html:93
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "שפה משנית"
@@ -210,18 +207,18 @@ msgstr[2] "שפות משניות"
 msgstr[3] "שפות משניות"
 
 #. Translators: label for tags on a document
-#: geniza/corpus/templates/corpus/document_detail.html:109
-#: geniza/corpus/templates/corpus/snippets/document_result.html:112
+#: corpus/templates/corpus/document_detail.html:109
+#: corpus/templates/corpus/snippets/document_result.html:112
 msgid "Tags"
 msgstr "תגים"
 
 #. Translators: Label for date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:122
+#: corpus/templates/corpus/document_detail.html:122
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/document_detail.html:124
+#: corpus/templates/corpus/document_detail.html:124
 #, python-format
 msgid ""
 "\n"
@@ -233,36 +230,36 @@ msgstr ""
 "            "
 
 #. Translators: label for document description
-#: geniza/corpus/templates/corpus/document_detail.html:132
+#: corpus/templates/corpus/document_detail.html:132
 msgid "Description"
 msgstr "תיאור"
 
 #. Translators: label for permanent link to a document
-#: geniza/corpus/templates/corpus/document_detail.html:146
+#: corpus/templates/corpus/document_detail.html:146
 msgid "Permalink"
 msgstr "קישור קבוע"
 
 #. Translators: Search submit button
-#: geniza/corpus/templates/corpus/document_list.html:14
+#: corpus/templates/corpus/document_list.html:14
 msgid "Submit search"
 msgstr "חיפוש"
 
-#: geniza/corpus/templates/corpus/document_list.html:19
-#: geniza/corpus/templates/corpus/document_list.html:30
+#: corpus/templates/corpus/document_list.html:19
+#: corpus/templates/corpus/document_list.html:30
 msgid "Filters"
 msgstr "מסננים"
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: geniza/corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:25
 msgid "Close filter options"
 msgstr "סגור אפשרויות סינון"
 
-#: geniza/corpus/templates/corpus/document_list.html:60
+#: corpus/templates/corpus/document_list.html:60
 msgid "Apply"
 msgstr "החל"
 
 #. Translators: number of search results
-#: geniza/corpus/templates/corpus/document_list.html:87
+#: corpus/templates/corpus/document_list.html:87
 #, python-format
 msgid "1 result"
 msgid_plural "%(count_humanized)s total results"
@@ -272,55 +269,55 @@ msgstr[2] "%(count_humanized)s תוצאות"
 msgstr[3] "%(count_humanized)s תוצאות"
 
 #. Translators: accessibility label for a footnote source citation in scholarship records view
-#: geniza/corpus/templates/corpus/document_scholarship.html:21
+#: corpus/templates/corpus/document_scholarship.html:21
 msgid "Bibliographic citation"
 msgstr "ציטוט"
 
 #. Translators: label for included document relations for a single footnote
-#: geniza/corpus/templates/corpus/document_scholarship.html:28
+#: corpus/templates/corpus/document_scholarship.html:28
 msgid "includes"
 msgstr "כלול"
 
 #. Translators: label for document relations in list of footnotes
-#: geniza/corpus/templates/corpus/document_scholarship.html:31
+#: corpus/templates/corpus/document_scholarship.html:31
 #, python-format
 msgid "for %(relation)s see"
 msgstr "ל%(relation)s ראה"
 
 #. Translators: label for document relations for one footnote with no location or URL
-#: geniza/corpus/templates/corpus/document_scholarship.html:36
+#: corpus/templates/corpus/document_scholarship.html:36
 #, python-format
 msgid "includes %(relation)s"
 msgstr "כולל %(relation)s"
 
 #. Translators: Document edit link for admins
-#: geniza/corpus/templates/corpus/snippets/document_header.html:9
+#: corpus/templates/corpus/snippets/document_header.html:9
 msgid "Edit"
 msgstr "עריכה"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:4
+#: corpus/templates/corpus/snippets/document_image_rights.html:4
 msgid "Image Permissions Statement"
 msgstr "תנאי היתר שימוש בתצלום"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:21
+#: corpus/templates/corpus/snippets/document_image_rights.html:21
 msgid "No attribution or license noted."
 msgstr "לא מצוין ייחוס או רישיון."
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:38
+#: corpus/templates/corpus/snippets/document_image_rights.html:38
 msgid "Jewish Theological Seminary homepage"
 msgstr "עמוד הבית  Jewish Theological Seminary"
 
-#: geniza/corpus/templates/corpus/snippets/document_image_rights.html:40
+#: corpus/templates/corpus/snippets/document_image_rights.html:40
 msgid "Jewish Theological Seminary logo"
 msgstr "סמל Jewish Theological Seminary"
 
 #. Translators: Date document was first added to the PGP
-#: geniza/corpus/templates/corpus/snippets/document_result.html:31
+#: corpus/templates/corpus/snippets/document_result.html:31
 msgid "In PGP since"
 msgstr "נמצא בPGP מאז"
 
 #. Translators: number of editions for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:77
+#: corpus/templates/corpus/snippets/document_result.html:77
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -330,7 +327,7 @@ msgstr[2] "%(counter)s תעתוקים"
 msgstr[3] "%(counter)s תעתוקים"
 
 #. Translators: number of translations for this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:87
+#: corpus/templates/corpus/snippets/document_result.html:87
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -340,7 +337,7 @@ msgstr[2] "%(counter)s תרגומים"
 msgstr[3] "%(counter)s תרגומים"
 
 #. Translators: number of sources that discuss this document
-#: geniza/corpus/templates/corpus/snippets/document_result.html:97
+#: corpus/templates/corpus/snippets/document_result.html:97
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -349,60 +346,60 @@ msgstr[1] "%(counter)s דיונים"
 msgstr[2] "%(counter)s דיונים"
 msgstr[3] "%(counter)s דיונים"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:105
+#: corpus/templates/corpus/snippets/document_result.html:105
 msgid "No Scholarship Records"
 msgstr "אין רשומות קשורות"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:119
+#: corpus/templates/corpus/snippets/document_result.html:119
 msgid "more"
 msgstr "עוד"
 
-#: geniza/corpus/templates/corpus/snippets/document_result.html:138
+#: corpus/templates/corpus/snippets/document_result.html:138
 msgid "View document details"
 msgstr "הצגת פרטי מסמך"
 
 #. Translators: accessibility text label for document detail view tabs navigation
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:4
+#: corpus/templates/corpus/snippets/document_tabs.html:4
 msgid "tabs"
 msgstr "כרטיסיות"
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:7
+#: corpus/templates/corpus/snippets/document_tabs.html:7
 msgid "Document Details"
 msgstr "פרטי מסמך"
 
 #. Translators: n_records is number of scholarship records
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:10
+#: corpus/templates/corpus/snippets/document_tabs.html:10
 #, python-format
 msgid "Scholarship Records (%(n_records)s)"
 msgstr "רשומות קשורות (%(n_records)s)"
 
-#: geniza/corpus/templates/corpus/snippets/document_tabs.html:17
+#: corpus/templates/corpus/snippets/document_tabs.html:17
 #, python-format
 msgid "Related Documents (%(n_reldocs)s)"
 msgstr "מסמכים קשורים (%(n_reldocs)s)"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:23
+#: corpus/templates/corpus/snippets/document_transcription.html:23
 msgid "show images"
 msgstr "הצג תמונות"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:27
+#: corpus/templates/corpus/snippets/document_transcription.html:27
 msgid "show transcription"
 msgstr "הצג תעתוק"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:31
+#: corpus/templates/corpus/snippets/document_transcription.html:31
 msgid "show translation"
 msgstr "הצג תרגום"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:74
+#: corpus/templates/corpus/snippets/document_transcription.html:74
 msgid "Zoom and Rotate"
 msgstr "הגדל וסובב"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:98
+#: corpus/templates/corpus/snippets/document_transcription.html:98
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "ראה %(related_doc)s"
 
-#: geniza/corpus/templates/corpus/snippets/document_transcription.html:128
+#: corpus/templates/corpus/snippets/document_transcription.html:128
 #, fuzzy
 #| msgid "1 Transcription"
 #| msgid_plural "%(counter)s Transcriptions"
@@ -410,43 +407,43 @@ msgid "Transcription"
 msgstr "תעתוק אחד"
 
 #. Translators: label for a link to a resource with no named location
-#: geniza/corpus/templates/corpus/snippets/footnote_location.html:9
+#: corpus/templates/corpus/snippets/footnote_location.html:9
 msgid "online resource"
 msgstr "מקור אינטרנטי"
 
 #. Translators: Label for "previous page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:5
+#: corpus/templates/corpus/snippets/pagination.html:5
 msgid "Previous"
 msgstr "הקודם"
 
 #. Translators: Title for link to page number in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:19
+#: corpus/templates/corpus/snippets/pagination.html:19
 #, python-format
 msgid "page %(number)s"
 msgstr "%(number)s עמודים"
 
 #. Translators: Label for "next page" button in search results
-#: geniza/corpus/templates/corpus/snippets/pagination.html:60
+#: corpus/templates/corpus/snippets/pagination.html:60
 msgid "Next"
 msgstr "הבא"
 
 #. Translators: title of document search page
-#: geniza/corpus/views.py:42
+#: corpus/views.py:42
 msgid "Search Documents"
 msgstr "חיפוש מסמכים"
 
 #. Translators: description of document search page, for search engines
-#: geniza/corpus/views.py:44
+#: corpus/views.py:44
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
 #. Translators: title of document scholarship page
-#: geniza/corpus/views.py:350
+#: corpus/views.py:350
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "רשומה קשורה ל-%(doc)s"
 
-#: geniza/corpus/views.py:357
+#: corpus/views.py:357
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -456,12 +453,12 @@ msgstr[2] "%(count)d רשומות קשורות"
 msgstr[3] "%(count)d רשומות קשורות"
 
 #. Translators: title of related documents page
-#: geniza/corpus/views.py:398
+#: corpus/views.py:398
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "מסמכים קשורים %(doc)s"
 
-#: geniza/corpus/views.py:405
+#: corpus/views.py:405
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -471,29 +468,29 @@ msgstr[2] "%(count)d מסמכים קשורים"
 msgstr[3] "%(count)d מסמכים קשורים"
 
 #. Translators: Placeholder for when a work has no title available
-#: geniza/footnotes/models.py:211
+#: footnotes/models.py:211
 msgid "[digital geniza document edition]"
 msgstr "[גרסת מסמך גניזה דיגיטלי]"
 
-#: geniza/footnotes/models.py:438
+#: footnotes/models.py:438
 msgid "Edition"
 msgstr "מהדורה"
 
-#: geniza/footnotes/models.py:439
+#: footnotes/models.py:439
 msgid "Translation"
 msgstr "תרגום"
 
-#: geniza/footnotes/models.py:440
+#: footnotes/models.py:440
 msgid "Discussion"
 msgstr "דיון"
 
-#: geniza/footnotes/models.py:441
+#: footnotes/models.py:441
 #, fuzzy
 #| msgid "Edition"
 msgid "Digital Edition"
 msgstr "מהדורה"
 
-#: geniza/pages/models.py:13
+#: pages/models.py:13
 msgid ""
 "Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
@@ -501,7 +498,7 @@ msgstr ""
 "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
 "בהקשר זה."
 
-#: geniza/pages/models.py:44
+#: pages/models.py:44
 msgid ""
 "This text will only be read to     non-sighted users and should describe the "
 "major insights or     takeaways from the graphic. Multiple paragraphs are "
@@ -511,131 +508,131 @@ msgstr ""
 "שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
-#: geniza/templates/404.html:5 geniza/templates/404.html:13
+#: templates/404.html:5 templates/404.html:13
 msgid "Not Found"
 msgstr "לא נמצא"
 
 #. Translators: description for Not Found (404) error page
-#: geniza/templates/404.html:7 geniza/templates/404.html:14
+#: templates/404.html:7 templates/404.html:14
 msgid "Oops, you've hit a lacuna! Page not found."
 msgstr "אופס, נתקלת בלאקונה! העמוד המבוקש לא נמצא."
 
 #. Translators: title for Internal Server Error (500) error page
-#: geniza/templates/500.html:5 geniza/templates/500.html:19
+#: templates/500.html:5 templates/500.html:19
 msgid "Server Error"
 msgstr "שגיאת שרת"
 
 #. Translators: description for Internal Server Error (500) error page
-#: geniza/templates/500.html:7 geniza/templates/500.html:20
+#: templates/500.html:7 templates/500.html:20
 msgid "Something went wrong putting this page together."
 msgstr "דבר מה השתבש בהפקת עמוד זה."
 
-#: geniza/templates/admin/base_site.html:4
+#: templates/admin/base_site.html:4
 msgid "Django site admin"
 msgstr "ניהול האתר"
 
-#: geniza/templates/base.html:91
+#: templates/base.html:91
 msgid "Skip to main content"
 msgstr "דילוג לתוכן"
 
 #. Translators: accessibility text label for footer site navigation
-#: geniza/templates/footer.html:4
+#: templates/footer.html:4
 msgid "footer navigation"
 msgstr "ניווט בתחתית העמוד"
 
 #. Translators: accessibility label for Princeton Geniza Lab homepage, for footer
-#: geniza/templates/footer.html:21
+#: templates/footer.html:21
 msgid "Princeton Geniza Lab homepage"
 msgstr "עמוד הבית Princeton Geniza Lab"
 
-#: geniza/templates/footer.html:28 geniza/templates/footer.html:42
+#: templates/footer.html:28 templates/footer.html:42
 #, python-format
 msgid "Follow %(username)s on Twitter."
 msgstr ""
 
 #. Translators: accessibility label for Princeton CDH homepage, for footer
-#: geniza/templates/footer.html:35
+#: templates/footer.html:35
 msgid "Princeton Center for Digital Humanities homepage"
 msgstr "Princeton Center for Digital Humanities עמוד הבית"
 
-#: geniza/templates/footer.html:46
+#: templates/footer.html:46
 #, python-format
 msgid "Follow %(username)s on Instagram."
 msgstr ""
 
 #. Translators: link label for Princeton accessibility assistance page, for footer
-#: geniza/templates/footer.html:56
+#: templates/footer.html:56
 msgid "Accessibility"
 msgstr "נגישות"
 
 #. Translators: official name of Princeton University's board of trustees, for footer
-#: geniza/templates/footer.html:61
+#: templates/footer.html:61
 msgid "The Trustees of Princeton University"
 msgstr "The Trustees of Princeton University"
 
 #. Translators: Creative Commons license text, for footer
-#: geniza/templates/footer.html:65
+#: templates/footer.html:65
 msgid "Creative Commons CC-BY license"
 msgstr "דרישת ייחוס על פי רישיון ״קריאייטיב קומונס״ (CC-BY)"
 
 #. Translators: International Standard Serial Number (ISSN), for footer
-#: geniza/templates/footer.html:72
+#: templates/footer.html:72
 msgid "ISSN: 2834-4146"
 msgstr ""
 
 #. Translators: software version, for footer
-#: geniza/templates/footer.html:76
+#: templates/footer.html:76
 msgid "software version"
 msgstr "גרסת תוכנה"
 
 #. Translators: official name of Princeton University, for footer
-#: geniza/templates/footer.html:83
+#: templates/footer.html:83
 msgid "Princeton University homepage"
 msgstr "עמוד הבית Princeton University"
 
 #. Translators: accessibility text label for site navigation
-#: geniza/templates/nav.html:4
+#: templates/nav.html:4
 msgid "main navigation"
 msgstr "ניווט"
 
 #. Translators: accessibility label for 'home' button in main navigation
-#: geniza/templates/nav.html:11
+#: templates/nav.html:11
 msgid "home"
 msgstr "דף הבית"
 
 #. Translators: site name label for 'home' button in main navigation
-#: geniza/templates/nav.html:13
+#: templates/nav.html:13
 msgid "The Princeton Geniza Project"
 msgstr "The Princeton Geniza Project"
 
 #. Translators: label for 'menu' open button for mobile navigation
-#: geniza/templates/nav.html:24
+#: templates/nav.html:24
 msgid "Open main navigation menu"
 msgstr "פתיחת תפריט ניווט"
 
 #. Translators: label for 'menu' close button for mobile navigation
-#: geniza/templates/nav.html:32
+#: templates/nav.html:32
 msgid "Close main navigation menu"
 msgstr "סגירת תפריט ניווט"
 
 #. Translators: label for language choices in navigation
-#: geniza/templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "קריאת העמוד ב-%(language_name)s (%(language_code)s)"
 
 #. Translators: label for link to 'Search' page in main navigation
-#: geniza/templates/snippets/menu.html:7
+#: templates/snippets/menu.html:7
 msgid "Search"
 msgstr "חיפוש"
 
 #. Translators: label for main menu back button for mobile navigation
-#: geniza/templates/snippets/sub_menu.html:8
+#: templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
 msgstr "חזרה לתפריט הראשי"
 
 #. Translators: label for dark mode/light mode theme switcher
-#: geniza/templates/snippets/theme_toggle.html:5
+#: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
 

--- a/geniza/templates/footer.html
+++ b/geniza/templates/footer.html
@@ -67,6 +67,10 @@
             <img src="{% static 'img/icons/license-icon.svg' %}" width="32" height="16" alt="{{ license_text }}" />
         </a>
     </li>
+    <li id="issn">
+        {# Translators: International Standard Serial Number (ISSN), for footer #}
+        <span>{% translate 'ISSN: 2834-4146' %}</span>
+    </li>
     <li id="sw-version">
         {# Translators: software version, for footer #}
         {% translate 'software version' as version_text %}

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -214,6 +214,7 @@ footer {
         }
 
         li#sw-version {
+            // padding added for tap-target size
             a {
                 padding-bottom: 1.5rem;
             }

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -185,12 +185,11 @@ footer {
             }
         }
 
-        // CC-BY license icon
+        // CC-BY license icon, software version
         li#license,
         li#sw-version {
             margin: 0;
             text-align: center;
-            min-height: 48px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -204,6 +203,10 @@ footer {
             a {
                 text-decoration: none;
             }
+        }
+
+        li#license {
+            min-height: 48px;
         }
 
         li#sw-version {

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -121,10 +121,12 @@ footer {
         }
         // footer links (desktop)
         @include breakpoints.for-tablet-landscape-up {
+            display: flex;
+            justify-content: flex-end;
+            margin-right: spacing.$spacing-3xl;
             & > li {
                 margin: spacing.$spacing-md spacing.$spacing-lg 0 0;
             }
-            display: flex;
             a.logo {
                 display: flex;
                 align-items: center;
@@ -145,9 +147,7 @@ footer {
             grid-area: legal;
             display: flex;
             align-items: center;
-            justify-content: space-between;
             li {
-                flex: 1 0 auto;
                 // accessibility link li
                 &:first-child {
                     text-align: left;
@@ -180,7 +180,8 @@ footer {
                 content: "\f115"; // phosphor copyright icon
             }
             @include breakpoints.for-tablet-landscape-up {
-                margin: 0;
+                margin: 0 0 0 2rem;
+                text-align: left;
                 flex: 0 1 auto;
             }
         }
@@ -198,7 +199,6 @@ footer {
             }
             @include breakpoints.for-tablet-landscape-up {
                 margin: spacing.$spacing-2xs spacing.$spacing-sm 0;
-                flex: 0 1 auto;
             }
             a {
                 text-decoration: none;
@@ -207,11 +207,16 @@ footer {
 
         li#license {
             min-height: 48px;
+            @include breakpoints.for-tablet-landscape-up {
+                flex: 1 0 auto;
+                justify-content: flex-start;
+            }
         }
 
         li#sw-version {
             @include breakpoints.for-tablet-landscape-up {
-                margin: 0;
+                margin: 0 0 0 1.5rem;
+                flex: 0 1 auto;
             }
         }
 
@@ -244,6 +249,11 @@ html[dir="rtl"] footer {
     }
     // reverse icons, alignment, and margin in external links
     ul#footer-links {
+        a.logo {
+            @include breakpoints.for-tablet-landscape-up {
+                justify-content: flex-end;
+            }
+        }
         ul.social {
             li {
                 @include icon-and-text-rtl;
@@ -261,8 +271,6 @@ html[dir="rtl"] footer {
                     text-align: left;
                 }
             }
-            @include breakpoints.for-tablet-landscape-up {
-            }
         }
         @include breakpoints.for-tablet-landscape-up {
             justify-content: flex-end;
@@ -279,6 +287,14 @@ html[dir="rtl"] footer {
             span::after {
                 content: "\f115"; // phosphor copyright icon
             }
+            @include breakpoints.for-tablet-landscape-up {
+                margin: 0 2rem 0 0;
+            }
+        }
+        li#sw-version {
+            @include breakpoints.for-tablet-landscape-up {
+                margin: 0 1.5rem 0 0;
+            }
         }
         @include breakpoints.for-tablet-landscape-up {
             li {
@@ -292,7 +308,7 @@ html[dir="rtl"] footer {
                 &:last-child {
                     text-align: left;
                     padding-right: 0;
-                    padding-left: spacing.$spacing-3xl;
+                    padding-left: spacing.$spacing-2xl;
                     margin-right: 0;
                     margin-left: -#{spacing.$spacing-md};
                 }

--- a/sitemedia/scss/components/_footer.scss
+++ b/sitemedia/scss/components/_footer.scss
@@ -214,7 +214,13 @@ footer {
         }
 
         li#sw-version {
+            a {
+                padding-bottom: 1.5rem;
+            }
             @include breakpoints.for-tablet-landscape-up {
+                a {
+                    padding-bottom: 0;
+                }
                 margin: 0 0 0 1.5rem;
                 flex: 0 1 auto;
             }


### PR DESCRIPTION
## In this PR

- Per #1195:
  - Add ISSN to footer, matching S&co styles
  - Fix resulting lighthouse issue

## Questions

- Does ISSN need a translation? (I assumed yes!)
- To match the S&Co site I needed to make a few other changes to the layout. Can you [take a quick look at Percy](https://percy.io/2cf28a24/geniza/builds/22188898/), and see if the change is acceptable?