### PR TITLE
Add "enlarge image" button when only image visible (#1413)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -122,6 +122,8 @@
                                         </svg>
                                         <span class="sr-only">Pop out</span>
                                     </button>
+                                {% else %}
+                                    <button class="enlarge-button" type="button"><span class="sr-only">Enlarge image</span></button>
                                 {% endif %}
                                 <div class="img-controls">
                                     <input data-iiif-target="zoomSlider" data-action="iiif#handleDeepZoom" id="zoom-slider-{{ forloop.counter0 }}" type="range" name="zoom-slider" min="1" max="100" value="0" step="0.01" />
@@ -135,11 +137,11 @@
                         </div>
                         <div class="deep-zoom-container">
                             <img class="iiif-image" data-iiif-target="image" data-annotation-target="image" src="{{ image_info.image|iiif_image:"size:width=500" }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
-                                 sizes="(max-width: 650px) 50vw, 94vw"
+                                 sizes="(max-width: 1440px) 50vw, 94vw"
                                  srcset="{{ image_info.image|iiif_image:"size:width=300" }} 300w,
                                          {{ image_info.image|iiif_image:"size:width=500" }} 500w,
                                          {{ image_info.image|iiif_image:"size:width=640" }} 640w,
-                                         {{ image_info.image|iiif_image:"size:width=1000" }} 1000w">
+                                         {{ image_info.image|iiif_image:"size:width=1440" }} 1440w">
                             <div class="osd" data-iiif-target="osd" data-iiif-url="{{ image_info.image.info }}"></div>
                         </div>
                     </div>

--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -20,6 +20,16 @@ export default class extends Controller {
     connect() {
         // make iiif controller available at element.iiif
         this.element[this.identifier] = this;
+
+        // allow "enlarge" image during viewing
+        const enlargeButton = this.imageContainerTarget.querySelector(
+            "button.enlarge-button"
+        );
+        enlargeButton.addEventListener("click", (e) => {
+            // use toggle to allow opening and closing with the pin icon
+            this.imageContainerTarget.classList.toggle("enlarged");
+            enlargeButton.classList.toggle("active");
+        });
     }
 
     rotationTargetConnected() {

--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -56,21 +56,29 @@ export default class extends Controller {
                 this.alignLines();
             } else {
                 // when one of those two toggles is closed, remove data-lines from each line (alignment no longer needed)
-                this.transcriptionTarget
-                    .querySelectorAll("li")
-                    .forEach((li) => {
-                        li.removeAttribute("data-lines");
-                    });
-                this.translationTarget.querySelectorAll("li").forEach((li) => {
-                    li.removeAttribute("data-lines");
-                });
+                if (this.hasTranscriptionTarget) {
+                    this.transcriptionTarget
+                        .querySelectorAll("li")
+                        .forEach((li) => {
+                            if (li) li.removeAttribute("data-lines");
+                        });
+                }
+                if (this.hasTranslationTarget) {
+                    this.translationTarget
+                        .querySelectorAll("li")
+                        .forEach((li) => {
+                            if (li) li.removeAttribute("data-lines");
+                        });
+                }
                 // also remove padding-top alignment of the two lists
-                this.transcriptionTarget
-                    .querySelector("ol")
-                    .removeAttribute("style");
-                this.translationTarget
-                    .querySelector("ol")
-                    .removeAttribute("style");
+                if (this.hasTranscriptionTarget) {
+                    const edOL = this.transcriptionTarget.querySelector("ol");
+                    if (edOL) edOL.removeAttribute("style");
+                }
+                if (this.hasTranslationTarget) {
+                    const trOL = this.translationTarget.querySelector("ol");
+                    if (trOL) trOL.removeAttribute("style");
+                }
             }
         }
     }

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -306,6 +306,10 @@
             overflow: hidden;
             max-width: 100%;
         }
+        /* hide enlarge button on mobile */
+        button.enlarge-button {
+            display: none;
+        }
         @include breakpoints.for-tablet-landscape-up {
             padding: 0 $toggle-default-width 0;
         }
@@ -325,6 +329,42 @@
         // image panel spacing
         div.img {
             margin: 0 auto;
+            /* enlarge button and enlarge functionality */
+            @include breakpoints.for-tablet-landscape-up {
+                transition: max-width 0.3s ease-in-out;
+                img {
+                    transition: width 0.3s ease-in-out;
+                }
+                &.enlarged {
+                    max-width: 100%;
+                    img {
+                        width: 100%;
+                    }
+                }
+                button.enlarge-button {
+                    display: flex;
+                    cursor: pointer;
+                    align-items: center;
+                    justify-content: center;
+                    position: relative;
+                    border: none;
+                    background: transparent;
+                    padding: 0;
+                    margin: 0;
+                    z-index: 2;
+                    &::after {
+                        color: var(--on-background);
+                        content: "\f118";
+                        @include typography.icon-button-lg;
+                    }
+                    &:active::after {
+                        color: var(--primary);
+                    }
+                    &.active::after {
+                        content: "\f117";
+                    }
+                }
+            }
         }
 
         // Attribution and license text
@@ -465,6 +505,10 @@
                     justify-content: flex-start;
                 }
             }
+        }
+        // image enlarge button
+        button.enlarge-button {
+            display: none;
         }
     }
 


### PR DESCRIPTION
## In this PR

- Per #1413, allow users to expand images to reach nearly the full width of the window, on desktop, when only images are visible; and toggle to collapse
- Fix some null checks in the Stimulus controller for ITT panel toggles when transcription or translation are not present