### PR TITLE
Add translation editor to ITT panel (#1337)

### DIFF
--- a/geniza/annotations/conftest.py
+++ b/geniza/annotations/conftest.py
@@ -20,6 +20,29 @@ def annotation(db, document, source):
                     "id": "http://ex.co/iiif/canvas/1",
                 }
             },
+            "motivation": ["sc:supplementing", "transcribing"],
+        },
+    )
+    return annotation
+
+
+@pytest.fixture
+def translation_annotation(db, document, source):
+    footnote = Footnote.objects.create(
+        source=source,
+        content_object=document,
+        doc_relation=Footnote.DIGITAL_TRANSLATION,
+    )
+    annotation = Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "body": [{"value": "Test annotation"}],
+            "target": {
+                "source": {
+                    "id": "http://ex.co/iiif/canvas/1",
+                }
+            },
+            "motivation": ["sc:supplementing", "translating"],
         },
     )
     return annotation

--- a/geniza/annotations/views.py
+++ b/geniza/annotations/views.py
@@ -58,10 +58,16 @@ def parse_annotation_data(request):
     del json_data["target"]["source"]["partOf"]
     del json_data["dc:source"]
 
+    # determine if this is a transcription or translation
+    if "motivation" in json_data and "translating" in json_data["motivation"]:
+        doc_relation = Footnote.DIGITAL_TRANSLATION
+    else:
+        doc_relation = Footnote.DIGITAL_EDITION
+
     # find or create DIGITAL_EDITION footnote for this source and document
     try:
         footnote = Footnote.objects.get(
-            doc_relation=[Footnote.DIGITAL_EDITION],
+            doc_relation=[doc_relation],
             source__pk=source_id,
             content_type=document_contenttype,
             object_id=document_id,
@@ -70,7 +76,7 @@ def parse_annotation_data(request):
         source = Source.objects.get(pk=source_id)
         footnote = Footnote.objects.create(
             source=source,
-            doc_relation=[Footnote.DIGITAL_EDITION],
+            doc_relation=[doc_relation],
             object_id=document_id,
             content_type=document_contenttype,
         )
@@ -216,6 +222,15 @@ class AnnotationSearch(View, MultipleObjectMixin):
             pgpid = document_id_from_manifest_uri(manifest_uri)
             annotations = annotations.filter(
                 footnote__object_id=pgpid, footnote__content_type__model="document"
+            )
+
+        motivation = self.request.GET.get("motivation")
+        # if a motivation is specified, filter on doc relation
+        if motivation:
+            annotations = annotations.filter(
+                footnote__doc_relation=Footnote.DIGITAL_TRANSLATION
+                if motivation == "translating"
+                else Footnote.DIGITAL_EDITION
             )
 
         # NOTE: if any params are ignored, they should be removed from id for search uri

--- a/geniza/corpus/templates/corpus/add_transcription_source.html
+++ b/geniza/corpus/templates/corpus/add_transcription_source.html
@@ -21,7 +21,7 @@
             {{ form }}
         </fieldset>
         {# TODO: add convenience link to an unpublished source where the currently logged in user is the sole author #}
-        <button class="primary" type="submit">Create transcription</button>
+        <button class="primary" type="submit">Create {{ doc_relation }}</button>
     </form>
 
     <h2>Scholarship record not yet in the database?</h2>

--- a/geniza/corpus/templates/corpus/document_transcribe.html
+++ b/geniza/corpus/templates/corpus/document_transcribe.html
@@ -35,5 +35,5 @@
     <div id="alerts" data-controller="alert"></div>
 
     {# viewer #}
-    {% include "corpus/snippets/document_transcription.html" with edit_mode=True %}
+    {% include "corpus/snippets/document_transcription.html" with edit_mode=annotation_config.secondary_motivation %}
 {% endblock main %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -27,7 +27,6 @@
 {% endif %}
 {# only enable ITT panel if images/transcription/translation are present, or we are in edit mode #}
 {% if document.has_digital_content or edit_mode %}
-    {{ edit_mode }}
     <section id="itt-panel" data-controller="ittpanel{% if not edit_mode %} transcription" data-action="click@document->transcription#clickCloseDropdown{% endif %}">
         {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}
         {# images displayed by default; disable if no images are available #}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -13,11 +13,15 @@
             <i class="ph-plus-circle"></i>
             <span>Add a new transcription</span>
         </a>
+        <a class="editor-navigation" href="{% url 'corpus:document-add-translation' document.id %}" data-turbo="false">
+            <i class="ph-plus-circle"></i>
+            <span>Add a new translation</span>
+        </a>
     {% endif %}
 {% endif %}
 {# only enable ITT panel if images/transcription/translation are present, or we are in edit mode #}
 {% if document.has_digital_content or edit_mode %}
-
+    {{ edit_mode }}
     <section id="itt-panel" data-controller="ittpanel{% if not edit_mode %} transcription" data-action="click@document->transcription#clickCloseDropdown{% endif %}">
         {# NOTE: inputs must be kept as SIBLINGS of panel-container for CSS selection/controls #}
         {# images displayed by default; disable if no images are available #}
@@ -26,16 +30,24 @@
         <label for="images-on"></label>
         {# transcription displayed by default; disable if no content is available #}
         {# translators: label for checkbox toggle to show the transcription panel for a document #}
-        <input type="checkbox" class="toggle" id="transcription-on" data-ittpanel-target="toggle" data-action="ittpanel#clickToggle" aria-label="{% translate 'show transcription' %}" {% if document.digital_editions or edit_mode %}checked="true" {% else %}disabled="true" {% endif %}/>
+        <input type="checkbox" class="toggle" id="transcription-on" data-ittpanel-target="toggle" data-action="ittpanel#clickToggle" aria-label="{% translate 'show transcription' %}" {% if not document.digital_editions and edit_mode != "transcribing" %}disabled="true" {% elif edit_mode == "transcribing" or not edit_mode %}checked="true" {% endif %}/>
         <label for="transcription-on"><svg><use xlink:href="{% static 'img/ui/all/all/transcription-toggle.svg' %}#transcription-toggle" /></svg></label>
         {# translators: label for checkbox toggle to show the translation panel for a document #}
-        <input type="checkbox" class="toggle" id="translation-on" data-ittpanel-target="toggle" data-action="ittpanel#clickToggle" aria-label="{% translate 'show translation' %}" {% if not document.digital_translations %}disabled="true" {% endif %}/>
+        <input type="checkbox" class="toggle" id="translation-on" data-ittpanel-target="toggle" data-action="ittpanel#clickToggle" aria-label="{% translate 'show translation' %}" {% if not document.digital_translations and edit_mode != "translating" %}disabled="true" {% elif edit_mode == "translating" %}checked="true" {% endif %}/>
         <label for="translation-on"><svg><use xlink:href="{% static 'img/ui/all/all/translation-toggle.svg' %}#translation-toggle" /></svg></label>
+
+        {% comment %}
+            TODO: Edit both transcription and translation at once.
+            - Add an "edit" button by the dropdown for the non-active panel in edit_mode
+            (i.e. translation if you are already editing a transcription, and vice versa)
+            - This button will instantiate a second tahqiq for each canvas, populated by 
+            annotations linked to the selected footnote
+        {% endcomment %}
         <div class="panel-container">
             {# label row #}
             <div class="label-row"></div> {# unused (no image label, needed for column alignment) #}
             <div class="transcription-panel label-row">
-                {% if edit_mode %}
+                {% if edit_mode == "transcribing" %}
                     {# show disabled details with source label in editor mode #}
                     <details class="itt-select" aria-expanded="false" disabled="true">
                         <summary>
@@ -62,22 +74,31 @@
                 {% endif %}
             </div>
             <div class="translation-panel label-row">
-                {# dropdown is disabled by default; enable if javascript is active #}
-                <details class="itt-select" aria-expanded="false" data-transcription-target="dropdownDetails" data-relation="translation" data-count="{{ document.digital_translations.count }}" disabled="true">
-                    <summary data-action="keydown->transcription#shiftTabCloseDropdown">
-                        <span data-transcription-target="translationShortLabel">Translation: {{ document.digital_translations.0.source.all_authors }} {{ document.digital_translations.0.source.all_languages }}</span>
-                    </summary>
-                    <ul>
-                        {% for tr in document.digital_translations.all %}
-                            <li>
-                                <label for="translation-{{ forloop.counter }}">
-                                    <input type="radio" name="translation" {% if forloop.first %} checked="true"{% endif %} value="relevance" data-action="input->transcription#changeDropdown keydown->transcription#keyboardCloseDropdown" id="translation-{{ forloop.counter }}" data-translation="tr-{{ tr.pk }}" />
-                                    <span>Translation: {{ tr.source.all_authors }} {{ tr.source.all_languages }}</span>
-                                </label>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </details>
+                {% if edit_mode == "translating" %}
+                    {# show disabled details with source label in editor mode #}
+                    <details class="itt-select" aria-expanded="false" disabled="true">
+                        <summary>
+                            <span>Translation: {{ source_label }}</span>
+                        </summary>
+                    </details>
+                {% else %}
+                    {# dropdown is disabled by default; enable if javascript is active #}
+                    <details class="itt-select" aria-expanded="false" data-transcription-target="dropdownDetails" data-relation="translation" data-count="{{ document.digital_translations.count }}" disabled="true">
+                        <summary data-action="keydown->transcription#shiftTabCloseDropdown">
+                            <span data-transcription-target="translationShortLabel">Translation: {{ document.digital_translations.0.source.all_authors }} {{ document.digital_translations.0.source.all_languages }}</span>
+                        </summary>
+                        <ul>
+                            {% for tr in document.digital_translations.all %}
+                                <li>
+                                    <label for="translation-{{ forloop.counter }}">
+                                        <input type="radio" name="translation" {% if forloop.first %} checked="true"{% endif %} value="relevance" data-action="input->transcription#changeDropdown keydown->transcription#keyboardCloseDropdown" id="translation-{{ forloop.counter }}" data-translation="tr-{{ tr.pk }}" />
+                                        <span>Translation: {{ tr.source.all_authors }} {{ tr.source.all_languages }}</span>
+                                    </label>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </details>
+                {% endif %}
             </div>
 
             {# loop based on canvases (for canvas with no image, image_info is a placeholder) #}
@@ -132,20 +153,10 @@
                     {% endif %}
                 </div>
                 <div class="transcription-panel">
-                    {% if edit_mode %}
-                        <div class="annotate transcription" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
+                    {% if edit_mode == "transcribing" %}
+                        <div class="annotate transcription" dir="rtl" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
                             {% if forloop.first %}
-                                {# Note: editor label/instructions are content admin-only and thus not translated. #}
-                                <h2>Transcribe</h2>
-                                <p class="instructions">
-                                    Hold shift and then click and drag over the image to select a rectangular region for the block of text you want to transcribe (this is an annotation zone).
-                                </p>
-                                <p class="instructions">
-                                    When an annotation zone is active on the image, use the red square in the thumbnail to move around the image when zoomed in.
-                                </p>
-                                <p class="instructions">
-                                    Drag blocks of text to reorder or move to a different image.
-                                </p>
+                                {% include "corpus/snippets/transcription_instructions.html" %}
                             {% endif %}
                         </div>
                     {% else %}
@@ -176,23 +187,31 @@
                     {% endif %}
                 </div>
                 <div class="translation-panel">
-                    {% if forloop.first %}
-                        <h2>{% translate 'Translation' %}</h2>
-                        <span data-transcription-target="translationFullLabel" class="current-translation{% if document.digital_editions.count > 1 %} multiple{% endif %}">
-                            {{ document.digital_translations.0.source.formatted_display|safe }}
-                        </span>
-                    {% endif %}
-                    {% if not image_info.excluded %}
-                        <div class="translations">
-                            {# display translation in chunks by index #}
-                            {% for translation in document.digital_translations.all %}
-                                <div class="translation tr-{{ translation.pk }}" data-label="{{ translation.source.formatted_display }}" {% if translation.source.languages.exists %}lang="{{ translation.source.languages.all.0.code }}" dir="{{ translation.source.languages.all.0.direction }}"{% else %}dir="ltr"{% endif %}>
-                                    {% for html_section in translation.content_html|dict_item:canvas_uri %}
-                                        {{ html_section|safe }}
-                                    {% endfor %}
-                                </div>
-                            {% endfor %}
+                    {% if edit_mode == "translating" %}
+                        <div class="annotate transcription" dir="{{ annotation_config.source_dir|default:"ltr" }}" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
+                            {% if forloop.first %}
+                                {% include "corpus/snippets/transcription_instructions.html" %}
+                            {% endif %}
                         </div>
+                    {% else %}
+                        {% if forloop.first %}
+                            <h2>{% translate 'Translation' %}</h2>
+                            <span data-transcription-target="translationFullLabel" class="current-translation{% if document.digital_editions.count > 1 %} multiple{% endif %}">
+                                {{ document.digital_translations.0.source.formatted_display|safe }}
+                            </span>
+                        {% endif %}
+                        {% if not image_info.excluded %}
+                            <div class="translations">
+                                {# display translation in chunks by index #}
+                                {% for translation in document.digital_translations.all %}
+                                    <div class="translation tr-{{ translation.pk }}" data-label="{{ translation.source.formatted_display }}" {% if translation.source.languages.exists %}lang="{{ translation.source.languages.all.0.code }}" dir="{{ translation.source.languages.all.0.direction }}"{% else %}dir="ltr"{% endif %}>
+                                        {% for html_section in translation.content_html|dict_item:canvas_uri %}
+                                            {{ html_section|safe }}
+                                        {% endfor %}
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endfor %}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -8,6 +8,12 @@
             <span>Edit {% for auth in ed.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% empty %}[unknown]{% endfor %}'s edition</span>
         </a>
     {% endfor %}
+    {% for tr in document.digital_translations.all %}
+        <a class="editor-navigation" href="{% url 'corpus:document-transcribe' document.id tr.source.pk %}" data-turbo="false">
+            <i class="ph-pencil"></i>
+            <span>Edit {% for auth in tr.source.authorship_set.all %}{% include "snippets/comma.html" %}{{ auth.creator.last_name }}{% empty %}[unknown]{% endfor %}'s translation</span>
+        </a>
+    {% endfor %}
     {% if document.id %}
         <a class="editor-navigation" href="{% url 'corpus:document-add-transcription' document.id %}" data-turbo="false">
             <i class="ph-plus-circle"></i>

--- a/geniza/corpus/templates/corpus/snippets/transcription_instructions.html
+++ b/geniza/corpus/templates/corpus/snippets/transcription_instructions.html
@@ -1,0 +1,16 @@
+{# Note: editor label/instructions are content admin-only and thus not translated. #}
+<h2 dir="ltr">
+    {% if edit_mode == "transcribing" %}Transcribe{% else %}Translate{% endif %}
+</h2>
+<p dir="ltr" class="instructions">
+    Hold shift and then click and drag over the image to select a rectangular
+    region for the block of text you want to transcribe (this is an annotation
+    zone).
+</p>
+<p dir="ltr" class="instructions">
+    When an annotation zone is active on the image, use the red square in the
+    thumbnail to move around the image when zoomed in.
+</p>
+<p dir="ltr" class="instructions">
+    Drag blocks of text to reorder or move to a different image.
+</p>

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1632,6 +1632,13 @@ class TestDocumentTranscribeView:
         assert (
             response.context["page_title"] == f"Edit transcription for {document.title}"
         )
+        # should use "translation" for translate view
+        response = admin_client.get(
+            reverse("corpus:document-translate", args=(document.id, source.pk))
+        )
+        assert (
+            response.context["page_title"] == f"Edit translation for {document.title}"
+        )
 
     def test_permissions(self, document, source, client):
         """should redirect to login if user does not have change document permissions"""
@@ -1669,6 +1676,22 @@ class TestDocumentTranscribeView:
             reverse("corpus:document-transcribe", args=(document.id, 123456789))
         )
         assert response.status_code == 404
+
+        # should include languages for source label in context on translations
+        response = admin_client.get(
+            reverse("corpus:document-translate", args=(document.id, source.pk))
+        )
+        assert source.all_languages() in response.context["source_label"]
+        # should include translating motivation
+        assert (
+            response.context["annotation_config"]["secondary_motivation"]
+            == "translating"
+        )
+        # should include directionality
+        assert (
+            response.context["annotation_config"]["source_dir"]
+            == source.languages.first().direction
+        )
 
 
 class TestSourceAutocompleteView:
@@ -1708,6 +1731,14 @@ class TestDocumentAddTranscriptionView:
             response.context["page_title"]
             == f"Add a new transcription for {document.title}"
         )
+        # should use translation for that view
+        response = admin_client.get(
+            reverse("corpus:document-add-translation", args=(document.id,))
+        )
+        assert (
+            response.context["page_title"]
+            == f"Add a new translation for {document.title}"
+        )
 
     def test_post(self, document, source, admin_client):
         # should redirect to transcription edit view
@@ -1719,6 +1750,15 @@ class TestDocumentAddTranscriptionView:
         assert response.url == reverse(
             "corpus:document-transcribe", args=(document.id, source.pk)
         )
+        # should redirect to translation edit view in add translation view
+        response = admin_client.post(
+            reverse("corpus:document-add-translation", args=(document.id,)),
+            {"source": source.pk},
+        )
+        assert response.status_code == 302
+        assert response.url == reverse(
+            "corpus:document-translate", args=(document.id, source.pk)
+        )
 
     def test_get_context_data(self, document, admin_client):
         # should include SourceChoiceForm
@@ -1729,3 +1769,6 @@ class TestDocumentAddTranscriptionView:
 
         # should have page_type "addsource"
         assert response.context["page_type"] == "addsource"
+
+        # should include doc relation in context
+        assert response.context["doc_relation"] == "transcription"

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -29,6 +29,11 @@ urlpatterns = [
         name="document-add-transcription",
     ),
     path(
+        "documents/<int:pk>/translate/",
+        corpus_views.DocumentAddTranscriptionView.as_view(doc_relation="translation"),
+        name="document-add-translation",
+    ),
+    path(
         "source-autocomplete/",
         corpus_views.SourceAutocompleteView.as_view(),
         name="source-autocomplete",
@@ -37,6 +42,11 @@ urlpatterns = [
         "documents/<int:pk>/transcribe/<int:source_pk>/",
         corpus_views.DocumentTranscribeView.as_view(),
         name="document-transcribe",
+    ),
+    path(
+        "documents/<int:pk>/translate/<int:source_pk>/",
+        corpus_views.DocumentTranscribeView.as_view(doc_relation="translation"),
+        name="document-translate",
     ),
     path(
         "documents/<int:pk>/transcription/<int:transcription_pk>/",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -812,8 +812,6 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     ),
                     "csrf_token": csrf_token(self.request),
                     "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
-                    # TODO: when translations implemented, make this a data property or something
-                    # on the template; the editor will have both transcribing and translating
                     "secondary_motivation": "transcribing"
                     if self.doc_relation == "transcription"
                     else "translating",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -714,16 +714,22 @@ class DocumentAddTranscriptionView(PermissionRequiredMixin, DetailView):
     template_name = "corpus/add_transcription_source.html"
     viewname = "corpus:document-add-transcription"
     model = Document
+    doc_relation = "transcription"
 
     def page_title(self):
-        """Title of add transcription page"""
-        return "Add a new transcription for %(doc)s" % {"doc": self.get_object().title}
+        """Title of add transcription/translation page"""
+        return "Add a new %(doc_relation)s for %(doc)s" % {
+            "doc_relation": self.doc_relation,
+            "doc": self.get_object().title,
+        }
 
     def post(self, request, *args, **kwargs):
-        """Create footnote linking source to document, then redirect to edit transcription view"""
+        """Create footnote linking source to document, then redirect to edit transcription/translation view"""
         return redirect(
             reverse(
-                "corpus:document-transcribe",
+                "corpus:document-transcribe"
+                if self.doc_relation == "transcription"
+                else "corpus:document-translate",
                 args=(self.get_object().id, int(request.POST["source"])),
             )
         )
@@ -736,22 +742,26 @@ class DocumentAddTranscriptionView(PermissionRequiredMixin, DetailView):
                 "form": SourceChoiceForm,
                 "page_title": self.page_title(),
                 "page_type": "addsource",
+                "doc_relation": self.doc_relation,
             }
         )
         return context_data
 
 
 class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
-    """View for the Transcription Editor page that uses annotorious-tahqiq"""
+    """View for the Transcription/Translation Editor page that uses annotorious-tahqiq"""
 
     permission_required = "corpus.change_document"
-
     template_name = "corpus/document_transcribe.html"
     viewname = "corpus:document-transcribe"
+    doc_relation = "transcription"
 
     def page_title(self):
-        """Title of transcription editor page"""
-        return "Edit transcription for %(doc)s" % {"doc": self.get_object().title}
+        """Title of transcription/translation editor page"""
+        return "Edit %(doc_relation)s for %(doc)s" % {
+            "doc_relation": self.doc_relation,
+            "doc": self.get_object().title,
+        }
 
     def get_context_data(self, **kwargs):
         """Pass annotation configuration and TinyMCE API key to page context"""
@@ -762,6 +772,11 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
         # would have matched
         try:
             source = Source.objects.get(pk=self.kwargs["source_pk"])
+            source_label = (
+                source.all_authors()
+                if self.doc_relation == "transcription"
+                else f"{source.all_authors()} {source.all_languages()}"
+            )
         except Source.DoesNotExist:
             raise Http404
 
@@ -799,13 +814,18 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "tiny_api_key": getattr(settings, "TINY_API_KEY", ""),
                     # TODO: when translations implemented, make this a data property or something
                     # on the template; the editor will have both transcribing and translating
-                    "secondary_motivation": "transcribing",
+                    "secondary_motivation": "transcribing"
+                    if self.doc_relation == "transcription"
+                    else "translating",
+                    "source_dir": source.languages.first().direction
+                    if source and source.languages.exists()
+                    else "",
                 },
                 # TODO: Add Footnote notes to the following display, if present
                 "source_detail": mark_safe(source.formatted_display())
                 if source
                 else "",
-                "source_label": source.all_authors() if source else "",
+                "source_label": source_label if source_label else "",
                 "page_type": "document annotating",
             }
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@recogito/annotorious-openseadragon": "^2.7.6",
         "@recogito/annotorious-toolbar": "^1.1.0",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#31156a52bbc0a9b95b9335c6d53012f1eaeeb977",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#b252908e73ef09e131a4142a9308adce2fa7f1c5",
         "openseadragon": "^3.0.0",
         "stimulus-use": "^0.50.0-2"
       },
@@ -2228,9 +2228,9 @@
       "dev": true
     },
     "node_modules/@tinymce/tinymce-webcomponent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.1.tgz",
-      "integrity": "sha512-17rbpsggiRqfDTKaAvCFlt9LWfb3JBXXhCZtGprb/Rk707ZMJAjCMMrrobPdCqc71r7BTMCFRH5PL4sP87lbdw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.2.tgz",
+      "integrity": "sha512-mt3cP20mrKXTFsbO+ghi/8+qNSgxKkWq1NTSL/oxURl7lRShnaWMj7i4Wik21XE7un5xAs9qlRbm9Eyw9xBfYQ=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.1.1",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@ungap/custom-elements": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
-      "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.2.0.tgz",
+      "integrity": "sha512-zdSuu79stAwVUtzkQU9B5jhGh2LavtkeX4kxd2jtMJmZt7QqRJ1KJW5bukt/vUOaUs3z674GHd+nqYm0bu0Gyg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -2711,8 +2711,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.0.1",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#31156a52bbc0a9b95b9335c6d53012f1eaeeb977",
-      "integrity": "sha512-A6lxlZoPDW2IyurOunPdi71Z4FYKDGVtS3G9rrMjsnU6VonRmw+FmfktrsXNGo4sv0flLJoQA5XaWnB7t95cAQ==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#b252908e73ef09e131a4142a9308adce2fa7f1c5",
+      "integrity": "sha512-JdEXNMmpxeE+vZUiIq72wP4feaKWEwtsaytR2ibRh/CqlUYuxoGxYytPoSBCm9mDvi1s0639a1cwRkgSxXa6jg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
@@ -10063,9 +10063,9 @@
       "dev": true
     },
     "@tinymce/tinymce-webcomponent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.1.tgz",
-      "integrity": "sha512-17rbpsggiRqfDTKaAvCFlt9LWfb3JBXXhCZtGprb/Rk707ZMJAjCMMrrobPdCqc71r7BTMCFRH5PL4sP87lbdw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-webcomponent/-/tinymce-webcomponent-2.0.2.tgz",
+      "integrity": "sha512-mt3cP20mrKXTFsbO+ghi/8+qNSgxKkWq1NTSL/oxURl7lRShnaWMj7i4Wik21XE7un5xAs9qlRbm9Eyw9xBfYQ=="
     },
     "@trysound/sax": {
       "version": "0.1.1",
@@ -10258,9 +10258,9 @@
       }
     },
     "@ungap/custom-elements": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.1.0.tgz",
-      "integrity": "sha512-jPOtG6F8Wfmu3C+SF6lAglg/GsMGeiQCelikCrARXodcCVbH51GjG1Ga2GfM+WsxmRfnenLaUBLrkdxduHSGOA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.2.0.tgz",
+      "integrity": "sha512-zdSuu79stAwVUtzkQU9B5jhGh2LavtkeX4kxd2jtMJmZt7QqRJ1KJW5bukt/vUOaUs3z674GHd+nqYm0bu0Gyg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -10532,9 +10532,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#31156a52bbc0a9b95b9335c6d53012f1eaeeb977",
-      "integrity": "sha512-A6lxlZoPDW2IyurOunPdi71Z4FYKDGVtS3G9rrMjsnU6VonRmw+FmfktrsXNGo4sv0flLJoQA5XaWnB7t95cAQ==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#31156a52bbc0a9b95b9335c6d53012f1eaeeb977",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#b252908e73ef09e131a4142a9308adce2fa7f1c5",
+      "integrity": "sha512-JdEXNMmpxeE+vZUiIq72wP4feaKWEwtsaytR2ibRh/CqlUYuxoGxYytPoSBCm9mDvi1s0639a1cwRkgSxXa6jg==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#b252908e73ef09e131a4142a9308adce2fa7f1c5",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@recogito/annotorious-openseadragon": "^2.7.6",
     "@recogito/annotorious-toolbar": "^1.1.0",
     "angle-input": "^0.0.1",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#31156a52bbc0a9b95b9335c6d53012f1eaeeb977",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#b252908e73ef09e131a4142a9308adce2fa7f1c5",
     "openseadragon": "^3.0.0",
     "stimulus-use": "^0.50.0-2"
   }

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -48,11 +48,14 @@ export default class extends Controller {
             });
 
             // initialize transcription editor
-            // get sibling outside of controller scope
-            const annotationContainer =
-                this.imageContainerTarget.nextElementSibling.querySelector(
-                    ".annotate"
-                );
+            // get sibling outside of controller scope:
+            // - next sibling for transcription
+            // - sibling after next for translation
+            const sibling = config.secondary_motivation.includes("transcribing")
+                ? this.imageContainerTarget.nextElementSibling
+                : this.imageContainerTarget.nextElementSibling
+                      .nextElementSibling;
+            const annotationContainer = sibling.querySelector(".annotate");
 
             // grab iiif URL and manifest for tahqiq
             const canvasURL = this.imageContainerTarget.dataset.canvasUrl;
@@ -93,6 +96,7 @@ export default class extends Controller {
             target: canvasURL,
             manifest: config.manifest_base_url + manifestId,
             csrf_token: config.csrf_token,
+            directionality: config.source_dir,
         };
         if (config.source_uri) {
             annotationServerConfig["sourceUri"] = config.source_uri;


### PR DESCRIPTION
## In this PR

Per #1337: Add the translation editor to the ITT panel, which can be accessed by clicking "Add a new translation" or "Edit X's translation" from the document detail page.
- Add new routes for choosing the source of and editing a translation; these will use the existing transcription views with an argument indicating which of those two is chosen
  - Add logic for determining direction and displaying source language, depending on whether it's transcription or translation
- Update transcribe template and Stimulus controller to support translations
  - Factor annotation instructions out into a snippet
  - Allow viewing existing transcriptions when editing a translation, and vice versa
  - Use motivation as `edit_mode` value to differentiate between the current primary edit mode (transcribing or translating)
- In annotation views, support saving and searching annotations on different Footnote doc relations via motivation
- Bump `annotorious-tahqiq` commit hash (NOTE: to test this locally, run `npm install` to get the updated version)

See also https://github.com/Princeton-CDH/annotorious-tahqiq/pull/28

## Notes

I tried to think through how editing both transcription and translation in the same view might work eventually, and make sure that my current work would support this. Here's what I came up with:

- The basic idea is that when you click "add a new X" or "edit Y’s X," you have to choose one or the other, transcription or translation. That will determine the URL route you are directed to, and will be the "primary edit mode" that you are in.
- Then, in the future when this is implemented:
  - When the opposite, non-primary panel is opened, there will be an edit button that you can use to edit that entry next to the source label.
  - You can edit any of the entries in the dropdown, in case there may be multiple editions or translations on the same document.
  - Per the specific use case (and likely simplifying from an Annotorious perspective): You will not be able to edit the geometry of that entry, only make corrections to the text. 
