### PR TITLE
Respect perms in mixed inlines/formsets (#1434)

### DIFF
--- a/geniza/corpus/templatetags/admin_extras.py
+++ b/geniza/corpus/templatetags/admin_extras.py
@@ -12,24 +12,20 @@ def get_fieldsets_and_inlines(context):
     """
     adminform = context["adminform"]
     model_admin = adminform.model_admin
-    adminform = iter(adminform)
-    inlines = iter(context["inline_admin_formsets"])
+    adminform = list(adminform)
+    inlines = list(context["inline_admin_formsets"])
 
     fieldsets_and_inlines = []
-    for choice in model_admin.fieldsets_and_inlines_order:
-        try:
-            if choice == "f":
-                fieldsets_and_inlines.append(("f", next(adminform)))
-            elif choice == "i":
-                fieldsets_and_inlines.append(("i", next(inlines)))
-            elif choice == "itt":
-                # special case for itt panel on document
-                fieldsets_and_inlines.append(("itt", None))
-        except StopIteration:
-            raise IndexError(
-                """Too many values provided to fieldsets_and_inlines_order.
-                Ensure there is a fieldset (not just a field) for every 'f' provided."""
-            )
+    for choice in getattr(model_admin, "fieldsets_and_inlines_order", ()):
+        if choice == "f":
+            if adminform:
+                fieldsets_and_inlines.append(("f", adminform.pop(0)))
+        elif choice == "i":
+            if inlines:
+                fieldsets_and_inlines.append(("i", inlines.pop(0)))
+        elif choice == "itt":
+            # special case for itt panel on document
+            fieldsets_and_inlines.append(("itt", None))
 
     # render any remaining ones in the normal order: fieldsets, then inlines
     for fieldset in adminform:

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -197,17 +197,3 @@ class TestAdminExtrasTemplateTags:
 
         # should append the remaining inline at the end
         assert fieldsets_and_inlines[4] == ("i", "inline2")
-
-        # should throw indexerror if you supply too many fieldsets or inlines
-        adminform.model_admin.fieldsets_and_inlines_order = ("f", "i", "f", "f")
-        with pytest.raises(IndexError) as errorinfo:
-            admin_extras.get_fieldsets_and_inlines(
-                {"adminform": adminform, "inline_admin_formsets": inlines}
-            )
-        assert "Too many values" in str(errorinfo.value)
-        adminform.model_admin.fieldsets_and_inlines_order = ("f", "i", "i", "i")
-        with pytest.raises(IndexError) as errorinfo:
-            admin_extras.get_fieldsets_and_inlines(
-                {"adminform": adminform, "inline_admin_formsets": inlines}
-            )
-        assert "Too many values" in str(errorinfo.value)


### PR DESCRIPTION
Changes from [later commits on the adapted codebase](https://github.com/dezede/dezede/commits/a76c6792a44e3531dd3dcc01925db703567307b5/libretto/templatetags/admin_extras.py) already fix this bug, thankfully! This PR simply implements them.