### PR TITLE
Always index English doctype label when possible (#1507)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1158,7 +1158,13 @@ class Document(ModelIndexable, DocumentDateMixin):
                 "pgpid_i": self.id,
                 # type gets matched back to DocumentType object in get_result_document, for i18n;
                 # should always be indexed in English
-                "type_s": str(self.doctype) if self.doctype else "Unknown type",
+                "type_s": (
+                    self.doctype.display_label_en
+                    or self.doctype.name_en
+                    or str(self.doctype)
+                )
+                if self.doctype
+                else "Unknown type",
                 # use english description for now
                 "description_en_bigram": strip_tags(self.description_en),
                 "notes_t": self.notes or None,

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1170,6 +1170,21 @@ class TestDocument:
         ).exists()
         assert doc.index_data()["input_year_i"] == doc.created.year
 
+    def test_index_data_locale(self):
+        # create a doctype with a label in hebrew and english
+        dt = DocumentType.objects.create(
+            display_label_he="wrong", display_label_en="right"
+        )
+        # in english, str should return english label
+        activate("en")
+        assert str(dt) == "right"
+        # in hebrew, str should return hebrew label
+        activate("he")
+        assert str(dt) == "wrong"
+        # but index data should always be in english
+        doc = Document.objects.create(doctype=dt)
+        assert doc.index_data()["type_s"] == "right"
+
     def test_editions(self, document, source):
         # create multiple footnotes to test filtering and sorting
 


### PR DESCRIPTION
## In this PR

Per #1507:
- Ensure the doctype indexed is always English, regardless of the currently active locale