### PR TITLE
Allow adding document directly to entity using shelfmark/PGPID search (#1461)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -108,25 +108,18 @@ class DocumentInline(admin.TabularInline):
 
     verbose_name = "Related Document"
     verbose_name_plural = "Related Documents"
-    autocomplete_fields = ["type"]
+    autocomplete_fields = ("document", "type")
     fields = (
-        "document_link",
+        "document",
         "document_description",
         "type",
         "notes",
     )
-    readonly_fields = ("document_link", "document_description")
+    readonly_fields = ("document_description",)
     formfield_overrides = {
         TextField: {"widget": Textarea(attrs={"rows": 4})},
     }
-    extra = 0
-    max_num = 0
-
-    def document_link(self, obj):
-        document_path = reverse("admin:corpus_document_change", args=[obj.document.id])
-        return format_html(f'<a href="{document_path}">{str(obj.document)}</a>')
-
-    document_link.short_description = "Document"
+    extra = 1
 
     def document_description(self, obj):
         return obj.document.description

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -29,17 +29,6 @@ from geniza.entities.models import (
 
 @pytest.mark.django_db
 class TestPersonDocumentInline:
-    def test_document_link(self):
-        goitein = Person.objects.create()
-        doc = Document.objects.create()
-        relation = PersonDocumentRelation.objects.create(person=goitein, document=doc)
-        inline = PersonDocumentInline(goitein, admin_site=admin.site)
-
-        doc_link = inline.document_link(relation)
-
-        assert str(doc.id) in doc_link
-        assert str(doc) in doc_link
-
     def test_document_description(self):
         goitein = Person.objects.create()
         test_description = "A medieval poem"


### PR DESCRIPTION
## In this PR

Per #1461:
- Simply add "document" as an autocomplete field on Person and Place Document inlines
- Also remove `document_link` as it won't be needed

## Notes

it searches on the string representation, and it seems fast enough. If there are issues we can revise.