### PR TITLE
Refactor footnote export to use new exporter code

### DIFF
--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -96,8 +96,9 @@ class Exporter:
         elif value is None:
             return ""
         elif type(value) in {list, tuple, set}:
+            # don't sort here since order may be meaningful
             return self.sep_within_cells.join(
-                self.serialize_value(subval) for subval in sorted(list(value))
+                self.serialize_value(subval) for subval in list(value)
             )
         else:
             return str(value)

--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -354,13 +354,16 @@ def test_base_exporter():
 
     # serializes correctly?
     sep = exporter.sep_within_cells
+    # should preserve order passed in
     assert exporter.serialize_value([1, 2, 3]) == f"1{sep}2{sep}3"
-    assert exporter.serialize_value([1, 3, 2]) == f"1{sep}2{sep}3"
-    assert exporter.serialize_value({1, 3, 2}) == f"1{sep}2{sep}3"
-    assert exporter.serialize_dict({"key": [1, 3, 2]}) == {"key": f"1{sep}2{sep}3"}
+    assert exporter.serialize_value([1, 3, 2]) == f"1{sep}3{sep}2"
+    assert (
+        exporter.serialize_value({3, 2, 1}) == f"1{sep}2{sep}3"
+    )  # set order not preserved
+    assert exporter.serialize_dict({"key": [1, 3, 2]}) == {"key": f"1{sep}3{sep}2"}
 
     # keys already enforced to be strings by database
-    assert exporter.serialize_dict({"0": [1, 3, 2]}) == {"0": f"1{sep}2{sep}3"}
+    assert exporter.serialize_dict({"0": [1, 3, 2]}) == {"0": f"1{sep}3{sep}2"}
 
     assert exporter.serialize_value(123) == "123"
 

--- a/geniza/footnotes/metadata_export.py
+++ b/geniza/footnotes/metadata_export.py
@@ -56,3 +56,39 @@ class SourceExporter(Exporter):
             # construct directly to avoid extra db calls
             "admin_url": f"{self.url_scheme}{self.site_domain}/admin/footnotes/source/{source.id}/change/",
         }
+
+
+class FootnoteExporter(Exporter):
+    """
+    A subclass of :class:`geniza.common.metadata_export.Exporter` that
+    exports information relating to :class:`~geniza.footnotes.models.Footnote`.
+    """
+
+    model = Footnote
+    csv_fields = [
+        "document",  # ~ content object
+        "document_id",
+        "source",
+        "location",
+        "doc_relation",
+        "notes",
+        "url",
+        "content",
+        "admin_url",
+    ]
+
+    def get_queryset(self):
+        return self.queryset or self.model.objects.all().metadata_prefetch()
+
+    def get_export_data_dict(self, footnote):
+        return {
+            "document": footnote.content_object,
+            "document_id": footnote.content_object.pk,
+            "source": footnote.source,
+            "location": footnote.location,
+            "doc_relation": footnote.get_doc_relation_list(),
+            "notes": footnote.notes,
+            "url": footnote.url,
+            "content": footnote.content_text or "",
+            "admin_url": f"{self.url_scheme}{self.site_domain}/admin/footnotes/footnote/{footnote.id}/change/",
+        }


### PR DESCRIPTION
same thing as what I just did for sources, I refactored the old tabular_export to use our new metadata export code

I also removed the sorting from the common metadata export serialization code — there are cases where the order may be meaningful and order shouldn't be changed.

FYI, I think both of these will need public variants — we don't want to include the admin url in our public exports, but it's useful for the admin downloads.