### PR TITLE
Fix display of multiple footnotes on same source (#1446)

### DIFF
--- a/geniza/corpus/templates/corpus/document_scholarship.html
+++ b/geniza/corpus/templates/corpus/document_scholarship.html
@@ -26,19 +26,19 @@
                             <dt class="relation">
                                 {# Translators: label for included document relations for a single footnote #}
                                 {% translate "includes" as includes_text %}
-                                {% if source.list|length > 1 or source.list.0.location or source.list.0.url %}
+                                {% if source.list|has_location_or_url %}
                                     {# Translators: label for document relations in list of footnotes #}
-                                    {% blocktranslate with relation=source.list.0.doc_relation|lower trimmed %}
+                                    {% blocktranslate with relation=source.list|all_doc_relations|lower trimmed %}
                                         for {{ relation }} see
                                     {% endblocktranslate%}
                                 {% else %}
                                     {# Translators: label for document relations for one footnote with no location or URL #}
-                                    {% blocktranslate with relation=source.list.0.doc_relation|lower trimmed %}
+                                    {% blocktranslate with relation=source.list|all_doc_relations|lower trimmed %}
                                         includes {{ relation }}
                                     {% endblocktranslate%}
                                 {% endif %}
                             </dt>
-                            {% if source.list|length > 1 or source.list.0.location or source.list.0.url %}
+                            {% if source.list|has_location_or_url %}
                                 <dd class="relation">
                                     <ul>
                                         {% for fn in source.list %}

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -171,4 +171,4 @@ def has_location_or_url(footnotes):
 def all_doc_relations(footnotes):
     """For scholarship records list: join doc relations for all footnotes
     by a comma."""
-    return ", ".join([str(fn.doc_relation) for fn in footnotes])
+    return ", ".join(set([str(fn.doc_relation) for fn in footnotes]))

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -158,3 +158,17 @@ def translate_url(context, lang_code):
     # thanks to https://stackoverflow.com/a/51974042
     path = context.get("request").get_full_path()
     return django_translate_url(path, lang_code)
+
+
+@register.filter
+def has_location_or_url(footnotes):
+    """For scholarship records list: return True if any footnote in the list
+    has a URL or location."""
+    return any(fn.url or fn.location for fn in footnotes)
+
+
+@register.filter
+def all_doc_relations(footnotes):
+    """For scholarship records list: join doc relations for all footnotes
+    by a comma."""
+    return ", ".join([str(fn.doc_relation) for fn in footnotes])

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -63,6 +63,18 @@ class TestCorpusExtrasTemplateTags:
             corpus_extras.all_doc_relations(list(document.footnotes.all()))
             == "Edition, Digital Edition"
         )
+        # should not repeat doc relations even if multiple of the same type appear
+        Footnote.objects.create(
+            object_id=document.pk,
+            content_type=footnote.content_type,
+            source=footnote.source,
+            doc_relation=Footnote.EDITION,
+            location="other place",
+        )
+        assert (
+            corpus_extras.all_doc_relations(list(document.footnotes.all()))
+            == "Edition, Digital Edition"
+        )
 
 
 def test_dict_item():

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -6,6 +6,7 @@ from piffle.iiif import IIIFImageClient
 
 from geniza.common.utils import absolutize_url
 from geniza.corpus.templatetags import admin_extras, corpus_extras
+from geniza.footnotes.models import Footnote
 
 
 class TestCorpusExtrasTemplateTags:
@@ -37,6 +38,31 @@ class TestCorpusExtrasTemplateTags:
         lst = []
         alphabetized = corpus_extras.alphabetize(lst)
         assert alphabetized == []
+
+    def test_has_location_or_url(self, document, footnote):
+        # footnote has a location
+        assert corpus_extras.has_location_or_url([footnote]) == True
+        footnote_2 = Footnote.objects.create(
+            object_id=document.pk,
+            content_type=footnote.content_type,
+            source=footnote.source,
+        )
+        # footnote has no location or url
+        assert corpus_extras.has_location_or_url([footnote_2]) == False
+        # one of the document's footnotes has a location
+        assert corpus_extras.has_location_or_url(list(document.footnotes.all())) == True
+
+    def test_all_doc_relations(self, document, footnote):
+        Footnote.objects.create(
+            object_id=document.pk,
+            content_type=footnote.content_type,
+            source=footnote.source,
+            doc_relation=Footnote.DIGITAL_EDITION,
+        )
+        assert (
+            corpus_extras.all_doc_relations(list(document.footnotes.all()))
+            == "Edition, Digital Edition"
+        )
 
 
 def test_dict_item():


### PR DESCRIPTION
## In this PR

per #1446:
- Use template filter to check if any footnote on a source has a location or url
- Use template filter to collect doc relations for ALL footnotes on the source, not just displaying the first