### PR TITLE
Improve help text display for document admin date (#1338)

### DIFF
--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -305,3 +305,15 @@ table.change-history {
 table.change-history tbody th {
     width: 16em;
 }
+
+/* fixing spacing of help text in document admin, dates section */
+div.form-row.field-doc_date_original {
+    display: grid;
+    gap: 1rem;
+}
+@media (min-width: 1358px) {
+    /* on smaller viewports, two columns looks bad, but at this size it's fine */
+    div.form-row.field-doc_date_original {
+        grid-template-columns: 1fr 1fr;
+    }
+}


### PR DESCRIPTION
## In this PR

Per #1338:
- A bit of admin CSS to manually override the document date section to display as a grid, with a gap wide enough to accommodate the help text issue
  - Help text issue was happening because the field label is more than one line long and pushing down the help text, which we can't otherwise address without changing the HTML structure (or doing hacky negative margin stuff)