### PR TITLE
Migrate regex from python to solr (#1286)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1219,8 +1219,6 @@ class Document(ModelIndexable, DocumentDateMixin):
         # collect transcription and translation texts for indexing
         transcription_texts = []
         translation_texts = []
-        # collect cleaned transcriptions (no html, no sigla) for partial matching
-        clean_transcription_texts = []
         # keep track of translation language for RTL/LTR display
         translation_langcode = ""
         translation_langdir = "ltr"
@@ -1234,9 +1232,6 @@ class Document(ModelIndexable, DocumentDateMixin):
                 content = fn.content_html_str
                 if content:
                     transcription_texts.append(Footnote.explicit_line_numbers(content))
-                    clean_transcription_texts.append(
-                        Footnote.clean_text(fn.content_text)
-                    )
             elif Footnote.DIGITAL_TRANSLATION in fn.doc_relation:
                 content = fn.content_html_str
                 if content:
@@ -1274,7 +1269,6 @@ class Document(ModelIndexable, DocumentDateMixin):
                 "scholarship_t": [fn.display() for fn in footnotes],
                 # transcription content as html
                 "text_transcription": transcription_texts,
-                "clean_transcription": clean_transcription_texts,
                 "translation_language_code_s": translation_langcode,
                 "translation_language_direction_s": translation_langdir,
                 # translation content as html

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1119,7 +1119,6 @@ class TestDocument:
         assert index_data["has_digital_translation_b"] == True
         assert index_data["scholarship_count_i"] == 3  # unique sources
         assert index_data["text_transcription"] == ["transcrip[ti]on lines"]
-        assert index_data["clean_transcription"] == ["transcription lines"]
         assert index_data["text_translation"] == ["translation lines"]
         assert index_data["translation_language_code_s"] == "en"
         assert index_data["translation_language_direction_s"] == "ltr"

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -653,49 +653,6 @@ class Footnote(TrackChangesModel):
         if self.content_html_str:
             return BeautifulSoup(self.content_html_str, features="lxml").get_text()
 
-    @staticmethod
-    def clean_text(text):
-        """
-        Strip transcription sigla and unwanted Arabic connectors from passed text, for indexing,
-        so that users can search for words otherwise interrupted by transcription meta-typography
-        """
-        # NOTE: It may be worth moving this to solr PatternReplaceCharFilterFactory to avoid near-
-        # duplicate fields; revisit during future work on indexing transcriptions and translations
-
-        cleaned = text
-
-        # the following sigla are used to indicate various kinds of additions or substitutions:
-        # <> = erroneous omission; \/ or \\// = interlinear addition; () = expanded abbreviation;
-        # [] = restored lacuna; 〚〛 = restored deletion
-        sigla_set = r"[<>\\\/\(\)\[\]〚〛]"
-
-        # the Arabic connector tatweel/kasheeda (ـ U+0640) is sometimes used purely for
-        # typographical reasons before and after sigla in the middle of words with insertions.
-        # (it is also used as a normal part of words, but those cases should not be cleaned.)
-        tatweel = re.compile(f"\u0640{sigla_set}+\u0640")
-        # strip them for indexing
-        cleaned = tatweel.sub("", cleaned)
-        # sometimes it will appear only before or only after a siglum; cleaned separately to ensure
-        # no stray tatweel in the more common case
-        tatweel_edge = re.compile(f"({sigla_set}\u0640)|(\u0640{sigla_set})")
-        cleaned = tatweel_edge.sub("", cleaned)
-
-        # additional sigla: erroneous/superfluous characters surrounded by {}; dot with space
-        removable = re.compile("|".join([sigla_set, r"\{\S+\}", r"( \.)", r"(\. )"]))
-        # strip them for indexing
-        cleaned = removable.sub("", cleaned)
-
-        # the pipe | symbol is used to indicate the edge of a manuscript, and may be used between
-        # two words, or in the middle of a word. since there is no way to tell which one is
-        # happening without NLP, we store both in the cleaned text (i.e. "A | B" --> "A B AB")
-        pipe_space_regex = re.compile(r"(\S+) \| (\S+)")
-        cleaned = pipe_space_regex.sub(r"\1 \2 \1\2", cleaned)
-        # in some cases, transcriptions include the pipe in the middle of a word using A|B; simply
-        # remove the remaining pipes to handle this
-        cleaned = cleaned.replace("|", "")
-
-        return cleaned.strip()
-
     def iiif_annotation_content(self):
         """Return transcription content from this footnote (if any)
         as a IIIF annotation resource that can be associated with a canvas.

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -355,31 +355,6 @@ class TestFootnote:
         assert edition.content_text == None
         assert edition.content_text != "None"
 
-    def test_clean_text(self):
-        # should remove instances of basic transcription sigla
-        assert (
-            Footnote.clean_text("פי 〚מ〛תל //דלך// [א]לל[ה] תע/א\לי[ . . . ]")
-            == "פי מתל דלך אללה תעאלי"
-        )
-
-        # should remove instances of the tatweel Arabic connector when beside a siglum
-        with_tatweel = "فوزن العـ[ـبد] شهد"
-        assert Footnote.clean_text(with_tatweel) == "فوزن العبد شهد"
-        # should have removed: 2 bracket characters, 2 connector characters
-        assert len(Footnote.clean_text(with_tatweel)) == len(with_tatweel) - 4
-
-        # but should not remove tatweel when inside a word normally
-        normal_word_tatweel = "الحمــــــد"
-        assert Footnote.clean_text(normal_word_tatweel) == normal_word_tatweel
-
-        # should remove superfluous characters surrounded by {}
-        assert Footnote.clean_text("ויב{י}עו") == "ויבעו"
-
-        # should do the transformation "A | B" --> "A B AB"
-        assert Footnote.clean_text("להא | בגמיע") == "להא בגמיע להאבגמיע"
-        # and remove | otherwise
-        assert Footnote.clean_text("ולא|ואן") == "ולאואן"
-
     def test_explicit_line_numbers(self, document, source):
         # should parse html to include line numbers in li "value" attribute
         digital_edition = Footnote.objects.create(

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -104,6 +104,36 @@
     <fieldType name="transcription_text" class="solr.TextField" positionIncrementGap="100" multiValued="true">
     <analyzer type="index">
       <charFilter class="solr.HTMLStripCharFilterFactory"/>
+      <!-- Strip transcription sigla and unwanted Arabic connectors from passed text, for indexing,
+        so that users can search for words otherwise interrupted by transcription meta-typography.
+
+        the following sigla are used to indicate various kinds of additions or substitutions:
+        <> = erroneous omission; \/ or \\// = interlinear addition; () = expanded abbreviation;
+        [] = restored lacuna; 〚〛 = restored deletion
+      -->
+
+      <!-- the Arabic connector tatweel/kasheeda (ـ U+0640) is sometimes used purely for
+      typographical reasons before and after sigla in the middle of words with insertions.
+      (it is also used as a normal part of words, but those cases should not be cleaned.) -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="\u0640[\u003c\u003e\\\/\(\)\[\]〚〛]+\u0640" replacement="" />
+      <!-- sometimes connector will appear only before or only after a siglum; cleaned separately
+      to ensure no stray tatweel in the more common case -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="([\u003c\u003e\\\/\(\)\[\]〚〛]\u0640)|(\u0640[\u003c\u003e\\\/\(\)\[\]〚〛])"
+                  replacement="" />
+      <!-- additional sigla: erroneous/superfluous characters surrounded by {}; dot with space -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="([\u003c\u003e\\\/\(\)\[\]〚〛])|(\{\S+\})|( \.)|(\. )" replacement="" />
+      <!-- the pipe | symbol is used to indicate the edge of a manuscript, and may be used between
+      two words, or in the middle of a word. since there is no way to tell which one is
+      happening without NLP, we store both in the cleaned text (i.e. "A | B" -> "A B AB") -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="(\S+) \| (\S+)" replacement="$1 $2 $1$2" />
+      <!--  in some cases, transcriptions include the pipe in the middle of a word using A|B; simply
+      remove the remaining pipes to handle this -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="\|" replacement="" />
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       <filter class="solr.ICUFoldingFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>
@@ -111,6 +141,18 @@
       <filter class="solr.LowerCaseFilterFactory"/>
     </analyzer>
     <analyzer type="query">
+      <!-- use same charFilters on query, to highlight matches when query term contains sigla -->
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="\u0640[\u003c\u003e\\\/\(\)\[\]〚〛]+\u0640" replacement="" />
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="([\u003c\u003e\\\/\(\)\[\]〚〛]\u0640)|(\u0640[\u003c\u003e\\\/\(\)\[\]〚〛])"
+                  replacement="" />
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="([\u003c\u003e\\\/\(\)\[\]〚〛])|(\{\S+\})|( \.)|(\. )" replacement="" />
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="(\S+) \| (\S+)" replacement="$1 $2 $1$2" />
+      <charFilter class="solr.PatternReplaceCharFilterFactory"
+                  pattern="\|" replacement="" />
       <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       <filter class="solr.ICUFoldingFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="stopwords.txt" ignoreCase="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -734,7 +734,6 @@
         scholarship_t
         old_pgpids_is
         text_transcription^30
-        clean_transcription^30
         text_translation^30
         document_date_t
       </str>
@@ -749,7 +748,6 @@
         tags_t
         scholarship_t^80
         text_transcription^2500
-        clean_transcription^2500
         text_translation^2500
         document_date_t^550
       </str>
@@ -770,7 +768,6 @@
         old_pgpids_is
         scholarship_t
         text_transcription
-        clean_transcription
         text_translation
         fragment_old_shelfmark_ss
         old_shelfmark_t
@@ -788,7 +785,6 @@
         needs_review_t
         scholarship_t
         text_transcription
-        clean_transcription
         text_translation
         old_shelfmark_t
         old_shelfmark_textnum


### PR DESCRIPTION
As you suggested @rlskoeser, moving the regex to solr was absolutely the way to go here! Not only did it simplify the indexing code and reduce the index size, but it also fixed a bug where a search term without sigla would not be highlighted in a transcription where that term only appears _with_ sigla.