### PR TITLE
Allow searching for words with brackets and other sigla in transcriptions (#1286)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,10 @@
 # Deploy Notes
 
+## 4.17
+
+-   Solr configuration has changed. Ensure Solr configset has been updated
+    and then reindex all content: `python manage.py index`
+
 ## 4.16
 
 -   Import Bodleian catalog numbers from a spreadsheet using the script

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1219,6 +1219,8 @@ class Document(ModelIndexable, DocumentDateMixin):
         # collect transcription and translation texts for indexing
         transcription_texts = []
         translation_texts = []
+        # collect cleaned transcriptions (no html, no sigla) for partial matching
+        clean_transcription_texts = []
         # keep track of translation language for RTL/LTR display
         translation_langcode = ""
         translation_langdir = "ltr"
@@ -1232,6 +1234,9 @@ class Document(ModelIndexable, DocumentDateMixin):
                 content = fn.content_html_str
                 if content:
                     transcription_texts.append(Footnote.explicit_line_numbers(content))
+                    clean_transcription_texts.append(
+                        Footnote.clean_text(fn.content_text)
+                    )
             elif Footnote.DIGITAL_TRANSLATION in fn.doc_relation:
                 content = fn.content_html_str
                 if content:
@@ -1269,6 +1274,7 @@ class Document(ModelIndexable, DocumentDateMixin):
                 "scholarship_t": [fn.display() for fn in footnotes],
                 # transcription content as html
                 "text_transcription": transcription_texts,
+                "clean_transcription": clean_transcription_texts,
                 "translation_language_code_s": translation_langcode,
                 "translation_language_direction_s": translation_langdir,
                 # translation content as html

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1086,7 +1086,7 @@ class TestDocument:
         Annotation.objects.create(
             footnote=edition,
             content={
-                "body": [{"value": "transcription lines"}],
+                "body": [{"value": "transcrip[ti]on lines"}],
             },
         )
         # digital translation footnote
@@ -1118,7 +1118,8 @@ class TestDocument:
         assert index_data["num_translations_i"] == 2
         assert index_data["has_digital_translation_b"] == True
         assert index_data["scholarship_count_i"] == 3  # unique sources
-        assert index_data["text_transcription"] == ["transcription lines"]
+        assert index_data["text_transcription"] == ["transcrip[ti]on lines"]
+        assert index_data["clean_transcription"] == ["transcription lines"]
         assert index_data["text_translation"] == ["translation lines"]
         assert index_data["translation_language_code_s"] == "en"
         assert index_data["translation_language_direction_s"] == "ltr"

--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -164,8 +164,10 @@ class TestDocumentSolrQuerySet:
 
     def test_search_term_cleanup__arabic_to_ja(self):
         dqs = DocumentSolrQuerySet()
-        # confirm arabic to judaeo-arabic runs here
-        dqs._search_term_cleanup("دينار") == "(دينار|דיהאר)"
+        # confirm arabic to judaeo-arabic runs here (with boost)
+        assert dqs._search_term_cleanup("دينار") == "(دينار^2.0|דינאר)"
+        # confirm arabic to judaeo-arabic does not run here
+        assert dqs._search_term_cleanup('"دي[نا]ر"') == 'content_nostem:"دي[نا]ر"'
 
     def test_search_term_cleanup__exact_match_regex(self):
         dqs = DocumentSolrQuerySet()

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -659,6 +659,9 @@ class Footnote(TrackChangesModel):
         Strip transcription sigla and unwanted Arabic connectors from passed text, for indexing,
         so that users can search for words otherwise interrupted by transcription meta-typography
         """
+        # NOTE: It may be worth moving this to solr PatternReplaceCharFilterFactory to avoid near-
+        # duplicate fields; revisit during future work on indexing transcriptions and translations
+
         cleaned = text
 
         # the following sigla are used to indicate various kinds of additions or substitutions:

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -355,6 +355,31 @@ class TestFootnote:
         assert edition.content_text == None
         assert edition.content_text != "None"
 
+    def test_clean_text(self):
+        # should remove instances of basic transcription sigla
+        assert (
+            Footnote.clean_text("פי 〚מ〛תל //דלך// [א]לל[ה] תע/א\לי[ . . . ]")
+            == "פי מתל דלך אללה תעאלי"
+        )
+
+        # should remove instances of the tatweel Arabic connector when beside a siglum
+        with_tatweel = "فوزن العـ[ـبد] شهد"
+        assert Footnote.clean_text(with_tatweel) == "فوزن العبد شهد"
+        # should have removed: 2 bracket characters, 2 connector characters
+        assert len(Footnote.clean_text(with_tatweel)) == len(with_tatweel) - 4
+
+        # but should not remove tatweel when inside a word normally
+        normal_word_tatweel = "الحمــــــد"
+        assert Footnote.clean_text(normal_word_tatweel) == normal_word_tatweel
+
+        # should remove superfluous characters surrounded by {}
+        assert Footnote.clean_text("ויב{י}עו") == "ויבעו"
+
+        # should do the transformation "A | B" --> "A B AB"
+        assert Footnote.clean_text("להא | בגמיע") == "להא בגמיע להאבגמיע"
+        # and remove | otherwise
+        assert Footnote.clean_text("ולא|ואן") == "ולאואן"
+
     def test_explicit_line_numbers(self, document, source):
         # should parse html to include line numbers in li "value" attribute
         digital_edition = Footnote.objects.create(

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -104,14 +104,14 @@
     <fieldType name="transcription_text" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <charFilter class="solr.HTMLStripCharFilterFactory"/>
-      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       <filter class="solr.ICUFoldingFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
       <filter class="solr.NGramFilterFactory" minGramSize="2" maxGramSize="20" />
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
     <analyzer type="query">
-      <tokenizer class="solr.StandardTokenizerFactory"/>
+      <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       <filter class="solr.ICUFoldingFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
       <filter class="solr.SynonymGraphFilterFactory" expand="true" ignoreCase="true" synonyms="synonyms.txt"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -734,6 +734,7 @@
         scholarship_t
         old_pgpids_is
         text_transcription^30
+        clean_transcription^30
         text_translation^30
         document_date_t
       </str>
@@ -748,6 +749,7 @@
         tags_t
         scholarship_t^80
         text_transcription^2500
+        clean_transcription^2500
         text_translation^2500
         document_date_t^550
       </str>
@@ -768,6 +770,7 @@
         old_pgpids_is
         scholarship_t
         text_transcription
+        clean_transcription
         text_translation
         fragment_old_shelfmark_ss
         old_shelfmark_t
@@ -785,6 +788,7 @@
         needs_review_t
         scholarship_t
         text_transcription
+        clean_transcription
         text_translation
         old_shelfmark_t
         old_shelfmark_textnum


### PR DESCRIPTION
## In this PR

Per #1286:
- Allow searching for exact matches on words with brackets and other [transcription sigla](https://docs.google.com/document/d/1pyFajrGRYTzRsb2yFjfX0XmNqpz1kUO9mhlISGwfpxk/edit) inside them using double quotes (e.g. `"wo[r]d"` should match a transcription with `wo[r]d` in it verbatim)
  - Use whitespace tokenizer instead of standard tokenizer in transcription field to prevent sigla from breaking up words
  - Exclude double quoted exact searches from arabic-JA conversion
- Allow searches for words without sigla to match instances of the word with sigla inside, when not using double quotes (e.g. `word` should also match a transcription with `wo[r]d` in it)
  - Use a transcription cleaning method to index such words