### PR TITLE
Remove transcription/images check for IIT panel in doc admin (#1253)

### DIFF
--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -55,12 +55,10 @@
         {% endif %}
     {% endwith %}
 
-    {% if original.digital_editions or original.has_image %}
-        <fieldset class="module aligned transcriptions-field">
-            <div class="form-row">
-                <label>Transcription{{ original.digital_editions.count|pluralize }}/image{{ original.iiif_images|length|pluralize }}</label>
-                {% include "corpus/snippets/document_transcription.html" with document=original %}
-            </div>
-        </fieldset>
-    {% endif %}
+    <fieldset class="module aligned transcriptions-field">
+        <div class="form-row">
+            <label>Transcription{{ original.digital_editions.count|pluralize }}/image{{ original.iiif_images|length|pluralize }}</label>
+            {% include "corpus/snippets/document_transcription.html" with document=original %}
+        </div>
+    </fieldset>
 {% endblock %}


### PR DESCRIPTION
## In this PR

Per #1253:
- Remove conditional that checked for images or transcriptions in order to show the ITT panel, and thus allow adding transcriptions. This conditional prevented users from seeing an "add transcription" link when there was no image or transcription on the document.