### PR TITLE
Add "pop out" button to images in editor (#1261)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -67,25 +67,31 @@
             {% for canvas_uri, image_info in images.items %}
                 {# only images that are part of the current document are zoomable #}
                 <div class="img{% if image_info.excluded %} excluded{% endif %}{% if image_info.placeholder %} placeholder{% endif %}" id="{{ image_info.label }}"{% if not image_info.excluded %} data-controller="iiif {% if edit_mode %}annotation" data-iiif-edit-mode-value="true{% endif %}" data-canvas-url="{{ canvas_uri }}" data-iiif-target="imageContainer" data-annotation-target="imageContainer"{% endif %}>
-                    <div class="img-header" data-iiif-target="imageHeader">
-                        <h2>{{ image_info.shelfmark }} {{ image_info.label }}</h2>
-                        {% if not image_info.excluded %}
-                            <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
-                            <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
-                            <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
-                            <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
-                            <div id="rotation-{{ forloop.counter0 }}" class="rotation" data-iiif-target="rotation" data-action="input->iiif#handleDeepZoom change->iiif#handleDeepZoom"></div>
-                            <label for="rotation-{{ forloop.counter0 }}" data-iiif-target="rotationLabel">0&deg;</label>
-                        {% endif %}
-                    </div>
-                    <div class="deep-zoom-container">
-                        <img class="iiif-image" data-iiif-target="image" data-annotation-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
-                            sizes="(max-width: 650px) 50vw, 94vw"
-                            srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
-                            {{ image_info.image|iiif_image:"size:width=500" }} 500w,
-                            {{ image_info.image|iiif_image:"size:width=640" }} 640w,
-                            {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
-                        <div class="osd" data-iiif-target="osd" data-iiif-url="{{ image_info.image.info }}"></div>
+                    <div class="popout-container">
+                        <div class="img-header" data-iiif-target="imageHeader">
+                            <h2>{{ image_info.shelfmark }} {{ image_info.label }}</h2>
+                            {% if not image_info.excluded %}
+                                <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
+                                <label data-iiif-target="zoomSliderLabel" for="zoom-slider-{{ forloop.counter0 }}">100%</label>
+                                <input data-iiif-target="zoomToggle" data-action="iiif#handleDeepZoom" id="zoom-toggle-{{ forloop.counter0 }}" type="checkbox" name="zoom-toggle" />
+                                <label for="zoom-toggle-{{ forloop.counter0 }}">{% translate 'Zoom and Rotate' %}</label>
+                                <div id="rotation-{{ forloop.counter0 }}" class="rotation" data-iiif-target="rotation" data-action="input->iiif#handleDeepZoom change->iiif#handleDeepZoom"></div>
+                                <label for="rotation-{{ forloop.counter0 }}" data-iiif-target="rotationLabel">0&deg;</label>
+                            {% endif %}
+                        </div>
+                        <div class="deep-zoom-container">
+                            <img class="iiif-image" data-iiif-target="image" data-annotation-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
+                                sizes="(max-width: 650px) 50vw, 94vw"
+                                srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
+                                {{ image_info.image|iiif_image:"size:width=500" }} 500w,
+                                {{ image_info.image|iiif_image:"size:width=640" }} 640w,
+                                {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
+                            <div class="osd" data-iiif-target="osd" data-iiif-url="{{ image_info.image.info }}"></div>
+                            {% if edit_mode %}
+                                <button class="primary popout-close-button" type="button" aria-label="Close"><i class="ph-x"></i></button>
+                                <button class="primary popout-button" type="button">Pop out</button>
+                            {% endif %}
+                        </div>
                     </div>
                     {% if image_info.excluded %}
                         {# if this image isn't actually in this document, link to related documents #}

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -27,6 +27,26 @@ export default class extends Controller {
             // TODO: Better way of determining if we're on mobile?
             const isMobile = window.innerWidth <= 900;
 
+            // allow "pop out" image during editing
+            const popOutButton = this.imageContainerTarget.querySelector(
+                "button.popout-button"
+            );
+            const closeButton = this.imageContainerTarget.querySelector(
+                "button.popout-close-button"
+            );
+            const popOutContainer =
+                this.imageContainerTarget.querySelector(".popout-container");
+            popOutButton.addEventListener("click", (e) => {
+                popOutContainer.classList.add("open");
+                closeButton.style.display = "flex";
+                popOutButton.style.display = "none";
+            });
+            closeButton.addEventListener("click", (e) => {
+                popOutContainer.classList.remove("open");
+                closeButton.style.display = "none";
+                popOutButton.style.display = "flex";
+            });
+
             // initialize transcription editor
             // get sibling outside of controller scope
             const annotationContainer =

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -110,3 +110,9 @@ main.addsource
     background-color: var(--background);
     color: var(--on-background);
 }
+
+// rtl tweak for popout container
+html[dir="rtl"] #itt-panel .popout-container.open {
+    left: auto;
+    right: 0;
+}

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -1,5 +1,6 @@
 /* styles for transcription and annotation */
 
+@use "../base/breakpoints";
 @use "../base/spacing";
 @use "../base/typography";
 
@@ -59,7 +60,7 @@ main.annotating {
         .deep-zoom-container {
             // popout open and close buttons
             button.popout-button {
-                display: flex;
+                display: none;
                 align-items: center;
                 justify-content: center;
                 position: relative;
@@ -70,13 +71,16 @@ main.annotating {
                     margin-left: 5px;
                     font-weight: normal;
                 }
+                @include breakpoints.for-tablet-landscape-up {
+                    display: flex;
+                }
             }
             button.popout-close-button {
                 font-size: 32px;
                 display: none;
                 position: absolute;
                 top: 0;
-                right: 0;
+                right: -1rem;
                 z-index: 2;
             }
         }
@@ -88,6 +92,8 @@ main.annotating {
             z-index: 5;
             width: 50vw;
             max-width: 50vw;
+            height: 100vh;
+            padding: 1rem;
             background-color: var(--background-gray);
         }
         // add some spacing to the "empty" div when the popout is open

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -50,10 +50,52 @@ main.annotating {
             margin-bottom: 2rem;
         }
     }
-    // style placeholder images with gray background in editor
-    #itt-panel .img.placeholder .deep-zoom-container {
-        background-color: var(--background-gray);
-        opacity: 1;
+    #itt-panel .img {
+        // style placeholder images with gray background in editor
+        &.placeholder .deep-zoom-container {
+            background-color: var(--background-gray);
+            opacity: 1;
+        }
+        .deep-zoom-container {
+            // popout open and close buttons
+            button.popout-button {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                position: relative;
+                z-index: 2;
+                &::after {
+                    font-family: "Phosphor";
+                    content: "\f058";
+                    margin-left: 5px;
+                    font-weight: normal;
+                }
+            }
+            button.popout-close-button {
+                font-size: 32px;
+                display: none;
+                position: absolute;
+                top: 0;
+                right: 0;
+                z-index: 2;
+            }
+        }
+        // opened "pop out" view of an image
+        .popout-container.open {
+            position: fixed;
+            top: 0;
+            left: 0;
+            z-index: 5;
+            width: 50vw;
+            max-width: 50vw;
+            background-color: var(--background-gray);
+        }
+        // add some spacing to the "empty" div when the popout is open
+        &:has(.popout-container.open) {
+            min-height: 100vh !important;
+            display: block;
+            position: relative;
+        }
     }
 }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -7,7 +7,7 @@
 @use "../components/searchform";
 
 #itt-panel {
-    z-index: 3;
+    z-index: 6;
     max-width: none;
     width: 100%;
     display: flex;


### PR DESCRIPTION
## In this PR

Per #1261:
- Allows users to "stick" an image to the left side of the screen in order to continue transcribing when the transcription extends past the visible portion of the image

## Notes

I spent a lot of time trying to get `position: sticky` to work, or mimic that behavior with JS, but I wasn't able to get it to work with the current HTML/CSS structure. In order to avoid making significant changes, I came up with a compromise: a "pop out" button that only appears in the editor, which takes up half of your screen with the image, in a fixed position.

It's not the best looking thing in the world, but it's just for the editor, and seems to work OK.

Would appreciate a checkout and test locally if you have the time!

(Also, the html changes aren't that significant; recommend hiding whitespace changes in the diff)