### PR TITLE
Use newline separator for highlights (#1487)

### DIFF
--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -186,6 +186,8 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
                         method="unified",
                         fragsize=150,  # try including more context
                         requireFieldMatch=True,
+                        # use newline as passage boundary
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
                     )
                     .highlight(
                         "translation",


### PR DESCRIPTION
## In this PR

Per #1487:
- Fix an issue where the highlighter (with `bs.type` set to `SENTENCE`) would include the entire transcription as context
  - turns out setting it to `LINE` doesn't work either with lists!