### PR TITLE
doi + citation file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,91 @@
+{
+  "contributors": [
+    {
+      "orcid": "0000-0003-4510-2388",
+      "affiliation": "Princeton University",
+      "type": "ProjectLeader",
+      "name": "Rustow, Marina"
+    },
+    {
+      "orcid": "0000-0002-9349-6097",
+      "affiliation": "Princeton University",
+      "type": "ProjectManager",
+      "name": "Ryzhova, Ksenia"
+    },
+    {
+      "affiliation": "Princeton University",
+      "type": "ProjectManager",
+      "name": "Richman, Rachel"
+    },
+    {
+      "type": "Other",
+      "name": "Janco, Andrew"
+    },
+    {
+      "type": "Other",
+      "name": "Duffy-Massey, Owen"
+    }
+  ],
+  "license": "Apache-2.0",
+  "related_identifiers": [
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/Princeton-CDH/geniza/tree/4.11",
+      "relation": "isSupplementTo"
+    },
+    {
+      "scheme": "url",
+      "identifier": "https://geniza.princeton.edu/",
+      "relation": "compiles"
+    },
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/princetongenizalab/pgp-metadata",
+      "relation": "compiles",
+      "resource_type": "dataset"
+    },
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/princetongenizalab/pgp-text",
+      "relation": "compiles",
+      "resource_type": "dataset"
+    },
+    {
+      "scheme": "doi",
+      "identifier": "10.5281/zenodo.7347725",
+      "relation": "isVersionOf"
+    }
+  ],
+  "upload_type": "software",
+  "creators": [
+    {
+      "orcid": "0000-0002-8762-8057",
+      "affiliation": "Center for Digital Humanities, Princeton University",
+      "name": "Koeser, Rebecca Sutton"
+    },
+    {
+      "orcid": "0000-0002-6702-6964",
+      "affiliation": "Center for Digital Humanities, Princeton University",
+      "name": "Doroudian, Gissoo"
+    },
+    {
+      "orcid": "0000-0002-4597-439X",
+      "affiliation": "Performant Software",
+      "name": "Silverman, Ben"
+    },
+    {
+      "orcid": "0000-0002-4542-0899",
+      "name": "Budak, Nick"
+    },
+    {
+      "orcid": "0000-0003-2577-8102",
+      "name": "McElwee, Kevin"
+    },
+    {
+      "orcid": "0000-0002-4155-4961",
+      "affiliation": "Center for Digital Humanities, Princeton University",
+      "name": "Heuser, Ryan"
+    }
+  ],
+  "access_right": "open"
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,64 @@
+# YAML 1.2
+# Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
+cff-version: 1.0.3
+message: If you use this software, please cite it using these metadata.
+# FIXME title as repository name might not be the best name, please make human readable
+title: 'Princeton-CDH/geniza: v4.11'
+doi: 10.5281/zenodo.7347726
+identifiers:
+  - description: "DOI for all versions of the geniza codebase"
+    type: doi
+    value: 10.5281/zenodo.7347725
+  - description: "DOI for version 4.11 of the geniza codebase"
+    type: doi
+    value: 10.5281/zenodo.7347726
+authors:
+- given-names: Rebecca
+  family-names: Koeser
+  name-particle: Sutton
+  affiliation: Center for Digital Humanities, Princeton University
+  orcid: https://orcid.org/0000-0002-8762-8057
+- given-names: Gissoo
+  family-names: Doroudian
+  affiliation: Center for Digital Humanities, Princeton University
+  orcid: https://orcid.org/0000-0002-6702-6964
+- given-names: Ben
+  family-names: Silverman
+  affiliation: Performant Software
+  orcid: https://orcid.org/0000-0002-4597-439X
+- given-names: Nick
+  family-names: Budak
+  orcid: https://orcid.org/0000-0002-4542-0899
+- given-names: Kevin
+  family-names: McElwee
+  orcid: https://orcid.org/0000-0003-2577-8102
+- given-names: Ryan
+  family-names: Heuser
+  affiliation: Center for Digital Humanities, Princeton University
+  orcid: https://orcid.org/0000-0002-4155-4961
+version: '4.11'
+date-released: 2022-11-22
+repository-code: https://github.com/Princeton-CDH/geniza
+license: Apache-2.0
+references:
+- type: website
+  title: Princeton Geniza Project (v4.x)
+  year: 2022
+  authors:
+  - name: The Center for Digital Humanities at Princeton
+    website: https://cdh.princeton.edu
+  url: https://geniza.princeton.edu/
+- type: dataset
+  title: Princeton Geniza Project metadata
+  year: 2022
+  url: https://github.com/princetongenizalab/pgp-metadata
+- type: dataset
+  title: Princeton Geniza Project text
+  year: 2022
+  url: https://github.com/princetongenizalab/pgp-text
+keywords:
+ - geniza
+ - judaeo-arabic
+ - "digital humanities"
+ - python
+ - django

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ Python/Django web application for a version 4.x of the `Princeton Geniza Project
 
 Python 3.9 / Django 3.2 / Node 16 / Postgresql / Solr 8.6
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.7347726.svg
+   :target: https://doi.org/10.5281/zenodo.7347726
 
 .. image:: https://github.com/Princeton-CDH/geniza/workflows/unit%20tests/badge.svg
     :target: https://github.com/Princeton-CDH/geniza/actions?query=workflow%3Aunit&20tests


### PR DESCRIPTION
I've turned on Zenodo sync and tagged a release, which created a DOI for the codebase.

In this update:
- add DOI badge to readme
- add zenodo metadata file with information I added to the DOI record, for inclusion in future releases
- add CITATION.cff with the same information, to make easily citable on GitHub  