### PR TITLE
Improvements for web archiving (#1437)

### DIFF
--- a/geniza/context_processors.py
+++ b/geniza/context_processors.py
@@ -18,5 +18,9 @@ def template_globals(request):
         ),
         "site": site,
         "GTAGS_ANALYTICS_ID": getattr(settings, "GTAGS_ANALYTICS_ID", None),
+        "IS_ARCHIVE_CRAWLER": "archive.org_bot"
+        in request.META.get("HTTP_USER_AGENT", "")
+        if hasattr(request, "META")
+        else False,
     }
     return context_extras

--- a/geniza/templates/base.html
+++ b/geniza/templates/base.html
@@ -81,7 +81,7 @@
         {% endif %}
         {% block extrascript %}{% endblock extrascript %}
     </head>
-    <body>
+    <body {% if IS_ARCHIVE_CRAWLER %}data-turbo="false"{% endif %}>
         {% wagtailuserbar 'bottom-right' %}
         {% if "SHOW_WARNING_BANNER" in FEATURE_FLAGS %}
             {% include 'snippets/test_banner.html' %}

--- a/sitemedia/js/controllers/theme_controller.js
+++ b/sitemedia/js/controllers/theme_controller.js
@@ -8,7 +8,11 @@ export default class extends Controller {
     systemDarkMode() {
         // Check system and prior user selection for dark mode
         return (
+            // url param for dark mode should override all
+            new URLSearchParams(window.location.search).get("dark-mode") ||
+            // next priority should be prior user selection
             window.localStorage.getItem("darkMode") === "true" ||
+            // finally, fallback to system setting
             (window.localStorage.getItem("darkMode") === null &&
                 window.matchMedia &&
                 window.matchMedia("(prefers-color-scheme: dark)").matches)


### PR DESCRIPTION
## In this PR

Per #1437
- Disable turbo on any request where the user agent includes `archive.org_bot`
- Adds the ability to append `?dark-mode=true` to any url to force dark mode