### PR TITLE
Ignore TextBlock side info when excluding images (#1295)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -754,7 +754,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                             "label": labels[i],
                             "canvas": canvases[i],
                             "shelfmark": b.fragment.shelfmark,
-                            "excluded": b.side and i not in b.selected_images,
+                            "excluded": i not in b.selected_images,
                         }
 
         # when requested, include any placeholder canvas URIs referenced by any associated transcriptions


### PR DESCRIPTION
## In this PR

Per #1295:
- Fixes issue where sometimes deselected fragment images would still appear as part of the document in the admin

## Notes

After some debugging, I figured out that the exclusions were only failing when there were _no_ selected images in a given `TextBlock`. Seems like the code I removed is a vestigial check from back when `TextBlock.side` was an actual property and not something computed based on `selected_images`—[this is the oldest code I could find](https://github.com/Princeton-CDH/geniza/blame/ee6d8d1e0fb377fe7168e92ef9983da82b6ace28/geniza/corpus/models.py#L624) with this check.

Unit tests are all still passing, and the admin and public images seem to be working as expected, but maybe I'm missing something. Wish I had documented why I was not counting exclusion unless `b.side` was defined. Let me know if you think of any reason why this check would need to be here!

Not directly connected to this check, but a baked-in assumption: I guess the feature was designed thinking that at least _one_ image would be selected in a given TextBlock, or else why attach it as part of the join? Perhaps that's a mistaken assumption and I need to think through the other implications with the rest of the team. That said, such a decision/conversation is not a blocker for moving forward with this fix, as far as I can tell.