### PR TITLE
Consider all TextBlock images selected when there are 0 selected (#1295)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -754,7 +754,8 @@ class Document(ModelIndexable, DocumentDateMixin):
                             "label": labels[i],
                             "canvas": canvases[i],
                             "shelfmark": b.fragment.shelfmark,
-                            "excluded": i not in b.selected_images,
+                            "excluded": len(b.selected_images)
+                            and i not in b.selected_images,
                         }
 
         # when requested, include any placeholder canvas URIs referenced by any associated transcriptions


### PR DESCRIPTION
Applying this hotfix based on conversation in #1302, in order to unblock testing other things on QA (as transcriptions were failing to show up due to images not being selected). Possibly temporary until that is resolved. See also #1295