### PR TITLE
Allow deprecated edismax nested search for shelfmarks (#1476)

### DIFF
--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -27,6 +27,15 @@ class TestDocumentSolrQuerySet:
                 doc_query="CUL Or.1080 3.41 T-S 13J16.20 T-S 13J8.14"
             )
 
+    def test_admin_search_nested_edismax(self):
+        dqs = DocumentSolrQuerySet()
+        with patch.object(dqs, "search") as mocksearch:
+            # scoped search with edismax subquery should use uf="* _query_" workaround
+            dqs.admin_search('shelfmark:"T-S 13J8.14"')
+            mocksearch.return_value.raw_query_parameters.assert_called_with(
+                doc_query='%s"T-S 13J8.14"' % dqs.shelfmark_qf, uf="* _query_"
+            )
+
     def test_keyword_search_shelfmark(self):
         dqs = DocumentSolrQuerySet()
         with patch.object(dqs, "search") as mocksearch:
@@ -49,7 +58,8 @@ class TestDocumentSolrQuerySet:
         with patch.object(dqs, "search") as mocksearch:
             dqs.keyword_search("shelfmark:ena")
             mocksearch.return_value.raw_query_parameters.assert_called_with(
-                keyword_query="%sena" % dqs.shelfmark_qf
+                keyword_query="%sena" % dqs.shelfmark_qf,
+                uf="* _query_",  # solr 7.2 workaround for nested edismax
             )
 
     def test_keyword_search_exact_match(self):


### PR DESCRIPTION
## In this PR

Per #1476:
- Add a new `uf` param to searches that contain nested `type=edismax` searches, as [since solr 7.2](https://solr.apache.org/guide/7_2/solr-upgrade-notes.html#solr-7-2) they will not work without it. (Shelfmark scoped search happened to be the one place where a `type=edismax` exists inside another `type=edismax` so far!)