### PR TITLE
Align transcriptions/translations with JS (#1358)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -159,7 +159,12 @@
                 </div>
                 <div class="transcription-panel">
                     {% if edit_mode == "transcribing" %}
-                        <div class="annotate transcription" dir="rtl" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
+                        <div class="annotate transcription"
+                            dir="rtl"
+                            data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}"
+                            data-ittpanel-target="transcription"
+                            data-action="mousedown->ittpanel#clickAnnotation"
+                            >
                             {% if forloop.first %}
                                 {% include "corpus/snippets/transcription_instructions.html" %}
                             {% endif %}
@@ -176,6 +181,7 @@
                                 {# display transcription in chunks by index #}
                                 {% for edition in document.digital_editions.all %}
                                     <div class="transcription ed-{{ edition.pk }}"
+                                        data-ittpanel-target="transcription"
                                         data-label="{{ edition.source.formatted_display }}"
                                         lang="{{ document.primary_lang_code|default:"" }}"
                                         dir="rtl"
@@ -193,7 +199,12 @@
                 </div>
                 <div class="translation-panel">
                     {% if edit_mode == "translating" %}
-                        <div class="annotate transcription" dir="{{ annotation_config.source_dir|default:"ltr" }}" data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}">
+                        <div class="annotate translation"
+                            data-ittpanel-target="translation"
+                            data-action="mousedown->ittpanel#clickAnnotation"
+                            dir="{{ annotation_config.source_dir|default:"ltr" }}"
+                            data-manifest="{% url 'corpus-uris:document-manifest' document.pk %}"
+                            >
                             {% if forloop.first %}
                                 {% include "corpus/snippets/transcription_instructions.html" %}
                             {% endif %}
@@ -209,7 +220,11 @@
                             <div class="translations">
                                 {# display translation in chunks by index #}
                                 {% for translation in document.digital_translations.all %}
-                                    <div class="translation tr-{{ translation.pk }}" data-label="{{ translation.source.formatted_display }}" {% if translation.source.languages.exists %}lang="{{ translation.source.languages.all.0.code }}" dir="{{ translation.source.languages.all.0.direction }}"{% else %}dir="ltr"{% endif %}>
+                                    <div class="translation tr-{{ translation.pk }}"
+                                        data-ittpanel-target="translation"
+                                        data-label="{{ translation.source.formatted_display }}"
+                                        {% if translation.source.languages.exists %}lang="{{ translation.source.languages.all.0.code }}" dir="{{ translation.source.languages.all.0.direction }}"{% else %}dir="ltr"{% endif %}
+                                    >
                                         {% for html_section in translation.content_html|dict_item:canvas_uri %}
                                             {{ html_section|safe }}
                                         {% endfor %}

--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -3,7 +3,25 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-    static targets = ["toggle"];
+    static targets = ["toggle", "transcription", "translation"];
+
+    initialize() {
+        // bind "this" so we can access other methods in this controller from within event handler
+        this.boundAlertHandler = this.handleSaveAnnotation.bind(this);
+    }
+
+    connect() {
+        document.addEventListener("tahqiq-alert", this.boundAlertHandler);
+    }
+
+    disconnect() {
+        document.removeEventListener("tahqiq-alert", this.boundAlertHandler);
+    }
+
+    isDesktop() {
+        // Minimum width for desktop devices
+        return window.innerWidth >= 900;
+    }
 
     clickToggle(evt) {
         // when all three toggles are opened, automatically close one, depending on which you
@@ -26,6 +44,87 @@ export default class extends Controller {
                         (target) => target.id === "images-on"
                     ).checked = false;
                     break;
+            }
+        }
+
+        if (this.isDesktop()) {
+            if (this.transcriptionAndTranslationOpen()) {
+                // when transcription and translation are both opened, align their contents line-by-line
+                this.alignLines();
+            } else {
+                // when one of those two toggles is closed, remove inline styles from lines (alignment no longer needed)
+                this.transcriptionTarget
+                    .querySelectorAll("li")
+                    .forEach((li) => {
+                        li.removeAttribute("style");
+                    });
+                this.translationTarget.querySelectorAll("li").forEach((li) => {
+                    li.removeAttribute("style");
+                });
+            }
+        }
+    }
+
+    transcriptionAndTranslationOpen() {
+        // check toggle targets to find out whether both transcription and translated are open
+        return ["transcription-on", "translation-on"].every(
+            (id) =>
+                this.toggleTargets.find((target) => target.id === id)
+                    .checked === true
+        );
+    }
+
+    alignLines() {
+        // align each line of transcription to translation
+        const edLines = this.transcriptionTarget.querySelectorAll("li");
+        const trLines = this.translationTarget.querySelectorAll("li");
+        // only align as many lines as we need to
+        const [lessLines, moreLines] =
+            edLines.length < trLines.length
+                ? [trLines, edLines]
+                : [edLines, trLines];
+        lessLines.forEach((li, i) => {
+            if (li && moreLines[i]) {
+                // compare top of lines by position in list
+                const thisLiPos = li.getBoundingClientRect();
+                const thatLiPos = moreLines[i].getBoundingClientRect();
+                // add padding-top to the elements that need it
+                if (thisLiPos.top < thatLiPos.top) {
+                    li.style.paddingTop = `${thatLiPos.top - thisLiPos.top}px`;
+                } else if (thisLiPos.top > thatLiPos.top) {
+                    moreLines[i].style.paddingTop = `${
+                        thisLiPos.top - thatLiPos.top
+                    }px`;
+                }
+            }
+        });
+    }
+
+    clickAnnotation(e) {
+        // on mousedown to edit content, clear any style that was added to li elements.
+        // otherwise, modified HTML will be loaded inside the editor, and saved with the annotation!
+        if (this.isDesktop() && e.target.tagName === "ANNOTATION-BLOCK") {
+            const lines = this.transcriptionTarget.querySelector(
+                "annotation-block"
+            )
+                ? this.transcriptionTarget.querySelectorAll("li")
+                : this.translationTarget.querySelectorAll("li");
+            lines.forEach((li) => {
+                li.removeAttribute("style");
+            });
+        }
+    }
+
+    handleSaveAnnotation(e) {
+        // reverse of clickAnnotation; on save, re-align transcription and translation lines
+        // TODO: handle cancel?
+        if (this.isDesktop()) {
+            const { message } = e.detail;
+            if (
+                message.includes("saved") &&
+                this.transcriptionAndTranslationOpen()
+            ) {
+                this.alignLines();
             }
         }
     }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -480,7 +480,9 @@
             // adjust line heights to align transcription with translation when both visible
             // TODO: Handle this more gracefully with javascript to include 3+ line <li>s
             div.editions ol li,
-            div.translations ol li {
+            div.translations ol li,
+            .annotate.translation ol li,
+            .annotate.transcription ol li {
                 // li, height of two lines (line height = 34px)
                 min-height: 68px;
             }


### PR DESCRIPTION
## In this PR

Per #1358:
- On desktop, use stimulus controller to align transcription lines with translation lines when side by side
  - On load, add inline padding style to each line to match corresponding line's height
  - On editing an annotation, remove the padding so that the inline style does not get saved with the annotation
  - On saving an annotation, recalculate and reapply padding

## Questions

- Is it a good approach to add inline padding to each line? I couldn't think of another way, but there is the issue with inline styles persisting in the HTML. Checking the alert event message for "saved" is definitely hacky—my instinct is to add some more events to tahqiq (simple "save" and "cancel" events), but wanted to get your feedback on this and overall approach first.