### PR TITLE
Reindex annotated documents after annotation save, on update and create (#1308)

### DIFF
--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -149,6 +149,7 @@ class TestAnnotationQuerySet:
             footnote=annotation.footnote,
             content={
                 "target": {"source": {"id": annotation.target_source_id}},
+                "body": [{"value": "foo"}],
             },
         )
         other_canvas = "http://ex.co/iiif/canvas/3421"
@@ -156,11 +157,12 @@ class TestAnnotationQuerySet:
             footnote=annotation.footnote,
             content={
                 "target": {"source": {"id": other_canvas}},
+                "body": [{"value": "bar"}],
             },
         )
         # should be ignored but not cause an error
         no_target_anno = Annotation.objects.create(
-            footnote=annotation.footnote, content={"body": "foo"}
+            footnote=annotation.footnote, content={"body": [{"value": "foo bar"}]}
         )
 
         annos_by_canvas = Annotation.objects.all().group_by_canvas()

--- a/geniza/annotations/tests/test_annotations_views.py
+++ b/geniza/annotations/tests/test_annotations_views.py
@@ -117,10 +117,7 @@ class TestAnnotationList:
         assert log_entry.action_flag == ADDITION
         assert log_entry.change_message == "Created via API"
 
-    @patch.object(ModelIndexable, "index_items")
-    def test_create_annotation(
-        self, mock_indexitems, admin_client, document, source, annotation_json
-    ):
+    def test_create_annotation(self, admin_client, document, source, annotation_json):
         # should create a DIGITAL_EDITION footnote if one does not exist
         assert not document.digital_editions().filter(source=source).exists()
         admin_client.post(
@@ -135,10 +132,6 @@ class TestAnnotationList:
         assert LogEntry.objects.filter(
             object_id=footnote.pk, action_flag=ADDITION
         ).exists()
-
-        # should reindex document
-        document = Document.objects.get(pk=footnote.object_id)
-        mock_indexitems.assert_called_with([document])
 
 
 @pytest.mark.django_db
@@ -177,10 +170,7 @@ class TestAnnotationDetail:
             )
             assert response.status_code == 400
 
