### PR TITLE
Reorder dating metadata in document csv export (#1399)

### DIFF
--- a/geniza/corpus/metadata_export.py
+++ b/geniza/corpus/metadata_export.py
@@ -33,6 +33,10 @@ class DocumentExporter(Exporter):
         "doc_date_original",
         "doc_date_calendar",
         "doc_date_standard",
+        "doc_dating_display",
+        "doc_dating_standard",
+        "doc_dating_rationale",
+        "doc_dating_notes",
         "initial_entry",
         "last_modified",
         "input_by",
@@ -40,10 +44,6 @@ class DocumentExporter(Exporter):
         "collection",
         "has_transcription",
         "has_translation",
-        "doc_dating_display",
-        "doc_dating_standard",
-        "doc_dating_rationale",
-        "doc_dating_notes",
     ]
 
     # queryset filter for content types included in this import


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/1399#issuecomment-1677523254, reorders the columns in CSV export to move inferred dating columns next to the existing date columns.