### PR TITLE
Ensure 2nd image in JRL IIIF is always "verso"

### DIFF
--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -1,0 +1,6 @@
+# requirements for the scripts in the scripts directory
+
+iiif
+pandas
+python-slugify
+ratelimit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,8 @@
 This directory contains stand-alone scripts associated with
 Princeton Geniza Project that are not part of the web application proper.
 
+Requirements for these scripts can be found in `requirements/scripts.txt`.
+
 ## IIIF
 
 Scripts for generating and managing static iiif content (manifests and
@@ -11,6 +13,7 @@ iiif image api level 0 images) for import and display in PGP.
 -   bodleian_iiif.py : generate iiif maniests from Bodleian TEI XML
 -   tile_images.py : generate static image tiles; includes extra image sizes needed for PGP application
 -   manifests_to_csv.py: generate a CSV file for importing IIIF urls into PGP
+-   jrl_iiif.py: generate remixed iiif maniests from Manchester JRL manifests
 
 ### Bulk editing
 

--- a/scripts/jrl_iiif.py
+++ b/scripts/jrl_iiif.py
@@ -116,12 +116,19 @@ def combine_manifests(csvfilepath, output_dir):
                 v.label: v.value for v in manifest.sequences[0].canvases[0].metadata
             }
             reference_number = row.reference_number
+
+            # NOTE: not every record has a folio; use reference number as fallback
+            folio = canvas_metadata.get("Folio", reference_number)
+            # override folio to use "verso" for second image, in case of double recto
+            if row.sequence == "2" and "recto" in folio:
+                folio = folio.replace("recto", "verso")
+
             if current_shelfmark == shelfmark:
                 # add canvas + image from current manifest to the new one
                 add_canvas_to_manifest(
                     manifest,
                     seq,
-                    canvas_metadata.get("Folio", reference_number),
+                    folio,
                     reference_number,
                 )
 
@@ -175,13 +182,10 @@ def combine_manifests(csvfilepath, output_dir):
                 # add canvas + image from current manifest to the new one;
                 # use folio information from metadata (when available),
                 # since it provides additional information
-
-                # NOTE: not every record has a folio;
-                # use reference number as fallback
                 add_canvas_to_manifest(
                     manifest,
                     seq,
-                    canvas_metadata.get("Folio", reference_number),
+                    folio,
                     reference_number,
                 )
 

--- a/scripts/jrl_iiif.py
+++ b/scripts/jrl_iiif.py
@@ -7,13 +7,11 @@
 
 
 import argparse
-import csv
 import os.path
 from urllib.parse import urlencode
 
 import pandas as pd
 from iiif_prezi.factory import ManifestFactory
-from piffle.image import IIIFImageClient
 from piffle.presentation import IIIFPresentation
 from ratelimit import limits
 from rich.progress import Progress


### PR DESCRIPTION
## In this PR

Per #1288 
- Use `row.sequence` to find the second image in each set from JRL IIIF, and ensure that its label reads "verso" and not "recto"

## Questions

- Is there a way to test this locally, and what settings should I use to do so?
- When this is ready to go, can you help me walk through the steps to run this script on the server and deploy? I imagine it's similar to what we did with the IIIF CSV import, but since it involves the extra step of publishing to GitHub (and it involves existing records) I want to make sure I don't mess it up.