### PR TITLE
Automatically set Person.has_page = True if document count meets threshold (#1381)

### DIFF
--- a/geniza/entities/apps.py
+++ b/geniza/entities/apps.py
@@ -1,5 +1,16 @@
 from django.apps import AppConfig
+from django.db.models.signals import m2m_changed
 
 
 class EntitiesConfig(AppConfig):
     name = "geniza.entities"
+
+    def ready(self):
+        # attach m2m_changed signal for person-document relations
+        from geniza.entities.models import PersonSignalHandlers
+
+        m2m_changed.connect(
+            PersonSignalHandlers.person_document_relation_changed,
+            sender="entities.PersonDocumentRelation",
+        )
+        return super().ready()

--- a/geniza/entities/apps.py
+++ b/geniza/entities/apps.py
@@ -1,16 +1,5 @@
 from django.apps import AppConfig
-from django.db.models.signals import m2m_changed
 
 
 class EntitiesConfig(AppConfig):
     name = "geniza.entities"
-
-    def ready(self):
-        # attach m2m_changed signal for person-document relations
-        from geniza.entities.models import PersonSignalHandlers
-
-        m2m_changed.connect(
-            PersonSignalHandlers.person_document_relation_changed,
-            sender="entities.PersonDocumentRelation",
-        )
-        return super().ready()

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -88,30 +88,28 @@ class TestPersonDocumentRelation:
         )
         assert str(relation) == f"{recipient} relation: {goitein} and {doc}"
 
-
-@pytest.mark.django_db
-class TestPersonSignalHandlers:
-    def test_person_document_relation_changed(self):
+    def test_save(self):
         # create two people with has_page = false
         goitein = Person.objects.create()
-        rustow = Person.objects.create()
+        recipient = PersonDocumentRelationType.objects.create(name="Test Recipient")
 
         # associate with a bunch of documents
         for _ in range(Person.DOCUMENT_THRESHOLD - 1):
             doc = Document.objects.create()
-            goitein.documents.add(doc)
-            rustow.documents.add(doc)
+            PersonDocumentRelation.objects.create(
+                person=goitein,
+                document=doc,
+                type=recipient,
+            )
 
         # still one less than threshold, so has_page should still be false
         assert not goitein.has_page
-        assert not rustow.has_page
 
         # create and add one more, thus meeting the threshold
         doc = Document.objects.create()
-        goitein.documents.add(doc)
+        PersonDocumentRelation.objects.create(
+            person=goitein,
+            document=doc,
+            type=recipient,
+        )
         assert goitein.has_page
-
-        # should work in the reverse as well (but will require db refresh)
-        doc.people.add(rustow)
-        rustow.refresh_from_db()
-        assert rustow.has_page

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -92,19 +92,26 @@ class TestPersonDocumentRelation:
 @pytest.mark.django_db
 class TestPersonSignalHandlers:
     def test_person_document_relation_changed(self):
-        # create a person with has_page = false
+        # create two people with has_page = false
         goitein = Person.objects.create()
-        assert not goitein.has_page
+        rustow = Person.objects.create()
 
         # associate with a bunch of documents
         for _ in range(Person.DOCUMENT_THRESHOLD - 1):
             doc = Document.objects.create()
             goitein.documents.add(doc)
+            rustow.documents.add(doc)
 
         # still one less than threshold, so has_page should still be false
         assert not goitein.has_page
+        assert not rustow.has_page
 
         # create and add one more, thus meeting the threshold
         doc = Document.objects.create()
         goitein.documents.add(doc)
         assert goitein.has_page
+
+        # should work in the reverse as well (but will require db refresh)
+        doc.people.add(rustow)
+        rustow.refresh_from_db()
+        assert rustow.has_page

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -87,3 +87,24 @@ class TestPersonDocumentRelation:
             type=recipient,
         )
         assert str(relation) == f"{recipient} relation: {goitein} and {doc}"
+
+
+@pytest.mark.django_db
+class TestPersonSignalHandlers:
+    def test_person_document_relation_changed(self):
+        # create a person with has_page = false
+        goitein = Person.objects.create()
+        assert not goitein.has_page
+
+        # associate with a bunch of documents
+        for _ in range(Person.DOCUMENT_THRESHOLD - 1):
+            doc = Document.objects.create()
+            goitein.documents.add(doc)
+
+        # still one less than threshold, so has_page should still be false
+        assert not goitein.has_page
+
+        # create and add one more, thus meeting the threshold
+        doc = Document.objects.create()
+        goitein.documents.add(doc)
+        assert goitein.has_page


### PR DESCRIPTION
## In this PR

Per #1381:
- On adding a Person-Document relation, if the Person does not have a Person page yet (i.e. their `has_page` property is `False`) and they have >= 10 documents associated, give them a page

## Notes

- I started this with an `m2m_changed` signal handler, but discovered more weirdness with m2m relations and Django: calling `.add` on either side of the relation programmatically fires `m2m_changed`, but does not call `PersonDocumentRelation.save`. On the other hand, saving using the form (which is likely the only way this will ever be done) does the exact opposite: it calls `PersonDocumentRelation.save`, but does not fire `m2m_changed`, the latter of which is especially surprising to me. 
  - Is it still worth including the signal handler? I removed it in d6975ac1fbce40a86f95c4cbc1afe6c351e95248 but maybe it's worth keeping around in case the programmatic calls ever happen.
- Since the Person feature still hasn't been released on prod and we aren't doing any kind of bulk ingest of them, I didn't bother with a migration