### PR TITLE
Add tag merge feature (#506)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -390,8 +390,8 @@ class TagMergeForm(forms.Form):
         label="Select primary tag",
         queryset=None,
         help_text=(
-            "Select the primary tag, which the other selected tags will be merged into. "
-            "All tagged items will be combined on the merged tag."
+            "Select the primary tag, which will replace the names of the other selected tags. "
+            "All items tagged with the other selected tags will then only be tagged with the primary tag."
         ),
         empty_label=None,
         widget=forms.RadioSelect,

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -1,7 +1,9 @@
 from django import forms
+from django.db.models import Count
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
+from taggit.models import Tag
 
 from geniza.common.fields import RangeField, RangeForm, RangeWidget
 from geniza.common.utils import simplify_quotes
@@ -374,3 +376,40 @@ class DocumentMergeForm(forms.Form):
         if rationale == "other" and not rationale_notes:
             msg = 'Additional information is required when selecting "Other".'
             self.add_error("rationale", msg)
+
+
+class TagChoiceField(forms.ModelChoiceField):
+    """Add a count of tagged documents to a tag label on a form (used for tag merging)"""
+
+    def label_from_instance(self, tag):
+        return "%s (%s tagged)" % (tag.name, tag.item_count)
+
+
+class TagMergeForm(forms.Form):
+    primary_tag = TagChoiceField(
+        label="Select primary tag",
+        queryset=None,
+        help_text=(
+            "Select the primary tag, which the other selected tags will be merged into. "
+            "All tagged items will be combined on the merged tag."
+        ),
+        empty_label=None,
+        widget=forms.RadioSelect,
+    )
+
+    def __init__(self, *args, **kwargs):
+        tag_ids = kwargs.get("tag_ids", [])
+
+        # Remove the added kwarg so that the super method doesn't error
+        try:
+            del kwargs["tag_ids"]
+        except KeyError:
+            pass
+
+        super().__init__(*args, **kwargs)
+        # get queryset and annotate with tagged document count
+        self.fields["primary_tag"].queryset = Tag.objects.filter(
+            id__in=tag_ids
+        ).annotate(
+            item_count=Count("taggit_taggeditem_items", distinct=True),
+        )

--- a/geniza/corpus/templates/admin/corpus/tag/merge.html
+++ b/geniza/corpus/templates/admin/corpus/tag/merge.html
@@ -1,0 +1,53 @@
+{% extends 'admin/base_site.html' %}
+
+{% load admin_urls static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "css/admin-local.css" %}">
+{% endblock %}
+
+{% block title %} Merge selected tags {% endblock %}
+
+{% block breadcrumbs %}
+    {% if not is_popup %}
+        <div class="breadcrumbs">
+            <a href="{% url 'admin:index' %}">Home</a>
+            &rsaquo;
+            <a href="{% url 'admin:app_list' app_label='taggit' %}">Taggit</a>
+            &rsaquo;
+            <a href="{% url 'admin:taggit_tag_changelist'%}">tags</a>
+            &rsaquo;
+            Merge selected tags
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block content_title %}
+    <h1>Merge selected tags</h1>
+    <h2>Note: there is no automated way to unmerge tags! Please review to make sure these tags should be merged before submitting the form.</h2>
+{% endblock %}
+
+{% block content %}
+    <form method="post" class="merge-tag">
+        {% csrf_token %}
+        {% if form.errors|length > 0 %}
+            <p class="errornote">
+                Please correct the error below.
+            </p>
+        {% endif %}
+        <fieldset class="module aligned">
+            <div class="form-row">
+                {{ form.primary_tag.label_tag }}
+                {{ form.primary_tag }}
+                <p class="help">{{ form.primary_tag.help_text|safe }}</p>
+            </div>
+
+            <div class="submit-row">
+                <input type="submit" value="Submit">
+            </div>
+        </field>
+    </form>
+
+{% endblock %}


### PR DESCRIPTION
## In this PR

Per #506:
- Add feature to tag admin allowing admins to merge several tags into one primary tag

## Questions

- This may not be entirely DRY, considering how much was cribbed from the document merge feature, but it seems like there is just enough variance in each method that it might not be straightforward to generalize. Is this repetitive enough that it's worth the time to generalize? (I guess one reason to do so would be if there are other kinds of merges they will need to do in the future, but I'm not sure there are.)
- Do you think it's ok to not require a rationale here? I think tag merges are pretty straightforward and less impactful so I didn't think it was necessary.