### PR TITLE
Display proper validation errors on duplicate digital editions (#1252)

### DIFF
--- a/geniza/footnotes/admin.py
+++ b/geniza/footnotes/admin.py
@@ -141,7 +141,7 @@ class DocumentFootnoteInlineFormSet(BaseGenericInlineFormSet):
         """
         super().clean()
         # raise validation error if deleting footnote with associated annos
-        valid_forms = [form for form in self.forms if form.is_valid()]
+        valid_forms = [form for form in self.forms if hasattr(form, "cleaned_data")]
         if any(
             [
                 form.cleaned_data.get("DELETE")

--- a/geniza/footnotes/admin.py
+++ b/geniza/footnotes/admin.py
@@ -327,7 +327,6 @@ class FootnoteForm(forms.ModelForm):
         Raise error on attempted creation of a Digital Edition footnote if one
         already exists on this document and source
         """
-        print(self.data)
         super().clean()
         if (
             Footnote.DIGITAL_EDITION in self.cleaned_data.get("doc_relation", [])

--- a/geniza/footnotes/tests/test_footnote_admin.py
+++ b/geniza/footnotes/tests/test_footnote_admin.py
@@ -1,18 +1,22 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from django.contrib import admin
+from django.contrib.contenttypes.forms import generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
+from django.forms.models import inlineformset_factory
 from django.test import RequestFactory
 from django.urls import reverse
-from django.utils import timezone
 
 from geniza.corpus.models import Document
 from geniza.footnotes.admin import (
+    DocumentFootnoteInlineFormSet,
     DocumentRelationTypesFilter,
     FootnoteAdmin,
+    FootnoteForm,
     SourceAdmin,
     SourceFootnoteInline,
+    SourceFootnoteInlineFormSet,
 )
 from geniza.footnotes.metadata_export import FootnoteExporter
 from geniza.footnotes.models import Footnote, Source, SourceType
@@ -224,3 +228,88 @@ class TestSourceFootnoteInline:
 
         assert str(doc.id) in doc_link
         assert str(doc) in doc_link
+
+
+class TestSourceFootnoteInlineFormSet:
+    def test_clean(self, document, source):
+        FormSet = inlineformset_factory(
+            Source, Footnote, exclude=(), formset=SourceFootnoteInlineFormSet
+        )
+        doc_contenttype = ContentType.objects.get(app_label="corpus", model="document")
+        # should raise error if two digital editions on the same document
+        inline_formset = FormSet(
+            data={
+                "footnote_set-INITIAL_FORMS": ["0"],
+                "footnote_set-TOTAL_FORMS": ["2"],
+                "footnote_set-MAX_NUM_FORMS": ["1000"],
+                "footnote_set-0-source": [str(source.pk)],
+                "footnote_set-0-content_type": [str(doc_contenttype.pk)],
+                "footnote_set-0-object_id": [str(document.pk)],
+                "footnote_set-0-doc_relation": [Footnote.DIGITAL_EDITION],
+                "footnote_set-1-source": [str(source.pk)],
+                "footnote_set-1-content_type": [str(doc_contenttype.pk)],
+                "footnote_set-1-object_id": [str(document.pk)],
+                "footnote_set-1-doc_relation": [Footnote.DIGITAL_EDITION],
+            },
+            instance=source,
+        )
+        assert not inline_formset.is_valid()
+
+
+class TestDocumentFootnoteInlineFormSet:
+    def test_clean(self, source):
+        FormSet = generic_inlineformset_factory(
+            Footnote, formset=DocumentFootnoteInlineFormSet
+        )
+        doc = Document.objects.create()
+        # should raise error if two digital editions on the same source
+        inline_formset = FormSet(
+            data={
+                "footnotes-footnote-content_type-object_id-INITIAL_FORMS": ["0"],
+                "footnotes-footnote-content_type-object_id-TOTAL_FORMS": ["2"],
+                "footnotes-footnote-content_type-object_id-MAX_NUM_FORMS": ["1000"],
+                "footnotes-footnote-content_type-object_id-0-source": [str(source.pk)],
+                "footnotes-footnote-content_type-object_id-0-doc_relation": [
+                    Footnote.DIGITAL_EDITION,
+                ],
+                "footnotes-footnote-content_type-object_id-1-source": [str(source.pk)],
+                "footnotes-footnote-content_type-object_id-1-doc_relation": [
+                    Footnote.DIGITAL_EDITION
+                ],
+            },
+            instance=doc,
+        )
+        assert not inline_formset.is_valid()
+
+
+class TestFootnoteForm:
+    def test_clean(self, source, document):
+        # should be invalid when trying to create another digital edition on
+        # the same source and document
+        doc_contenttype = ContentType.objects.get(app_label="corpus", model="document")
+        footnote = Footnote.objects.create(
+            source=source,
+            content_object=document,
+            content_type=doc_contenttype,
+            doc_relation=[Footnote.DIGITAL_EDITION],
+        )
+        form = FootnoteForm(
+            data={
+                "doc_relation": footnote.doc_relation,
+                "content_type": footnote.content_type,
+                "object_id": footnote.object_id,
+                "source": footnote.source,
+            }
+        )
+        assert not form.is_valid()
+
+        # edition should be fine, though!
+        form = FootnoteForm(
+            data={
+                "doc_relation": [Footnote.EDITION],
+                "content_type": footnote.content_type,
+                "object_id": footnote.object_id,
+                "source": footnote.source,
+            }
+        )
+        assert form.is_valid()


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/1252#issuecomment-1382314066:
- Raise validation errors in the `clean` methods of footnote admin inlines and the single footnote admin form, if there are multiple digital editions on the same source/document. Fixes issue where it would just throw a DB integrity error due to the uniqueness constraint violation, and present the user with an opaque 500 error.

## Notes

It's pretty annoying that DB integrity errors don't automatically generate validation errors! 

Also realized I did a lot of extra work for something that wasn't necessary: validating on deletion of footnotes from the Source admin. You can't even do that in the first place! 🤦 

I was originally planning on making this a hotfix (thought showing an error would be simple!), but I think the code changes here are substantial enough to warrant review. Wondering about both the formsets and the testing approach.