### PR TITLE
Respect annotation reordering in document detail page (#1438)

### DIFF
--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -606,6 +606,7 @@ class Footnote(TrackChangesModel):
         # keyed on canvas uri
         # handle multiple annotations on the same canvas
         html_content = defaultdict(list)
+        # order by optional position property (set by manual reorder in editor), then date
         for a in self.annotation_set.all().order_by(
             "content__schema:position", "created"
         ):

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -606,7 +606,9 @@ class Footnote(TrackChangesModel):
         # keyed on canvas uri
         # handle multiple annotations on the same canvas
         html_content = defaultdict(list)
-        for a in self.annotation_set.all():
+        for a in self.annotation_set.all().order_by(
+            "content__schema:position", "created"
+        ):
             if a.label:
                 html_content[a.target_source_id].append(f"<h3>{a.label}</h3>")
             html_content[a.target_source_id].append(a.body_content)

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -274,7 +274,7 @@ class TestFootnote:
         canvas_uri = annotation.content["target"]["source"]["id"]
         digital_edition = annotation.footnote
         # create a second annotation
-        Annotation.objects.create(
+        second_annotation = Annotation.objects.create(
             footnote=digital_edition,
             content={
                 **annotation.content,
@@ -289,6 +289,20 @@ class TestFootnote:
             "<h3>A label</h3>",
             "Second annotation!",
         ]
+
+        # should respect reordering
+        second_annotation.content["schema:position"] = 1
+        second_annotation.save()
+        annotation.content["schema:position"] = 2
+        annotation.save()
+        # invalidate cache
+        del digital_edition.content_html
+        assert digital_edition.content_html[canvas_uri] == [
+            "<h3>A label</h3>",
+            "Second annotation!",
+            "Test annotation",
+        ]
+
         # should return None if there are no associated annotations
         edition = Footnote.objects.create(
             source=digital_edition.source,


### PR DESCRIPTION
## In this PR

Per #1438:
- Add `order_by("content__schema:position", "created")` to the annotation set in `Footnote.content_html`, so that reordered annotations will appear in the correct order on the document detail page

## Questions

- Since this is a cached property, I'm wondering about cache busting when annotations are reordered. It seems to work for me locally when I hard refresh the doc detail page, but wondering if that's always the case / if there's a way to do it automatically from the backend?