### PR TITLE
Separate admin and public exports for sources and footnotes

### DIFF
--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -1,3 +1,4 @@
+import codecs
 import csv
 
 from django.conf import settings
@@ -132,8 +133,12 @@ class Exporter:
             else Echo()
         ) as of:
             writer = csv.DictWriter(
-                of, fieldnames=self.csv_fields, extrasaction="ignore"
+                of,
+                fieldnames=self.csv_fields,
+                extrasaction="ignore",
             )
+            # start with byte-order mark so Excel will read unicode properly
+            yield codecs.BOM_UTF8
             yield writer.writeheader()
             yield from (
                 writer.writerow(self.serialize_dict(docd)) for docd in self.iter_dicts()

--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -127,18 +127,19 @@ class Exporter:
         :yield: String of current line in CSV
         :rtype: Generator[str]
         """
+        csv_filename = fn or self.csv_filename()
         with (
-            open(self.csv_filename() if not fn else fn, "w")
+            codecs.open(csv_filename, "w", encoding="utf-8-sig")
             if not pseudo_buffer
             else Echo()
         ) as of:
+            # start with byte-order mark so Excel will read unicode properly
+            yield codecs.BOM_UTF8
             writer = csv.DictWriter(
                 of,
                 fieldnames=self.csv_fields,
                 extrasaction="ignore",
             )
-            # start with byte-order mark so Excel will read unicode properly
-            yield codecs.BOM_UTF8
             yield writer.writeheader()
             yield from (
                 writer.writerow(self.serialize_dict(docd)) for docd in self.iter_dicts()

--- a/geniza/corpus/tests/test_metadata_export.py
+++ b/geniza/corpus/tests/test_metadata_export.py
@@ -159,12 +159,12 @@ def test_http_export_data_csv(document):
     assert headers_d.get("Content-Disposition") == f"attachment; filename={ofn}"
     assert response.status_code == 200
 
-    content_lines = [x.decode() for x in response]
-    # first line should be byte order mark)
-    assert content_lines[0] == codecs.BOM_UTF8.decode()
+    yielded_content = [x.decode() for x in response]
+    # first bit of content should be byte order mark)
+    assert yielded_content[0] == codecs.BOM_UTF8.decode()
 
     # remaining rows should be csv
-    csv_dictreader = csv.DictReader(content_lines[1:])
+    csv_dictreader = csv.DictReader(yielded_content[1:])
 
     # next row should be first row of csv dat
     row = next(csv_dictreader)

--- a/geniza/footnotes/admin.py
+++ b/geniza/footnotes/admin.py
@@ -15,7 +15,7 @@ from django_admin_inline_paginator.admin import TabularInlinePaginated
 from modeltranslation.admin import TabbedTranslationAdmin
 
 from geniza.common.admin import custom_empty_field_list_filter
-from geniza.footnotes.metadata_export import FootnoteExporter, SourceExporter
+from geniza.footnotes.metadata_export import AdminFootnoteExporter, AdminSourceExporter
 from geniza.footnotes.models import (
     Authorship,
     Creator,
@@ -174,7 +174,9 @@ class SourceAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     def export_to_csv(self, request, queryset=None):
         """Stream source records as CSV"""
         queryset = queryset or self.get_queryset(request)
-        return SourceExporter(queryset=queryset, progress=False).http_export_data_csv()
+        return AdminSourceExporter(
+            queryset=queryset, progress=False
+        ).http_export_data_csv()
 
     def get_urls(self):
         """Return admin urls; adds a custom URL for exporting all sources
@@ -301,7 +303,7 @@ class FootnoteAdmin(admin.ModelAdmin):
     def export_to_csv(self, request, queryset=None):
         """Stream footnote records as CSV"""
         queryset = queryset or self.get_queryset(request)
-        return FootnoteExporter(
+        return AdminFootnoteExporter(
             queryset=queryset, progress=False
         ).http_export_data_csv()
 

--- a/geniza/footnotes/metadata_export.py
+++ b/geniza/footnotes/metadata_export.py
@@ -26,7 +26,6 @@ class SourceExporter(Exporter):
         "url",
         "notes",
         "num_footnotes",
-        "admin_url",
     ]
 
     def get_queryset(self):
@@ -53,15 +52,13 @@ class SourceExporter(Exporter):
             "notes": source.notes,
             # count via annotated queryset
             "num_footnotes": source.footnote__count,
-            # construct directly to avoid extra db calls
-            "admin_url": f"{self.url_scheme}{self.site_domain}/admin/footnotes/source/{source.id}/change/",
         }
 
 
 class FootnoteExporter(Exporter):
     """
     A subclass of :class:`geniza.common.metadata_export.Exporter` that
-    exports information relating to :class:`~geniza.footnotes.models.Footnote`.
+    exports public information relating to :class:`~geniza.footnotes.models.Footnote`.
     """
 
     model = Footnote
@@ -90,5 +87,33 @@ class FootnoteExporter(Exporter):
             "notes": footnote.notes,
             "url": footnote.url,
             "content": footnote.content_text or "",
