### PR TITLE
Add case-insensitive unique validation to tag name field (#1333)

### DIFF
--- a/geniza/common/admin.py
+++ b/geniza/common/admin.py
@@ -71,8 +71,15 @@ admin.site.unregister(Tag)
 
 
 class TagForm(ModelForm):
-    """Extends the default tag admin form to validate uniqueness, case-insensitive,
-    on tag names."""
+    """
+    Extends the default tag admin form to validate uniqueness, case-insensitive,
+    on tag names.
+
+    NOTE: This is needed because the Tag model does not have a DB-level case-insensitive uniqueness
+    constraint applied out of the box, and adding such a constraint is not trivial at the moment.
+    TODO: Once Django is updated past 4.0, a "functional unique constraint" may be added to a custom
+    Tag model to solve this problem; then, this form override will no longer be needed.
+    """
 
     class Meta:
         model = Tag

--- a/geniza/common/tests.py
+++ b/geniza/common/tests.py
@@ -20,6 +20,7 @@ from geniza.common.admin import (
     CustomTagAdmin,
     LocalLogEntryAdmin,
     LocalUserAdmin,
+    TagForm,
     custom_empty_field_list_filter,
 )
 from geniza.common.fields import NaturalSortField, RangeField, RangeWidget
@@ -359,6 +360,18 @@ class TestCustomTagAdmin:
         assert isinstance(resp, HttpResponseRedirect)
         assert resp.status_code == 302
         assert resp["location"] == reverse("admin:taggit_tag_changelist")
+
+
+@pytest.mark.django_db
+class TestTagForm:
+    def test_form_clean(self):
+        Tag.objects.create(name="test name", slug="test-name")
+        # should raise a validation error on the "name" field if a tag with
+        # the same name exists, case-insensitive
+        form = TagForm()
+        form.cleaned_data = {"name": "Test Name", "slug": "test-name-2"}
+        form.clean()
+        assert "name" in form.errors
 
 
 def test_echo():


### PR DESCRIPTION
## In this PR

Per #1333:
- Validate tag names are unique, case-insensitive, during create or update of a tag within the tags admin