### PR TITLE
Add placeholders with labels for imageless fragments (#1229, #1230)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -240,10 +240,15 @@ class Fragment(TrackChangesModel):
         canvases = []
         # use images from locally cached manifest if possible
         if self.manifest:
-            for canvas in self.manifest.canvases.all():
-                images.append(canvas.image)
-                labels.append(canvas.label)
-                canvases.append(canvas.uri)
+            manifest_canvases = self.manifest.canvases.all()
+            # handle no canvases on manifest; cached QS will not incur extra DB hit
+            if not manifest_canvases.count():
+                return None
+            else:
+                for canvas in manifest_canvases:
+                    images.append(canvas.image)
+                    labels.append(canvas.label)
+                    canvases.append(canvas.uri)
 
         # if not cached, load from remote url
         else:
@@ -257,6 +262,7 @@ class Fragment(TrackChangesModel):
                     canvases.append(canvas.uri)
             except (IIIFException, ConnectionError, HTTPError):
                 logger.warning("Error loading IIIF manifest: %s" % self.iiif_url)
+                return None
 
         return images, labels, canvases
 

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1522,10 +1522,19 @@ class TestDocumentTranscribeView:
         assert response.context["annotation_config"]["source_uri"] == source.uri
         assert response.context["source_label"] == source.all_authors()
 
-        # since no images/transcription present, should append two placeholders for use in editor
+        # since no images/transcription present, and one textblock present,
+        # should append two placeholders for use in editor
         assert len(response.context["images"]) == 2
-        assert f"{document.permalink}iiif/canvas/1/" in response.context["images"]
-        assertContains(response, f"{document.permalink}iiif/canvas/2/")
+        tb = document.textblock_set.first()
+        assert (
+            f"{document.permalink}iiif/textblock/{tb.pk}/canvas/1/"
+            in response.context["images"]
+        )
+        assertContains(
+            response,
+            f"{document.permalink}iiif/textblock/{tb.pk}/canvas/2/",
+        )
+        assertContains(response, tb.fragment.shelfmark)
         assertContains(response, Document.PLACEHOLDER_CANVAS["image"]["info"])
 
         # non-existent source_pk should 404

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -756,7 +756,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
         # per each fragment without images, pass two placeholder canvases for use in editor
         for b in self.object.textblock_set.all():
             frag_images = b.fragment.iiif_images()
-            if frag_images is None or not frag_images[0]:
+            if frag_images is None:
                 canvas_base_uri = "%siiif/" % self.get_object().permalink
                 for i in [1, 2]:
                     # create a placeholder canvas URI that contains textblock pk and canvas number

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -422,8 +422,13 @@
         }
 
         &.placeholder {
-            .img-header {
-                display: none;
+            // hide placeholder zoom controls
+            .img-header *:not(h2) {
+                display: none !important;
+            }
+            // show placeholder label
+            .img-header h2 {
+                display: block;
             }
             // placeholders are completely transparent in viewer
             .deep-zoom-container {


### PR DESCRIPTION
## In this PR

Per #1229:
- Revise `DocumentTranscribeView` placeholder image logic to include exactly two placeholders for each fragment without images in the transcription editor, so that joins with multiple fragments will show enough placeholders to add all transcription content

Per #1230:
- On placeholder images, show labels with each associated fragment's shelfmark (and recto/verso for 1st and 2nd image)
- Include TextBlock id in placeholder canvas URI
- Revise `Document.iiif_images` to look for that TextBlock id and associate the placeholders with the correct shelfmark labels

## Notes

I think the method of using the TextBlock id in the placeholder URI is a little bit hacky, but it seems to work. My thinking was that this way, if images get added after transcriptions, the placeholder images will still show up with the correct labels by the transcription, so it will be easy to identify which fragment and side they belong to. 

A potential drawback for that type of document is that for the time between new images being added and transcription content being re-assigned from the placeholders, you end up with double entries on the viewer for each of those fragments—one for the real image and one for the placeholder. But I think that's better than no label for the placeholder (which is the problem in #1230).