### PR TITLE
Update annotation tests failing due to missing required footnote

### DIFF
--- a/geniza/annotations/tests/test_annotations_signals.py
+++ b/geniza/annotations/tests/test_annotations_signals.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 from django.contrib.admin.models import ADDITION, CHANGE, DELETION, LogEntry
 from django.contrib.auth.models import User
@@ -16,6 +17,7 @@ from geniza.corpus.models import Document
 from geniza.footnotes.models import Source
 
 
+@pytest.mark.skip("disabled until annotation signal footnote logic revamped")
 class TestCreateOrDeleteFootnote:
     def test_create_annotation(self, document, source):
         # should create a DIGITAL_EDITION footnote if one does not exist

--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -11,6 +11,7 @@ from pytest_django.asserts import assertContains, assertNotContains
 
 from geniza.annotations.models import Annotation
 from geniza.annotations.views import AnnotationResponse
+from geniza.footnotes.models import Footnote
 
 
 @pytest.mark.django_db
@@ -19,8 +20,12 @@ class TestAnnotationList:
     anno_list_url = reverse("annotations:list")
 
     def test_get_annotation_list(self, client, annotation):
-        anno1 = Annotation.objects.create(content={**annotation.content, "foo": "bar"})
-        anno2 = Annotation.objects.create(content={**annotation.content, "baz": "qux"})
+        anno1 = Annotation.objects.create(
+            footnote=annotation.footnote, content={**annotation.content, "foo": "bar"}
+        )
+        anno2 = Annotation.objects.create(
+            footnote=annotation.footnote, content={**annotation.content, "baz": "qux"}
+        )
 
         response = client.get(self.anno_list_url)
         assert response.status_code == 200
@@ -49,6 +54,7 @@ class TestAnnotationList:
         # not logged in, should get permission denied error
         assert response.status_code == 403
 
+    @pytest.mark.skip("disabled until annotation create view handles footnote logic")
     def test_post_annotation_list_admin(self, admin_client, annotation):
         response = admin_client.post(
             self.anno_list_url,
@@ -170,13 +176,16 @@ class TestAnnotationDetail:
 class TestAnnotationSearch:
     anno_search_url = reverse("annotations:search")
 
-    def test_search_uri(self, client, document, annotation):
+    def test_search_uri(self, client, document, annotation, source):
         # content__target__source__id=target_uri)
         manifest_uri = reverse(
             "corpus-uris:document-manifest", kwargs={"pk": document.pk}
         )
         target_uri = "http://example.com/target/1"
+
+        footnote = Footnote.objects.create(source=source, content_object=document)
         anno1 = Annotation.objects.create(
+            footnote=footnote,
             content={
                 **annotation.content,
                 "target": {
@@ -185,9 +194,10 @@ class TestAnnotationSearch:
                         "partOf": {"id": manifest_uri},
                     }
                 },
-            }
+            },
         )
         anno2 = Annotation.objects.create(
+            footnote=footnote,
             content={
                 **annotation.content,
                 "target": {
@@ -196,7 +206,7 @@ class TestAnnotationSearch:
                         "partOf": {"id": manifest_uri},
                     }
                 },
-            }
+            },
         )
         response = client.get(self.anno_search_url, {"uri": target_uri})
         assert response.status_code == 200
@@ -215,19 +225,25 @@ class TestAnnotationSearch:
             "corpus-uris:document-manifest", kwargs={"pk": document.pk}
         )
         source_uri = source.uri
+        footnote = Footnote.objects.create(source=source, content_object=document)
         anno1 = Annotation.objects.create(
-            content={**annotation.content, "dc:source": source_uri}
+            footnote=footnote, content={**annotation.content, "dc:source": source_uri}
+        )
+        twoauthor_footnote = Footnote.objects.create(
+            source=twoauthor_source, content_object=document
         )
         anno2 = Annotation.objects.create(
-            content={**annotation.content, "dc:source": twoauthor_source.uri}
+            footnote=twoauthor_footnote,
+            content={**annotation.content, "dc:source": twoauthor_source.uri},
         )
         anno3 = Annotation.objects.create(
+            footnote=footnote,
             content={
                 **annotation.content,
                 "target": {
                     "source": {"id": source_uri, "partOf": {"id": manifest_uri}}
                 },
-            }
+            },
         )
         response = client.get(self.anno_search_url, {"source": source_uri})
         assert response.status_code == 200
