### PR TITLE
Resolve document and inferred dates in document merge (#1429)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1296,13 +1296,30 @@ class Document(ModelIndexable, DocumentDateMixin):
             # handle document dates validation before making any changes;
             # mismatch should result in exception (caught by DocumentMerge.form_valid)
             if (
-                doc.doc_date_standard
-                and self.doc_date_standard
-                and self.doc_date_standard != doc.doc_date_standard
-            ) or (
-                doc.doc_date_original
-                and self.doc_date_original
-                and self.doc_date_original != doc.doc_date_original
+                (
+                    # both documents have standard dates, and they don't match
+                    doc.doc_date_standard
+                    and self.doc_date_standard
+                    and self.doc_date_standard != doc.doc_date_standard
+                )
+                or (
+                    # both documents have original dates, and they don't match
+                    doc.doc_date_original
+                    and self.doc_date_original
+                    and self.doc_date_original != doc.doc_date_original
+                )
+                or (
+                    # other document has original, this doc has standard, and they don't match
+                    doc.doc_date_original
+                    and self.doc_date_standard
+                    and doc.standardize_date() != self.doc_date_standard
+                )
+                or (
+                    # other document has standard, this doc has original, and they don't match
+                    doc.doc_date_standard
+                    and self.doc_date_original
+                    and self.standardize_date() != doc.doc_date_standard
+                )
             ):
                 raise ValidationError(
                     "Merged documents must not contain conflicting dates; resolve before merge"
@@ -1316,6 +1333,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                 self.doc_date_standard = doc.doc_date_standard
             if doc.doc_date_original:
                 self.doc_date_original = doc.doc_date_original
+                self.doc_date_calendar = doc.doc_date_calendar
 
             # add inferred datings (conflicts or duplicates are post-merge
             # data cleanup tasks)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1311,7 +1311,7 @@ class Document(ModelIndexable, DocumentDateMixin):
             # add any tags from merge document tags to primary doc
             self.tags.add(*doc.tags.names())
 
-            # if not in conflict, migrate dates to result document
+            # if not in conflict (i.e. missing or exact duplicate), copy dates to result document
             if doc.doc_date_standard:
                 self.doc_date_standard = doc.doc_date_standard
             if doc.doc_date_original:

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1657,8 +1657,8 @@ def test_document_merge_with_dates(document, join):
     join_clone_2.save()
 
     # create some datings; doesn't matter that they are identical, as cleaning
-    # up post-merge dupes is a data cleanup task. unit test will make sure that
-    # doesn't cause errors!
+    # up post-merge dupes is a manual data cleanup task. unit test will make
+    # sure that doesn't cause errors!
     dating_1 = Dating.objects.create(
         document=document,
         display_date="1000 CE",

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.contrib.admin.models import CHANGE, LogEntry
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.db.models.query import Prefetch
 from django.http import Http404, HttpResponse, JsonResponse
@@ -691,7 +692,14 @@ class DocumentMerge(PermissionRequiredMixin, FormView):
 
         # Merge secondary documents into the selected primary document
         user = getattr(self.request, "user", None)
-        primary_doc.merge_with(secondary_docs, rationale, user=user)
+
+        try:
+            primary_doc.merge_with(secondary_docs, rationale, user=user)
+        except ValidationError as err:
+            # in case the merge resulted in an error, display error to user
+            messages.error(self.request, err.message)
+            # redirect to this form page instead of one of the documents
+            return HttpResponseRedirect(self.request.get_full_path())
 
         # Display info about the merge to the user
         new_doc_link = reverse("admin:corpus_document_change", args=[primary_doc.id])

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -699,7 +699,10 @@ class DocumentMerge(PermissionRequiredMixin, FormView):
             # in case the merge resulted in an error, display error to user
             messages.error(self.request, err.message)
             # redirect to this form page instead of one of the documents
-            return HttpResponseRedirect(self.request.get_full_path())
+            return HttpResponseRedirect(
+                "%s?ids=%s"
+                % (reverse("admin:document-merge"), self.request.GET.get("ids", "")),
+            )
 
         # Display info about the merge to the user
         new_doc_link = reverse("admin:corpus_document_change", args=[primary_doc.id])


### PR DESCRIPTION
## In this PR

Per #1429:
- In document merge, handle dates
  - Raise ValidationError on conflicting standard/original document dates
  - If not in conflict, ensure no standard/original document dates are lost during merge
  - Add all inferred datings from merged documents
