### PR TITLE
Allow merge into primaries with no description (#1506)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1365,7 +1365,7 @@ class Document(ModelIndexable, DocumentDateMixin):
         # handle translated description: create a dict of descriptions
         # per supported language to aggregate and merge
         description_chunks = {
-            lang_code: [getattr(self, "description_%s" % lang_code)]
+            lang_code: [getattr(self, "description_%s" % lang_code) or ""]
             for lang_code in language_codes
         }
         language_notes = [self.language_note] if self.language_note else []
@@ -1430,7 +1430,7 @@ class Document(ModelIndexable, DocumentDateMixin):
             for lang_code in language_codes:
                 description_field = "description_%s" % lang_code
                 doc_description = getattr(doc, description_field)
-                current_description = getattr(self, description_field)
+                current_description = getattr(self, description_field) or ""
                 if doc_description and doc_description not in current_description:
                     description_chunks[lang_code].append(
                         "Description from PGPID %s:\n%s" % (doc.id, doc_description)

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1548,6 +1548,16 @@ def test_document_merge_with(document, join):
     assert join.needs_review.startswith("SCRIPTMERGE")
 
 
+def test_document_merge_with_no_description(document):
+    doc_id = document.id
+    # create a document with no description
+    doc_2 = Document.objects.create()
+    doc_2.merge_with([document], "test")
+    # should not error; should combine descriptions
+    assert "Description from PGPID %s:" % doc_id in doc_2.description
+    assert document.description in doc_2.description
+
+
 def test_document_merge_with_notes(document, join):
     join.notes = "original doc"
     join.needs_review = "cleanup needed"

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -175,7 +175,7 @@ class Person(models.Model):
         # handle translated description: create a dict of descriptions
         # per supported language to aggregate and merge
         description_chunks = {
-            lang_code: [getattr(self, "description_%s" % lang_code)]
+            lang_code: [getattr(self, "description_%s" % lang_code) or ""]
             for lang_code in language_codes
         }
 
@@ -216,7 +216,7 @@ class Person(models.Model):
             for lang_code in language_codes:
                 description_field = "description_%s" % lang_code
                 person_description = getattr(person, description_field)
-                current_description = getattr(self, description_field)
+                current_description = getattr(self, description_field) or ""
                 if person_description and person_description not in current_description:
                     description_chunks[lang_code].append(
                         "Description from merged entry:\n%s" % (person_description,)

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -84,6 +84,23 @@ class TestPerson:
             object_id=person.pk, change_message__contains=f"merged with {p2_str}"
         ).exists()
 
+    def test_merge_with_no_description(self):
+        # create two people
+        person = Person.objects.create(
+            gender=Person.UNKNOWN,
+        )
+        role = PersonRole.objects.create(name="example")
+        person_2 = Person.objects.create(
+            description_en="testing description",
+            gender=Person.FEMALE,
+            role=role,
+            has_page=True,
+        )
+        person.merge_with([person_2])
+        # should not error; should combine descriptions
+        assert "Description from merged entry:" in person.description
+        assert "testing description" in person.description
+
     def test_merge_with_conflicts(self):
         # should raise ValidationError on conflicting gender
         person = Person.objects.create(gender=Person.MALE)


### PR DESCRIPTION
## In this PR

Per #1506:
- Allow a document or person to be merged into a document or person that does not have a description