### PR TITLE
Seleucid dates (#886)

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -28,7 +28,7 @@ class Calendar:
     ANNO_MUNDI = "am"
 
     #: calendars that can be converted to Julian/Gregorian
-    can_convert = [ANNO_MUNDI, HIJRI]
+    can_convert = [ANNO_MUNDI, HIJRI, SELEUCID]
 
 
 class PartialDate:
@@ -365,6 +365,11 @@ def convert_hebrew_date(historic_date):
     return standardize_date(historic_date, Calendar.ANNO_MUNDI)
 
 
+def convert_seleucid_date(historic_date):
+    """Convert a date in the Greek Seleucid calendar to the Julian or Gregorian calendar"""
+    return standardize_date(historic_date, Calendar.SELEUCID)
+
+
 def convert_islamic_date(historic_date):
     """Convert a date in the Islamic Hijri calendar to the Julian or Gregorian calendar"""
     return standardize_date(historic_date, Calendar.HIJRI)
@@ -374,6 +379,7 @@ def convert_islamic_date(historic_date):
 calendar_converter = {
     Calendar.ANNO_MUNDI: convertdate.hebrew,
     Calendar.HIJRI: convertdate.islamic,
+    Calendar.SELEUCID: convertdate.hebrew,
 }
 
 
@@ -392,6 +398,9 @@ def standardize_date(historic_date, calendar):
     if match:
         date_info = match.groupdict()
         year = int(date_info["year"])
+        # Seleucid is Anno Mundi - 3449
+        if calendar == Calendar.SELEUCID:
+            year = year + 3449
         month = date_info["month"]
 
         if month:

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -30,6 +30,9 @@ class Calendar:
     #: calendars that can be converted to Julian/Gregorian
     can_convert = [ANNO_MUNDI, HIJRI, SELEUCID]
 
+    #: offset for Seleucid calendar: Anno Mundi - 3449
+    SELEUCID_OFFSET = 3449
+
 
 class PartialDate:
     """Simple partial date object to handle parsing and display of
@@ -398,9 +401,8 @@ def standardize_date(historic_date, calendar):
     if match:
         date_info = match.groupdict()
         year = int(date_info["year"])
-        # Seleucid is Anno Mundi - 3449
         if calendar == Calendar.SELEUCID:
-            year = year + 3449
+            year = year + Calendar.SELEUCID_OFFSET
         month = date_info["month"]
 
         if month:

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -382,6 +382,8 @@ def convert_islamic_date(historic_date):
 calendar_converter = {
     Calendar.ANNO_MUNDI: convertdate.hebrew,
     Calendar.HIJRI: convertdate.islamic,
+    # NOTE: Seleucid years cannot be passed directly into convertdate.hebrew; instead,
+    # convert them to AM using the Seleucid offset first, in order to handle leap years
     Calendar.SELEUCID: convertdate.hebrew,
 }
 

--- a/geniza/corpus/management/commands/convert_dates.py
+++ b/geniza/corpus/management/commands/convert_dates.py
@@ -12,7 +12,7 @@ from geniza.corpus.models import Document
 
 
 class Command(BaseCommand):
-    """Report on historical date conversions for current data"""
+    """Report on or update historical date conversions for current data"""
 
     report_fields = [
         "pgpid",
@@ -31,10 +31,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        # NOTE: for now, this script only reports on date conversion
-        # in future, will add an update mode to clean up and standardize
-        # existing dates in the databse
-
         # find all documents with original dates set;
         # limit to calendars that we support converting
         dated_docs = (

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -222,10 +222,16 @@ def test_convert_seleucid_date():
     # month/year
     seleucid_year = 1458
     converted_date = convert_seleucid_date(f"Tishri {seleucid_year}")
-    converted_date_am = convert_hebrew_date(f"Tishrei {seleucid_year + 3449}")
+    converted_date_am = convert_hebrew_date(
+        f"Tishrei {seleucid_year + Calendar.SELEUCID_OFFSET}"
+    )
     # the converted date range for Tishri Sel. should be the same as that for Tishri AM - 3449 years.
     assert converted_date[0] == converted_date_am[0]
     assert converted_date[1] == converted_date_am[1]
+
+    # leap day (Feb 29, 2020) should convert properly
+    converted_date = convert_seleucid_date("4 Adar 2331")
+    assert converted_date[1] == date(2020, 2, 29)
 
 
 # test islamic date conversion

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -9,6 +9,7 @@ from geniza.corpus.dates import (
     PartialDate,
     convert_hebrew_date,
     convert_islamic_date,
+    convert_seleucid_date,
     get_hebrew_month,
     get_islamic_month,
 )
@@ -202,6 +203,29 @@ def test_convert_hebrew_date():
     # should be the same as year only
     assert converted_date[0] == date(1871, 9, 16)
     assert converted_date[1] == date(1872, 10, 2)
+
+
+# test seleucid date conversion
+def test_convert_seleucid_date():
+    converted_date = convert_seleucid_date("29 Elul 1311")
+    # start/end should be the same
+    assert converted_date[0] == converted_date[1]
+    # expected converted date
+    assert converted_date[1] == date(1000, 9, 1)
+
+    converted_date = convert_seleucid_date("23 Adar I 1475")
+    # start/end should be the same
+    assert converted_date[0] == converted_date[1]
+    # expected converted date
+    assert converted_date[1] == date(1164, 2, 18)
+
+    # month/year
+    seleucid_year = 1458
+    converted_date = convert_seleucid_date(f"Tishri {seleucid_year}")
+    converted_date_am = convert_hebrew_date(f"Tishrei {seleucid_year + 3449}")
+    # the converted date range for Tishri Sel. should be the same as that for Tishri AM - 3449 years.
+    assert converted_date[0] == converted_date_am[0]
+    assert converted_date[1] == converted_date_am[1]
 
 
 # test islamic date conversion

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -233,6 +233,17 @@ def test_convert_seleucid_date():
     converted_date = convert_seleucid_date("4 Adar 2331")
     assert converted_date[1] == date(2020, 2, 29)
 
+    # leap year (4826 AM = 1377 Seleucid) should convert properly
+    seleucid_year = 1377
+    converted_date = convert_seleucid_date(f"21 Adar II {seleucid_year}")
+    converted_date_am = convert_hebrew_date(
+        f"21 Adar II {seleucid_year + Calendar.SELEUCID_OFFSET}"
+    )
+    assert converted_date[0] == converted_date_am[0]
+    assert converted_date[1] == converted_date_am[1]
+    # and it should be converted to 1066-03-21 CE
+    assert converted_date[1] == date(1066, 3, 21)
+
 
 # test islamic date conversion
 def test_get_islamic_month():


### PR DESCRIPTION
## In this PR

Per #886, support automatic conversion of Seleucid dates to CE.

## Notes

Had the scholars check [the report](https://docs.google.com/spreadsheets/d/1ccEIstQVp6yDxLsagVqHmPW-7m0YpYvbrK7BWoQ0yYY/edit), and they also passed it along to some outside researchers; all agreed the conversions were sound. They also requested that all existing standard dates be updated using the new formula, so I'll run `convert_dates update` after this is merged.

Do you think we should add an option to `convert_dates` to only update a certain calendar, or should it be fine to just go ahead and update all of them?