### PR TITLE
Reset entities person admin own_pk to None on add (#1366)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -132,6 +132,9 @@ class PersonAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin):
         """For Person-Person autocomplete on the PersonAdmin form, keep track of own pk"""
         if obj:
             self.own_pk = obj.pk
+        else:
+            # reset own_pk to None if we are creating a new person
+            self.own_pk = None
         return super().get_form(request, obj, **kwargs)
 
     def get_queryset(self, request):

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -57,6 +57,10 @@ class TestPersonAdmin:
         person_admin.get_form(mockrequest, obj=goitein)
         assert person_admin.own_pk == goitein.pk
 
+        # create new person, should be reset to None
+        person_admin.get_form(mockrequest, obj=None)
+        assert person_admin.own_pk == None
+
     def test_get_queryset(self):
         goitein = Person.objects.create()
         Person.objects.create()


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/1366#issuecomment-1672467994:
- When adding a new person, the most recently edited (existing) person would not appear in the Person-Person autocomplete list, making the relationship impossible to add. This was caused by a bug where the previous `PersonAdmin.own_pk` was persisted when a new person was being added.
- This PR fixes that bug