@@ -242,11 +258,15 @@ class TestAnnotationSearch:
     def test_search_manifest(self, client, source, document):
         # content__target__source__partOf__id=manifest_uri
         # within manifest
+        footnote = Footnote.objects.create(source=source, content_object=document)
         anno1 = Annotation.objects.create(
-            content={"target": {"source": {"partOf": {"id": document.manifest_uri}}}}
+            footnote=footnote,
+            content={"target": {"source": {"partOf": {"id": document.manifest_uri}}}},
         )
         # no manifest
-        anno2 = Annotation.objects.create(content={"dc:source": source.uri})
+        anno2 = Annotation.objects.create(
+            footnote=footnote, content={"dc:source": source.uri}
+        )
         response = client.get(self.anno_search_url, {"manifest": document.manifest_uri})
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/json"
@@ -256,23 +276,26 @@ class TestAnnotationSearch:
         assertContains(response, anno1.uri())
         assertNotContains(response, anno2.uri())
 
-    def test_search_sort(self, client):
-        anno3 = Annotation.objects.create(content={})
-        anno10 = Annotation.objects.create(content={})
-        anno1 = Annotation.objects.create(content={})
-        anno2 = Annotation.objects.create(content={})
+    def test_search_sort(self, client, annotation):
+        anno3 = Annotation.objects.create(footnote=annotation.footnote, content={})
+        anno10 = Annotation.objects.create(footnote=annotation.footnote, content={})
+        anno1 = Annotation.objects.create(footnote=annotation.footnote, content={})
+        anno2 = Annotation.objects.create(footnote=annotation.footnote, content={})
 
         # should return json AnnotationList with resources of length 4
         response = client.get(self.anno_search_url)
         assert response.status_code == 200
         results = response.json()
-        assert "resources" in results and len(results["resources"]) == 4
+        print(results)
+        assert "resources" in results
+        assert len(results["resources"]) == 5  # 4 plus fixture
 
         # in absence of schema:position, should order by created
-        assert results["resources"][0]["id"] == anno3.uri()
-        assert results["resources"][1]["id"] == anno10.uri()
-        assert results["resources"][2]["id"] == anno1.uri()
-        assert results["resources"][3]["id"] == anno2.uri()
+        assert results["resources"][0]["id"] == annotation.uri()
+        assert results["resources"][1]["id"] == anno3.uri()
+        assert results["resources"][2]["id"] == anno10.uri()
+        assert results["resources"][3]["id"] == anno1.uri()
+        assert results["resources"][4]["id"] == anno2.uri()
 
         # now set schema:position to reorder
         anno3.set_content({"schema:position": 3})
@@ -283,13 +306,16 @@ class TestAnnotationSearch:
         anno1.save()
         anno2.set_content({"schema:position": 2})
         anno2.save()
+        annotation.set_content({"schema:position": 5})
+        annotation.save()
 
         response = client.get(self.anno_search_url)
         results = response.json()
 
-        # results should respect schema:position order: 1, 2, 3, 10
+        # results should respect schema:position order: 1, 2, 3, 5, 10
         assert results["resources"][0]["id"] == anno1.uri()
         assert results["resources"][1]["id"] == anno2.uri()
         assert results["resources"][2]["id"] == anno3.uri()
-        assert results["resources"][3]["id"] == anno10.uri()
+        assert results["resources"][3]["id"] == annotation.uri()
+        assert results["resources"][4]["id"] == anno10.uri()
         assert results["resources"][-1]["schema:position"] == 10


### PR DESCRIPTION
update failing annotation tests:
- provide required footnote when instantiating (where possible / where makes sense)
- mark as skipped tests that depend on in-progress changes like signal handling (should be re-enabled and updated as needed as that work is completed)