### PR TITLE
Use gettext_lazy for search form per django docs (#1316)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.db.models import Count
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from taggit.models import Tag
 
 from geniza.common.fields import RangeField, RangeForm, RangeWidget


### PR DESCRIPTION
## In this PR

Per #1316:
- Use `gettext_lazy` instead of `gettext`, which is required for forms to be translated according to [django docs](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#lazy-translation), on search form