### PR TITLE
Include new default/disabled context variables in admin ITT viewer (#1400)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -906,6 +906,21 @@ class Document(ModelIndexable, DocumentDateMixin):
         )
 
     @property
+    def available_digital_content(self):
+        """Helper method for the ITT viewer to collect all available panels into a list"""
+
+        # NOTE: this is ordered by priority, with images first, then translations over
+        # transcriptions.
+        available_panels = []
+        if self.has_image():
+            available_panels.append("images")
+        if self.has_translation():
+            available_panels.append("translation")
+        if self.has_transcription():
+            available_panels.append("transcription")
+        return available_panels
+
+    @property
     def title(self):
         """Short title for identifying the document, e.g. via search."""
         return f"{self.doctype or _('Unknown type')}: {self.shelfmark_display or '??'}"

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -319,15 +319,8 @@ class DocumentDetailView(DocumentDetailBase, DetailView):
         context_data = super().get_context_data(**kwargs)
         images = self.object.iiif_images(with_placeholders=True)
 
-        # logic for which panels to show or disable by default: images always shown if available,
-        # then priority is translations over transcriptions. show both of the latter two if no imgs
-        available_panels = []
-        if self.object.has_image():
-            available_panels.append("images")
-        if self.object.has_translation():
-            available_panels.append("translation")
-        if self.object.has_transcription():
-            available_panels.append("transcription")
+        # collect available panels
+        available_panels = self.object.available_digital_content
 
         context_data.update(
             {


### PR DESCRIPTION
## In this PR

- Move the new "available panels" logic (#1404) to `Document` and include in document change view admin context