### PR TITLE
Improve document metadata export speed

### DIFF
--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -24,7 +24,7 @@ class Exporter:
     model = None
     csv_fields = []
     sep_within_cells = " ; "
-    true_false = {True: "y", False: "n"}
+    true_false = {True: "Y", False: "N"}
 
     def __init__(self, queryset=None, progress=False):
         self.queryset = queryset

--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -364,6 +364,6 @@ def test_base_exporter():
 
     assert exporter.serialize_value(123) == "123"
 
-    assert exporter.serialize_value(True) == "y"
-    assert exporter.serialize_value(False) == "n"
+    assert exporter.serialize_value(True) == "Y"
+    assert exporter.serialize_value(False) == "N"
     assert exporter.serialize_value(None) == ""

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -492,6 +492,7 @@ class DocumentQuerySet(MultilingualQuerySet):
                         "fragment", "fragment__collection"
                     ),
                 ),
+                "footnotes",
             )
             .annotate(shelfmk_all=ArrayAgg("textblock__fragment__shelfmark"))
         )


### PR DESCRIPTION
@quadrismegistus check it out! I was able to improve the prefetching and the export is much faster now.

It was easier to investigate now that we have a script export — I turned on django logging so I could see db calls,  added a 1s sleep so I could see what was going on, and used that to make sure all the db calls were made at the beginning and none per individual document.  Now the script to export all documents completes in around a minute.