### PR TITLE
Improve boosts for description exact matches (#1335)

### DIFF
--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -715,10 +715,10 @@
 
       <!-- keyword search field for geniza prototype -->
       <str name="keyword_qf">
-        shelfmark_bigram^200
-        shelfmark_s^150
+        shelfmark_s^200
+        content_nostem^190
+        shelfmark_bigram^180
         shelfmark_textnum^140
-        content_nostem^130
         description_en_bigram^50
         pgpid_i
         type_s


### PR DESCRIPTION
## In this PR

Per #1335:
- Boost exact matches in description (`content_nostem`) above partial matches in shelfmark
- Boost exact matches in shelfmark (`shelfmark_s`) above both