### PR TITLE
Various alignment bugfixes (#1409, #1431)

### DIFF
--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -115,10 +115,16 @@ a#needsreview:target {
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;
 }
+.form-row .transcription ol,
+.form-row .translation ol {
+    margin: 0;
+    padding: 0;
+}
 /* need to apply these manually for overriding purposes */
 .form-row .transcription p,
 .form-row .transcription li {
     font-family: "FrankRuhl 1924 MF Medium", "Amiri", "Times New Roman", serif;
+    box-sizing: border-box;
 }
 .form-row .translation p,
 .form-row .translation li {
@@ -134,7 +140,7 @@ a#needsreview:target {
 .form-row .translation[dir="ltr"] p,
 .form-row .translation[dir="ltr"] li {
     font-size: 20px;
-    line-height: 30px;
+    line-height: 34px;
 }
 .form-row .transcription[lang="ar"] p,
 .form-row .transcription[lang="ar"] li,
@@ -146,6 +152,9 @@ a#needsreview:target {
 }
 .form-row .itt-select ul {
     margin-left: 0;
+}
+.form-row .translation[dir="ltr"] ol li:not([value])::before {
+    line-height: 20px;
 }
 /* headers */
 .form-row .transcription h3,

--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -59,29 +59,34 @@ export default class extends Controller {
                 // when transcription and translation are both opened, align their contents line-by-line
                 this.alignLines();
             } else {
-                // when one of those two toggles is closed, remove data-lines from each line (alignment no longer needed)
+                // when one of those two toggles is closed, remove data-lines from each line
+                // (alignment no longer needed)
                 if (this.hasTranscriptionTarget) {
-                    this.transcriptionTarget
-                        .querySelectorAll("li")
-                        .forEach((li) => {
+                    this.transcriptionTargets.forEach((target) => {
+                        target.querySelectorAll("li").forEach((li) => {
                             if (li) li.removeAttribute("data-lines");
                         });
+                    });
                 }
                 if (this.hasTranslationTarget) {
-                    this.translationTarget
-                        .querySelectorAll("li")
-                        .forEach((li) => {
+                    this.translationTargets.forEach((target) => {
+                        target.querySelectorAll("li").forEach((li) => {
                             if (li) li.removeAttribute("data-lines");
                         });
+                    });
                 }
                 // also remove padding-top alignment of the two lists
                 if (this.hasTranscriptionTarget) {
-                    const edOL = this.transcriptionTarget.querySelector("ol");
-                    if (edOL) edOL.removeAttribute("style");
+                    this.transcriptionTargets.forEach((target) => {
+                        const edOL = target.querySelector("ol");
+                        if (edOL) edOL.removeAttribute("style");
+                    });
                 }
                 if (this.hasTranslationTarget) {
-                    const trOL = this.translationTarget.querySelector("ol");
-                    if (trOL) trOL.removeAttribute("style");
+                    this.translationTargets.forEach((target) => {
+                        const trOL = target.querySelector("ol");
+                        if (trOL) trOL.removeAttribute("style");
+                    });
                 }
             }
         }
@@ -106,38 +111,45 @@ export default class extends Controller {
     }
 
     alignLines() {
-        // first, align tops of lists (using inline styles)
-        const edTop = this.transcriptionTarget
-            .querySelector("ol")
-            .getBoundingClientRect().top;
-        const trTop = this.translationTarget
-            .querySelector("ol")
-            .getBoundingClientRect().top;
-        if (edTop < trTop) {
-            this.transcriptionTarget.querySelector("ol").style.paddingTop = `${
-                trTop - edTop
-            }px`;
-        } else if (trTop < edTop) {
-            this.translationTarget.querySelector("ol").style.paddingTop = `${
-                edTop - trTop
-            }px`;
-        }
-
-        // then, align each line of transcription to translation
-        const edLines = this.transcriptionTarget.querySelectorAll("li");
-        const trLines = this.translationTarget.querySelectorAll("li");
-        // only align as many lines as we need to
-        const minLines = Math.min(edLines.length, trLines.length);
-        for (let i = 0; i < minLines; i++) {
-            if (edLines[i] && trLines[i]) {
-                // calculate number of lines based on line height
-                const maxLineCount = Math.max(
-                    this.getLineCount(edLines[i]),
-                    this.getLineCount(trLines[i])
-                );
-                // set data-lines attribute on each li according to which is longer
-                edLines[i].setAttribute("data-lines", maxLineCount);
-                trLines[i].setAttribute("data-lines", maxLineCount);
+        // loop through each transcription and translation (only as many as needed)
+        const minTargets = Math.min(
+            this.transcriptionTargets.length,
+            this.translationTargets.length
+        );
+        for (let i = 0; i < minTargets; i++) {
+            // loop through as many OLs in each transcription/translation as needed
+            const edOls = this.transcriptionTargets[i].querySelectorAll("ol");
+            const trOls = this.translationTargets[i].querySelectorAll("ol");
+            const minLists = Math.min(edOls.length, trOls.length);
+            for (let j = 0; j < minLists; j++) {
+                // first, align tops of lists (using inline styles)
+                const edOl = edOls[j];
+                const trOl = trOls[j];
+                const edTop = edOl.getBoundingClientRect().top;
+                // translation is always 1 pixel difference
+                const trTop = trOl.getBoundingClientRect().top - 1;
+                if (edTop < trTop) {
+                    edOl.style.paddingTop = `${trTop - edTop}px`;
+                } else if (trTop < edTop) {
+                    trOl.style.paddingTop = `${edTop - trTop}px`;
+                }
+                // then, align each line of transcription to translation
+                const edLines = edOl.querySelectorAll("li");
+                const trLines = trOl.querySelectorAll("li");
+                // only align as many lines as we need to
+                const minLines = Math.min(edLines.length, trLines.length);
+                for (let k = 0; k < minLines; k++) {
+                    if (edLines[k] && trLines[k]) {
+                        // calculate number of lines based on line height
+                        const maxLineCount = Math.max(
+                            this.getLineCount(edLines[k]),
+                            this.getLineCount(trLines[k])
+                        );
+                        // set data-lines attribute on each li according to which is longer
+                        edLines[k].setAttribute("data-lines", maxLineCount);
+                        trLines[k].setAttribute("data-lines", maxLineCount);
+                    }
+                }
             }
         }
     }

--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
         // bind "this" so we can access other methods in this controller from within event handler
         this.boundAlertHandler = this.handleSaveAnnotation.bind(this);
         this.boundCancelHandler = this.handleCancelAnnotation.bind(this);
+        this.boundResizeHandler = this.handleResizeAlign.bind(this);
     }
 
     connect() {
@@ -18,6 +19,8 @@ export default class extends Controller {
             // if transcription + translation both open, align their contents line-by-line
             this.alignLines();
         }
+        // on resize, retrigger alignment
+        window.addEventListener("resize", this.boundResizeHandler);
     }
 
     disconnect() {
@@ -59,35 +62,8 @@ export default class extends Controller {
                 // when transcription and translation are both opened, align their contents line-by-line
                 this.alignLines();
             } else {
-                // when one of those two toggles is closed, remove data-lines from each line
-                // (alignment no longer needed)
-                if (this.hasTranscriptionTarget) {
-                    this.transcriptionTargets.forEach((target) => {
-                        target.querySelectorAll("li").forEach((li) => {
-                            if (li) li.removeAttribute("data-lines");
-                        });
-                    });
-                }
-                if (this.hasTranslationTarget) {
-                    this.translationTargets.forEach((target) => {
-                        target.querySelectorAll("li").forEach((li) => {
-                            if (li) li.removeAttribute("data-lines");
-                        });
-                    });
-                }
-                // also remove padding-top alignment of the two lists
-                if (this.hasTranscriptionTarget) {
-                    this.transcriptionTargets.forEach((target) => {
-                        const edOL = target.querySelector("ol");
-                        if (edOL) edOL.removeAttribute("style");
-                    });
-                }
-                if (this.hasTranslationTarget) {
-                    this.translationTargets.forEach((target) => {
-                        const trOL = target.querySelector("ol");
-                        if (trOL) trOL.removeAttribute("style");
-                    });
-                }
+                // when one of those two toggles is closed, alignment no longer needed
+                this.removeAlignment();
             }
         }
     }
@@ -151,6 +127,46 @@ export default class extends Controller {
                     }
                 }
             }
+        }
+    }
+
+    removeAlignment() {
+        // remove alignment
+        // first remove data-lines from each line
+        if (this.hasTranscriptionTarget) {
+            this.transcriptionTargets.forEach((target) => {
+                target.querySelectorAll("li").forEach((li) => {
+                    if (li) li.removeAttribute("data-lines");
+                });
+            });
+        }
+        if (this.hasTranslationTarget) {
+            this.translationTargets.forEach((target) => {
+                target.querySelectorAll("li").forEach((li) => {
+                    if (li) li.removeAttribute("data-lines");
+                });
+            });
+        }
+        // then remove padding-top alignment of the two lists
+        if (this.hasTranscriptionTarget) {
+            this.transcriptionTargets.forEach((target) => {
+                const edOL = target.querySelector("ol");
+                if (edOL) edOL.removeAttribute("style");
+            });
+        }
+        if (this.hasTranslationTarget) {
+            this.translationTargets.forEach((target) => {
+                const trOL = target.querySelector("ol");
+                if (trOL) trOL.removeAttribute("style");
+            });
+        }
+    }
+
+    handleResizeAlign() {
+        // on resize, remove alignment and realign using new heights
+        if (this.isDesktop() && this.transcriptionAndTranslationOpen()) {
+            this.removeAlignment();
+            this.alignLines();
         }
     }
 

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -538,22 +538,28 @@ $toggle-default-neg: -82px; /* only applies on tablet up */
             }
             li[data-lines="1"] {
                 min-height: calc(1 * 34 / 22 * 1.375rem);
+                max-height: calc(1 * 34 / 22 * 1.375rem);
             }
             li[data-lines="2"] {
                 // li, height of two lines (line height = 34 / 22, font size = 1.375rem)
                 min-height: calc(2 * 34 / 22 * 1.375rem);
+                max-height: calc(2 * 34 / 22 * 1.375rem);
             }
             li[data-lines="3"] {
                 min-height: calc(3 * 34 / 22 * 1.375rem);
+                max-height: calc(3 * 34 / 22 * 1.375rem);
             }
             li[data-lines="4"] {
                 min-height: calc(4 * 34 / 22 * 1.375rem);
+                max-height: calc(4 * 34 / 22 * 1.375rem);
             }
             li[data-lines="5"] {
                 min-height: calc(5 * 34 / 22 * 1.375rem);
+                max-height: calc(5 * 34 / 22 * 1.375rem);
             }
             li[data-lines="6"] {
                 min-height: calc(6 * 34 / 22 * 1.375rem);
+                max-height: calc(6 * 34 / 22 * 1.375rem);
             }
             h2 + span.current-transcription,
             h2 + span.current-translation {
@@ -1257,9 +1263,9 @@ a.editor-navigation {
             left: -9.5px;
 
             @include breakpoints.for-tablet-landscape-up {
-                font-size: 38px;
-                line-height: 21px;
-                left: -10.75px;
+                font-size: 50px;
+                line-height: 16px;
+                left: -12px;
             }
         }
     }


### PR DESCRIPTION
## In this PR

Per #1409:
- Fix issue where alignment was only applied to the first transcription/translation block, and only the first OL within those
  - Also apply this fix to alignment removal
- Fix issue where `min-height` was sometimes causing misalignment due to lack of `max-height`
- Fix issue where initial OL alignment for translation was exactly 1 pixel off
- Fix django admin CSS conflict issues

Per #1431:
- Apply alignment removal and re-alignment on window resize (if on desktop and both transcription and translation are open)

Other:
- I noticed the "li period hider" element was sometimes misaligned in various configurations, so I adjusted it in both the public and admin CSS