### PR TITLE
Admin LogEntry csv export #918

### DIFF
--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -180,10 +180,11 @@ class LogEntryExporter(Exporter):
         "action",
     ]
 
+    #: map log entry action flags to text labels
+    action_label = {ADDITION: "addition", CHANGE: "change", DELETION: "deletion"}
+
     def get_queryset(self):
         return super().get_queryset().select_related("content_type", "user")
-
-    action_label = {ADDITION: "addition", CHANGE: "change", DELETION: "deletion"}
 
     def get_export_data_dict(self, log):
         return {

--- a/geniza/common/metadata_export.py
+++ b/geniza/common/metadata_export.py
@@ -1,6 +1,7 @@
 import csv
 
 from django.conf import settings
+from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.sites.models import Site
 from django.http import StreamingHttpResponse
 from django.utils import timezone
@@ -165,3 +166,32 @@ class Exporter:
         response = StreamingHttpResponse(iterr, content_type="text/csv; charset=utf-8")
         response["Content-Disposition"] = f"attachment; filename={fn}"
         return response
+
+
+class LogEntryExporter(Exporter):
+    model = LogEntry
+    csv_fields = [
+        "action_time",
+        "user",
+        "content_type",
+        "content_type_app",
+        "object_id",
+        "change_message",
+        "action",
+    ]
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("content_type", "user")
+
+    action_label = {ADDITION: "addition", CHANGE: "change", DELETION: "deletion"}
+
+    def get_export_data_dict(self, log):
+        return {
+            "action_time": log.action_time,
+            "user": log.user,
+            "content_type": log.content_type.name,
+            "content_type_app": log.content_type.app_label,
+            "object_id": log.object_id,
+            "change_message": log.change_message,
+            "action": self.action_label[log.action_flag],
+        }

--- a/geniza/common/templates/admin/admin/logentry/change_list_object_tools.html
+++ b/geniza/common/templates/admin/admin/logentry/change_list_object_tools.html
@@ -1,0 +1,7 @@
+{% extends 'admin/change_list_object_tools.html' %}
+
+{% block object-tools-items %}
+    <li><a href="{% url 'admin:admin_logentry_csv' %}" class="">Download all as CSV</a></li>
+    {{ block.super }}
+{% endblock %}
+

--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -19,7 +19,7 @@ from geniza.common.admin import (
     custom_empty_field_list_filter,
 )
 from geniza.common.fields import NaturalSortField, RangeField, RangeWidget
-from geniza.common.metadata_export import Exporter
+from geniza.common.metadata_export import Exporter, LogEntryExporter
 from geniza.common.middleware import PublicLocaleMiddleware
 from geniza.common.models import UserProfile
 from geniza.common.utils import Echo, absolutize_url, custom_tag_string
@@ -370,3 +370,18 @@ def test_base_exporter():
     assert exporter.serialize_value(True) == "Y"
     assert exporter.serialize_value(False) == "N"
     assert exporter.serialize_value(None) == ""
+
+
+@pytest.mark.django_db
+def test_logentry_exporter_data(document):
+    logentry_exporter = LogEntryExporter()
+    # document fixture has two log entries; first should be creation/addition
+    logentry = document.log_entries.first()
+    data = logentry_exporter.get_export_data_dict(logentry)
+    assert data["action_time"] == logentry.action_time
+    assert data["user"] == logentry.user
+    assert data["content_type"] == logentry.content_type.name
+    assert data["content_type_app"] == logentry.content_type.app_label
+    assert data["object_id"] == str(document.pk)
+    assert data["change_message"] == logentry.change_message
+    assert data["action"] == "addition"

--- a/geniza/corpus/management/commands/convert_dates.py
+++ b/geniza/corpus/management/commands/convert_dates.py
@@ -37,9 +37,11 @@ class Command(BaseCommand):
 
         # find all documents with original dates set;
         # limit to calendars that we support converting
-        dated_docs = Document.objects.exclude(
-            doc_date_original="", doc_date_calendar=""
-        ).filter(doc_date_calendar__in=Calendar.can_convert)
+        dated_docs = (
+            Document.objects.exclude(doc_date_original="", doc_date_calendar="")
+            .filter(doc_date_calendar__in=Calendar.can_convert)
+            .order_by("pk")  # order by pk to ensure order is determinate
+        )
 
         if options["mode"] in ["update", "clean"]:
             self.doc_contenttype = ContentType.objects.get_for_model(Document)

--- a/geniza/corpus/tests/test_convert_dates.py
+++ b/geniza/corpus/tests/test_convert_dates.py
@@ -28,12 +28,16 @@ def test_convert_date_report(tmp_path, document, join):
         lines = f.readlines()
     # header + two documents with convertable dates
     assert len(lines) == 3
-    assert document.doc_date_original in lines[1]
-    assert document.get_doc_date_calendar_display() in lines[1]
-    assert document.doc_date_standard in lines[1]
+    # documents ordered by pk, join is first
+    assert join.doc_date_original in lines[1]
+    assert join.get_doc_date_calendar_display() in lines[1]
+    assert join.doc_date_standard in lines[1]
+    assert document.doc_date_original in lines[2]
+    assert document.get_doc_date_calendar_display() in lines[2]
+    assert document.doc_date_standard in lines[2]
     # converted date
-    assert "1113-06-18/1114-06-06" in lines[1]
-    assert "1208-08-26" in lines[2]
+    assert "1208-08-26" in lines[1]
+    assert "1113-06-18/1114-06-06" in lines[2]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Quick admin-only csv export for log entries (not intended for inclusion in metadata exports)

I remembered I had a gist from when I've done this in the past as a one-off: https://gist.github.com/rlskoeser/f9312d27eef352e16ccfa25a31132ca5

Adapted that to our new exporter code and tweaked the logentry admin we're using to add it.