### PR TITLE
Customize admin templates for document to allow inlines between other fields (#870)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -203,6 +203,7 @@ class DocumentDatingInline(admin.TabularInline):
     )
     min_num = 0
     extra = 1
+    insert_after = "standard_date"
 
 
 @admin.register(Document)

--- a/geniza/corpus/templates/admin/corpus/document/change_form.html
+++ b/geniza/corpus/templates/admin/corpus/document/change_form.html
@@ -14,6 +14,21 @@
 {% endblock %}
 
 
+{% block field_sets %}
+    {% for fieldset in adminform %}
+        {% include "admin/corpus/document/snippets/fieldset.html" with inline_admin_formsets=inline_admin_formsets %}
+    {% endfor %}
+{% endblock %}
+
+{% block inline_field_sets %}
+    {% for inline_admin_formset in inline_admin_formsets %}
+        {# don't repeat inline formsets that were inserted earlier #}
+        {% if not inline_admin_formset.opts.insert_after %}
+            {% include inline_admin_formset.opts.template %}
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+
 {% block after_field_sets %}
     {% if original.pk %} {# don't display record history when adding new document #}
         <fieldset class="module aligned">

--- a/geniza/corpus/templates/admin/corpus/document/snippets/fieldset.html
+++ b/geniza/corpus/templates/admin/corpus/document/snippets/fieldset.html
@@ -1,0 +1,40 @@
+{% comment %}
+modified django admin/includes/fieldset.html to allow inline formset after a field, adapted
+from https://linevi.ch/en/django-inline-in-fieldset.html
+{% endcomment %}
+
+<fieldset class="module aligned {{ fieldset.classes }}">
+    {% if fieldset.name %}<h2>{{ fieldset.name }}</h2>{% endif %}
+    {% if fieldset.description %}
+        <div class="description">{{ fieldset.description|safe }}</div>
+    {% endif %}
+    {% for line in fieldset %}
+        <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+            {% for field in line %}
+                <div{% if not line.fields|length_is:'1' %} class="fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="checkbox-row"{% endif %}>
+                    {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                    {% if field.is_checkbox %}
+                        {{ field.field }}{{ field.label_tag }}
+                    {% else %}
+                        {{ field.label_tag }}
+                        {% if field.is_readonly %}
+                            <div class="readonly">{{ field.contents }}</div>
+                        {% else %}
+                            {{ field.field }}
+                        {% endif %}
+                    {% endif %}
+                    {% if field.field.help_text %}
+                        <div class="help">{{ field.field.help_text|safe }}</div>
+                    {% endif %}
+                </div>
+                {# insert designated inlines after the field #}
+                {% for inline_admin_formset in inline_admin_formsets %}
+                    {% if inline_admin_formset.opts.insert_after == field.field.name %}
+                        {% include inline_admin_formset.opts.template %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        </div>
+    {% endfor %}
+</fieldset>

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -311,6 +311,10 @@ div.form-row.field-doc_date_original {
     display: grid;
     gap: 1rem;
 }
+/* prevent inline formset from causing problems with grid */
+div.form-row.field-doc_date_original .inline-group {
+    grid-column: 1 / -1;
+}
 @media (min-width: 1358px) {
     /* on smaller viewports, two columns looks bad, but at this size it's fine */
     div.form-row.field-doc_date_original {


### PR DESCRIPTION
## In this PR

- Customize admin document `change_form` template and `fieldset` snippet to allow moving inlines between other fields
- Move datings inline after document date fields, per #870