-            "admin_url": f"{self.url_scheme}{self.site_domain}/admin/footnotes/footnote/{footnote.id}/change/",
         }
+
+
+class AdminSourceExporter(SourceExporter):
+    """Admin version of :class:`~geniza.footnotes.metadata_export.SourceExporter`;
+    adds admin urls to the output."""
+
+    csv_fields = SourceExporter.csv_fields + ["admin_url"]
+
+    def get_export_data_dict(self, source):
+        data = super().get_export_data_dict(source)
+        # construct directly to avoid extra db calls
+        data[
+            "admin_url"
+        ] = f"{self.url_scheme}{self.site_domain}/admin/footnotes/source/{source.id}/change/"
+        return data
+
+
+class AdminFootnoteExporter(FootnoteExporter):
+    """Admin version of :class:`~geniza.footnotes.metadata_export.FootnoteExporter`;
+    adds admin urls to the output."""
+
+    csv_fields = FootnoteExporter.csv_fields + ["admin_url"]
+
+    def get_export_data_dict(self, footnote):
+        data = super().get_export_data_dict(footnote)
+        data[
+            "admin_url"
+        ] = f"{self.url_scheme}{self.site_domain}/admin/footnotes/footnote/{footnote.id}/change/"
+        return data

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -590,8 +590,10 @@ class Footnote(TrackChangesModel):
     @property
     def content_text(self):
         "content as plain text, if available"
-        # content html is a dict; values are lists of html content
-        return strip_tags(self.content_html_str)
+        # strip tags from content html (as single string), if set
+        # but only return if we have content (otherwise returns string "None")
+        if self.content_html_str:
+            return strip_tags(self.content_html_str)
 
     def iiif_annotation_content(self):
         """Return transcription content from this footnote (if any)

--- a/geniza/footnotes/tests/test_footnote_metadata_export.py
+++ b/geniza/footnotes/tests/test_footnote_metadata_export.py
@@ -66,6 +66,8 @@ def test_footnote_export_data(source, document):
     assert data["doc_relation"] == footnote.get_doc_relation_list()
     assert data["notes"] == footnote.notes
     assert "admin_url" not in data
+    # empty content should not serialize to None
+    assert data["content"] == ""
 
 
 @pytest.mark.django_db

--- a/geniza/footnotes/tests/test_footnote_metadata_export.py
+++ b/geniza/footnotes/tests/test_footnote_metadata_export.py
@@ -1,6 +1,12 @@
 import pytest
 
-from geniza.footnotes.metadata_export import SourceExporter
+from geniza.footnotes.metadata_export import (
+    AdminFootnoteExporter,
+    AdminSourceExporter,
+    FootnoteExporter,
+    SourceExporter,
+)
+from geniza.footnotes.models import Footnote
 
 
 @pytest.mark.django_db
@@ -30,7 +36,47 @@ def test_source_export_data(source):
     assert source.languages.first().name in data["languages"]
     # no footnotes in this fixture
     assert data["num_footnotes"] == 0
+    assert "admin_url" not in data
+
+
+@pytest.mark.django_db
+def test_admin_source_export_data(source):
+    admin_src_exporter = AdminSourceExporter()
+    # get source via exporter queryset for footnote count annotation
+    source_obj = admin_src_exporter.get_queryset().get(pk=source.id)
+    data = admin_src_exporter.get_export_data_dict(source_obj)
     assert (
         data["admin_url"]
         == f"https://example.com/admin/footnotes/source/{source.id}/change/"
+    )
+
+
+@pytest.mark.django_db
+def test_footnote_export_data(source, document):
+    footnote = Footnote(source=source, location="p. 11", notes="extra details")
+    footnote.content_object = document
+    footnote.save()
+
+    fn_exporter = FootnoteExporter()
+    data = fn_exporter.get_export_data_dict(footnote)
+    assert data["document"] == document
+    assert data["document_id"] == document.pk
+    assert data["source"] == source
+    assert data["location"] == footnote.location
+    assert data["doc_relation"] == footnote.get_doc_relation_list()
+    assert data["notes"] == footnote.notes
+    assert "admin_url" not in data
+
+
+@pytest.mark.django_db
+def test_admin_footnote_export_data(source, document):
+    footnote = Footnote(source=source)
+    footnote.content_object = document
+    footnote.save()
+
+    admin_fn_exporter = AdminFootnoteExporter()
+    data = admin_fn_exporter.get_export_data_dict(footnote)
+    assert (
+        data["admin_url"]
+        == f"https://example.com/admin/footnotes/footnote/{footnote.id}/change/"
     )


### PR DESCRIPTION
Splits out admin and public versions of source and footnote exporter
- makes the base exporter the public versions (for use in metadata export script)
- create admin variants that add admin url
- use admin exporter for admin csv export functionality
- unit tests for the changes

#1100 - updates for footnote export based on problems found in testing:
- `content_text` was returning text `None` when there was no content
- added UTF-8 byte order mark at beginning of CSV so that Excel will read content correctly
