### PR TITLE
Index rotations and display in search results (#1070)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1198,6 +1198,8 @@ class Document(ModelIndexable, DocumentDateMixin):
                 "language_code_s": self.primary_lang_code,
                 "language_script_s": self.primary_script,
                 # use image info link without trailing info.json to easily convert back to iiif image client
+                # NOTE: if/when piffle supports initializing from full image uris, we could simplify this
+                # code to index the full image url, with rotation overrides applied
                 "iiif_images_ss": [
                     img["image"].info()[:-10]  # i.e., remove /info.json
                     for img in images

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1203,6 +1203,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                     for img in images
                 ],
                 "iiif_labels_ss": [img["label"] for img in images],
+                "iiif_rotations_is": [img["rotation"] for img in images],
                 "has_image_b": len(images) > 0,
             }
         )

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -52,6 +52,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "translation_language_direction": "translation_language_direction_s",
         "iiif_images": "iiif_images_ss",
         "iiif_labels": "iiif_labels_ss",
+        "iiif_rotations": "iiif_rotations_is",
         "has_image": "has_image_b",
         "has_digital_edition": "has_digital_edition_b",
         "has_digital_translation": "has_digital_translation_b",
@@ -188,9 +189,11 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         # convert indexed iiif image paths to IIIFImageClient objects
         images = doc.get("iiif_images", [])
         doc["iiif_images"] = [IIIFImageClient(*img.rsplit("/", 1)) for img in images]
-        # zip images and associated labels into (img, label) tuples in result doc
+        # zip images, associated labels, and rotation overrides into (img, label, rotation) tuples
+        # in result doc
         labels = doc.get("iiif_labels", [])
-        doc["iiif_images"] = list(zip(doc["iiif_images"], labels))
+        rotations = [int(rot) for rot in doc.get("iiif_rotations", [0 for _ in labels])]
+        doc["iiif_images"] = list(zip(doc["iiif_images"], labels, rotations))
 
         # for multilingual support, set doctype to matched DocumentType object
         doctype_str = doc.get("type")

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -192,6 +192,8 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         # zip images, associated labels, and rotation overrides into (img, label, rotation) tuples
         # in result doc
         labels = doc.get("iiif_labels", [])
+        # NOTE: if/when piffle supports full image urls, revise to remove any rotation related code
+        # from here and search results template, as it will be applied at index time instead
         rotations = [int(rot) for rot in doc.get("iiif_rotations", [0 for _ in labels])]
         doc["iiif_images"] = list(zip(doc["iiif_images"], labels, rotations))
 

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -141,11 +141,15 @@
 
             {% if document.iiif_images %}
                 <ul class="images">
-                    {# list of tuples of (IIIF image, label) #}
+                    {# list of tuples of (IIIF image, label, rotation) #}
                     {% for image in document.iiif_images|slice:":3" %}
-                        <li class="image-{{ forloop.counter }}">
-                            <img src="{{ image.0|iiif_image:"size:width=250" }}" loading="lazy" alt="{{ image.1 }}">
-                        </li>
+                        {% with deg=image.2|stringformat:"i" %}
+                            {% with rotation="rotation:degrees="|add:deg %}
+                                <li class="image-{{ forloop.counter }}">
+                                    <img src="{{ image.0|iiif_image:"size:width=250"|iiif_image:rotation }}" loading="lazy" alt="{{ image.1 }}">
+                                </li>
+                            {% endwith %}
+                        {% endwith %}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1060,7 +1060,9 @@ class TestDocument:
         }
         # add mock images
         img1 = Mock()
+        img1.info.return_value = "http://example.co/iiif/ts-1/00001/info.json"
         img2 = Mock()
+        img2.info.return_value = "http://example.co/iiif/ts-1/00002/info.json"
         # Mock Fragment.iiif_images() to return those two images
         with patch.object(
             Fragment,

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1049,7 +1049,28 @@ class TestDocument:
                 "http://example.co/iiif/ts-1/00002",
             ]
             assert index_data["iiif_labels_ss"] == ["label1", "label2"]
+            assert index_data["iiif_rotations_is"] == [0, 0]
             assert index_data["has_image_b"] is True
+
+    def test_index_data_rotations(self, document):
+        # add image rotation
+        document.image_overrides = {
+            "canvas1": {"rotation": 90},
+            "canvas2": {"rotation": 180},
+        }
+        # add mock images
+        img1 = Mock()
+        img2 = Mock()
+        # Mock Fragment.iiif_images() to return those two images
+        with patch.object(
+            Fragment,
+            "iiif_images",
+            # match canvas1 and canvas2 names from image overrides
+            return_value=([img1, img2], ["label1", "label2"], ["canvas1", "canvas2"]),
+        ):
+            index_data = document.index_data()
+            # index data should pick up rotation overrides
+            assert index_data["iiif_rotations_is"] == [90, 180]
 
     def test_index_data_footnotes(
         self, document, source, twoauthor_source, multiauthor_untitledsource


### PR DESCRIPTION
## In this PR

Realized while writing testing notes for #1070 that rotated images did not appear in search results. So I made the following changes:
- Index rotation overrides as `*_is`, and zip into tuples in `get_result_document`, following the same pattern as labels
- Fallback to list of 0s (the same length of the list of images)
- Display rotated images in results using same method from ITT viewer

The nice thing about the fallback is that we don't have to reindex anything manually, as we know rotation is always 0 unless the override has been set, at which point the document will reindex on save.