### PR TITLE
Fix bugs with delete/empty annotation (#1357)

### DIFF
--- a/geniza/annotations/views.py
+++ b/geniza/annotations/views.py
@@ -321,7 +321,10 @@ class AnnotationDetail(
         # update footnote to remove DIGITAL_EDITION type if this is the last annotation associated with it
         footnote.refresh_from_db()
         if footnote.annotation_set.count() == 0:
-            footnote.doc_relation.remove(Footnote.DIGITAL_EDITION)
+            if Footnote.DIGITAL_EDITION in footnote.doc_relation:
+                footnote.doc_relation.remove(Footnote.DIGITAL_EDITION)
+            if Footnote.DIGITAL_TRANSLATION in footnote.doc_relation:
+                footnote.doc_relation.remove(Footnote.DIGITAL_TRANSLATION)
             footnote.save()
             footnote.refresh_from_db()
 

--- a/geniza/corpus/annotation_export.py
+++ b/geniza/corpus/annotation_export.py
@@ -220,17 +220,19 @@ class AnnotationExporter:
                         doc_transcription_dir,
                         "%s.%s" % (base_filename, output_format),
                     )
-                    doc_updated_files.append(outfile_path)
                     with open(outfile_path, "w") as outfile:
                         if output_format == "html":
                             content = html_template[fn_type].render(
                                 {"document": document, "edition": footnote}
                             )
-                            outfile.write(content)
                         else:
                             # text version is meant for corpus analytics,
                             # so should be minimal and content only
-                            outfile.write(footnote.content_text)
+                            content = footnote.content_text
+                        if content:
+                            # don't write/add to updated if no content
+                            outfile.write(content)
+                            doc_updated_files.append(outfile_path)
 
             # add all updated files for this document to the updated list
             updated_filenames.extend(doc_updated_files)


### PR DESCRIPTION
## In this PR

Per #1357:

- Fix bug where only `DIGITAL_EDITION` was getting removed when all annotations were deleted (even when the footnote didn't have that relation!)
- Fix export bug where `outfile.write(None)` could get called, likely as a result of the previous error (annotation was not deleted correctly); in case it happens again, handle this gracefully in export