### PR TITLE
Use Document.created as fallback input date in index (#887)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1207,7 +1207,8 @@ class Document(ModelIndexable, DocumentDateMixin):
         try:
             last_log_entry = list(self.log_entries.all())[-1]
         except IndexError:
-            # should only occur in unit tests, not real data
+            # occurs in unit tests, and sometimes when new documents are indexed before
+            # log entry is populated
             last_log_entry = None
 
         if last_log_entry:
@@ -1219,6 +1220,14 @@ class Document(ModelIndexable, DocumentDateMixin):
             index_data[
                 "input_date_dt"
             ] = last_log_entry.action_time.isoformat().replace("+00:00", "Z")
+        elif self.created:
+            # when log entry not available, use created date on document object
+            # (will always exist except in some unit tests)
+            index_data["input_year_i"] = self.created.year
+            index_data["input_date_dt"] = self.created.isoformat().replace(
+                "+00:00", "Z"
+            )
+
         return index_data
 
     # define signal handlers to update the index based on changes

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1106,6 +1106,15 @@ class TestDocument:
         all_old_shelfmarks.append(fragment2.old_shelfmarks)
         assert index_data["fragment_old_shelfmark_ss"] == all_old_shelfmarks
 
+    def test_index_data_input_date(self):
+        doc = Document.objects.create()
+        # when no logentry exists, should still get the year from created attr
+        assert not LogEntry.objects.filter(
+            object_id=doc.pk,
+            content_type_id=ContentType.objects.get_for_model(doc).id,
+        ).exists()
+        assert doc.index_data()["input_year_i"] == doc.created.year
+
     def test_editions(self, document, source):
         # create multiple footnotes to test filtering and sorting
 


### PR DESCRIPTION
## In this PR

Per #887:
- Use `Document.created` as a fallback when indexing input date, if the document's initial log entry is not yet created

## Notes

- Using the query from your comment in the issue, I found 364 documents on the public site that were missing input dates in the index, so it's definitely a common issue. (I also reindexed those documents on the public site so they are all fixed now.) But I think you are right that this will resolve it for all new records, which seems to be the only case where it happens anyway.