### PR TITLE
address transcription label text direction

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -137,6 +137,7 @@
                                     <div class="transcription ed-{{ edition.pk }}"
                                         data-label="{{ edition.source.formatted_display }}"
                                         lang="{{ document.primary_lang_code|default:"" }}"
+                                        dir="rtl"
                                         {% if document.primary_script %}
                                             data-lang-script="{{ document.primary_script|lower }}"{% endif %}
                                     >

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -948,7 +948,12 @@ a.editor-navigation {
     align-self: flex-end;
 
     text-align: right;
-    // direction: rtl; /* search results ae mixed rtl/ltr and include unicode order mark characters */
+    // direction: rtl; /* search results are mixed rtl/ltr and include unicode order mark characters */
+
+    // section labels are LTR
+    h3 {
+        direction: ltr;
+    }
 
     .search-result & p {
         text-align: right;


### PR DESCRIPTION
ref #1216 

- explicitly set text direction for transcription labels
- set text direction in html for transcription block in itt panel, for consistency with search results
 