### PR TITLE
transcription text cleanup

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from functools import cached_property
 
 import bleach
+from bs4 import BeautifulSoup
 from django.contrib import admin
 from django.db import models
 from django.urls import reverse
@@ -160,13 +161,27 @@ class Annotation(TrackChangesModel):
     @classmethod
     def sanitize_html(cls, html):
         """Sanitizes passed HTML according to allowed tags and attributes, stripping out any
-        that are not allowed."""
-        return bleach.clean(
+        that are not allowed, and spans with no attributes."""
+        # strip down to allowed tags and attributes
+        cleaned_html = bleach.clean(
             html,
             tags=cls.ALLOWED_TAGS,
             attributes=cls.ALLOWED_ATTRIBUTES,
             strip=True,
         )
+        # if resulting text has any span elements with no attributes, remove them
+        if "<span>" in cleaned_html:
+            # parse as html to identify spans with no attributes
+            soup = BeautifulSoup(cleaned_html)
+            for span in soup.find_all("span"):
+                # if span has no attributes, unwrap the text and remove the span tag
+                if not span.attrs:
+                    span.unwrap()
+            # serialize back out as html without wrapping html/body tags
+            return "".join(str(el) for el in soup.html.body.children)
+
+        else:
+            return cleaned_html
 
     def compile(self, include_context=True):
         """Combine annotation data and return as a dictionary that

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -117,6 +117,10 @@ class TestAnnotation:
         html = '<p>test <span lang="en">en</span></p><ol><li>line 1</li><li>line 2</li></ol>'
         assert Annotation.sanitize_html(html) == html
 
+        # should remove span elements with no attributes after bleaching
+        html = '<p>text <span style="foo:bar">and</span> more text</p>'
+        assert Annotation.sanitize_html(html) == "<p>text and more text</p>"
+
 
 @pytest.mark.django_db
 class TestAnnotationQuerySet:

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -3,6 +3,7 @@ from functools import cached_property
 from os import path
 from urllib.parse import urljoin
 
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -591,10 +592,11 @@ class Footnote(TrackChangesModel):
     @property
     def content_text(self):
         "content as plain text, if available"
-        # strip tags from content html (as single string), if set
+        # use beautiful soup to parse html content and return as text
+        # (strips tags and convert entities to plain text equivalent)
         # but only return if we have content (otherwise returns string "None")
         if self.content_html_str:
-            return strip_tags(self.content_html_str)
+            return BeautifulSoup(self.content_html_str).get_text()
 
     def iiif_annotation_content(self):
         """Return transcription content from this footnote (if any)

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -308,6 +308,16 @@ class TestFootnote:
         digital_edition_fnote = document.digital_editions()[0]
         assert digital_edition_fnote.content_text == strip_tags(annotation.body_content)
 
+    def test_content_text_entities(self, annotation):
+        annotation.content["body"][0]["value"] = "annotation with entities &amp; &gt;"
+        annotation.save()
+        manifest_uri = annotation.content["target"]["source"]["partOf"]["id"]
+        source_uri = annotation.content["dc:source"]
+        source = Source.from_uri(source_uri)
+        document = Document.from_manifest_uri(manifest_uri)
+        digital_edition_fnote = document.digital_editions()[0]
+        assert digital_edition_fnote.content_text == "annotation with entities & >"
+
     def test_content_text_empty(self, source, document):
         edition = Footnote.objects.create(
             source=source, content_object=document, doc_relation=[Footnote.EDITION]


### PR DESCRIPTION
addresses two problems documented in #1239  (primarily impacts transcription export)
- properly encode entities when converting to plain text
- remove empty spans when sanitizing transcription html