### PR TITLE
Allow source autocomplete on combined author and title (#1275)

### DIFF
--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1844,7 +1844,6 @@ class TestSourceAutocompleteView:
         # should filter on title, case insensitive
         source_autocomplete_view.request.GET = {"q": "programming"}
         qs = source_autocomplete_view.get_queryset()
-        print(qs.all())
         assert qs.count() == 1
         assert qs.first().pk == twoauthor_source.pk
 

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1844,6 +1844,21 @@ class TestSourceAutocompleteView:
         # should filter on title, case insensitive
         source_autocomplete_view.request.GET = {"q": "programming"}
         qs = source_autocomplete_view.get_queryset()
+        print(qs.all())
+        assert qs.count() == 1
+        assert qs.first().pk == twoauthor_source.pk
+
+        # should filter on combination of title and author, case insensitive
+        source_autocomplete_view.request.GET = {"q": "ritchie programming"}
+        qs = source_autocomplete_view.get_queryset()
+        assert qs.count() == 1
+        assert qs.first().pk == twoauthor_source.pk
+
+        # should filter on volume
+        twoauthor_source.volume = "XXII"
+        twoauthor_source.save()
+        source_autocomplete_view.request.GET = {"q": "ritchie programming xxii"}
+        qs = source_autocomplete_view.get_queryset()
         assert qs.count() == 1
         assert qs.first().pk == twoauthor_source.pk
 


### PR DESCRIPTION
## In this PR

Per #1275:
- When choosing a source, search based on a combination of all authors, title, and volume