-    @patch.object(ModelIndexable, "index_items")
-    def test_post_annotation_detail_admin(
-        self, mock_indexitems, admin_client, annotation
-    ):
+    def test_post_annotation_detail_admin(self, admin_client, annotation):
         # update annotation with POST request as admin
         # POST req must include manifest and source URIs
         response = admin_client.post(
@@ -208,10 +198,6 @@ class TestAnnotationDetail:
         assert updated_anno.content["body"] == [{"value": "new text"}]
         # updated content should be returned in the response
         assert response.json() == updated_anno.compile()
-
-        # should call index_items on document when annotation updated
-        document = Document.from_manifest_uri(annotation.target_source_manifest_id)
-        mock_indexitems.assert_called_with([document])
 
         # should have log entry for update
         log_entry = LogEntry.objects.get(object_id=annotation.id)
@@ -379,10 +365,12 @@ class TestAnnotationSearch:
     def test_search_manifest(self, client, source, document, join):
         # associated with document based on footnote
         footnote = Footnote.objects.create(source=source, content_object=document)
-        anno1 = Annotation.objects.create(footnote=footnote, content={})
+        anno1 = Annotation.objects.create(
+            footnote=footnote, content={"body": [{"value": "foo"}]}
+        )
         # different document
         footnote2 = Footnote.objects.create(source=source, content_object=join)
-        anno2 = Annotation.objects.create(footnote=footnote2, content={})
+        anno2 = Annotation.objects.create(footnote=footnote2, content=anno1.content)
         response = client.get(self.anno_search_url, {"manifest": document.manifest_uri})
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/json"
@@ -393,10 +381,18 @@ class TestAnnotationSearch:
         assertNotContains(response, anno2.uri())
 
     def test_search_sort(self, client, annotation):
-        anno3 = Annotation.objects.create(footnote=annotation.footnote, content={})
-        anno10 = Annotation.objects.create(footnote=annotation.footnote, content={})
-        anno1 = Annotation.objects.create(footnote=annotation.footnote, content={})
-        anno2 = Annotation.objects.create(footnote=annotation.footnote, content={})
+        anno3 = Annotation.objects.create(
+            footnote=annotation.footnote, content={"body": [{"value": "foo"}]}
+        )
+        anno10 = Annotation.objects.create(
+            footnote=annotation.footnote, content=anno3.content
+        )
+        anno1 = Annotation.objects.create(
+            footnote=annotation.footnote, content=anno3.content
+        )
+        anno2 = Annotation.objects.create(
+            footnote=annotation.footnote, content=anno3.content
+        )
 
         # should return json AnnotationList with resources of length 4
         response = client.get(self.anno_search_url)
@@ -414,15 +410,15 @@ class TestAnnotationSearch:
         assert results["resources"][4]["id"] == anno2.uri()
 
         # now set schema:position to reorder
-        anno3.set_content({"schema:position": 3})
+        anno3.set_content({**anno3.content, "schema:position": 3})
         anno3.save()
-        anno10.set_content({"schema:position": 10})
+        anno10.set_content({**anno10.content, "schema:position": 10})
         anno10.save()
-        anno1.set_content({"schema:position": 1})
+        anno1.set_content({**anno1.content, "schema:position": 1})
         anno1.save()
-        anno2.set_content({"schema:position": 2})
+        anno2.set_content({**anno2.content, "schema:position": 2})
         anno2.save()
-        annotation.set_content({"schema:position": 5})
+        annotation.set_content({**annotation.content, "schema:position": 5})
         annotation.save()
 
         response = client.get(self.anno_search_url)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -423,6 +423,7 @@ class DocumentSignalHandlers:
         "footnote": "footnotes",
         "source": "footnotes__source",
         "creator": "footnotes__source__authorship__creator",
+        "annotation": "footnotes__annotation",
     }
 
     @staticmethod
@@ -1100,6 +1101,10 @@ class Document(ModelIndexable, DocumentDateMixin):
             "pre_delete": DocumentSignalHandlers.related_delete,
         },
         "footnotes.creator": {
+            "post_save": DocumentSignalHandlers.related_save,
+            "pre_delete": DocumentSignalHandlers.related_delete,
+        },
+        "annotations.annotation": {
             "post_save": DocumentSignalHandlers.related_save,
             "pre_delete": DocumentSignalHandlers.related_delete,
         },

--- a/geniza/corpus/tests/test_corpus_signals.py
+++ b/geniza/corpus/tests/test_corpus_signals.py
@@ -14,7 +14,7 @@ from geniza.corpus.models import (
 
 @pytest.mark.django_db
 @patch.object(ModelIndexable, "index_items")
-def test_related_save(mock_indexitems, document, join, footnote):
+def test_related_save(mock_indexitems, document, join, footnote, annotation):
     # unsaved fragment should be ignored
     frag = Fragment(shelfmark="T-S 123")
 
@@ -58,6 +58,17 @@ def test_related_save(mock_indexitems, document, join, footnote):
     mock_indexitems.reset_mock()
     DocumentSignalHandlers.related_save(
         DocumentType, document.footnotes.first().source.authorship_set.first().creator
+    )
+    assert mock_indexitems.call_count == 1
+    assert document in mock_indexitems.call_args[0][0]
+
+    # annotation
+    mock_indexitems.reset_mock()
+    DocumentSignalHandlers.related_save(
+        DocumentType,
+        document.footnotes.filter(annotation__isnull=False)
+        .first()
+        .annotation_set.first(),
     )
     assert mock_indexitems.call_count == 1
     assert document in mock_indexitems.call_args[0][0]


### PR DESCRIPTION
## In this PR

Per #1308:
- On annotation update, wait until after annotation's `save()` method is called to reindex associated document, to ensure latest revision is in index
- On annotation creation, reindex associated document
