### PR TITLE
Set q.op=AND for admin doc search (#1483)

### DIFF
--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -134,8 +134,8 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
 
     # (adapted from mep)
     # edismax alias for searching on admin document pseudo-field;
-    # set minimum match to 100% (= require all search terms)
-    admin_doc_qf = "{!edismax qf=$admin_doc_qf pf=$admin_doc_pf v=$doc_query mm=100%}"
+    # set q.op to AND (= require all search terms by default, unless OR specified)
+    admin_doc_qf = "{!edismax qf=$admin_doc_qf pf=$admin_doc_pf v=$doc_query q.op=AND}"
 
     def admin_search(self, search_term):
         # remove " + " from search string to allow searching on shelfmark joins


### PR DESCRIPTION
## In this PR

Per #1483
- Set `q.op=AND` in `admin_doc_qf` to replace `mm=100%`, so that the `AND` boolean applies by default but can be overridden by specifying `OR` in the search query text
