### PR TITLE
Show an error on saving a new document without a fragment (#935)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -137,7 +137,8 @@ class DocumentTextBlockInline(SortableInlineAdminMixin, admin.TabularInline):
         "thumbnail",
         "selected_images",
     )
-    extra = 1
+    min_num = 1
+    extra = 0
     formfield_overrides = {
         CharField: {"widget": TextInput(attrs={"size": "10"})},
         ArrayField: {"widget": HiddenInput()},  # hidden input for selected_images


### PR DESCRIPTION
## In this PR

Per #935:
- In `DocumentTextBlockInline`, instead of using `extra = 1`, use `min_num = 1` and `extra = 0` to show one TextBlock inline form field. This causes an error to appear when saving the record without attaching a fragment.

Note that it's technically still possible to have a document without a fragment, but one has to attach a fragment first and then manually remove it to achieve that state.