### PR TITLE
Use Django conditional response to prevent mid-air collisions (#965)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@recogito/annotorious": "^2.7.13",
         "@recogito/annotorious-openseadragon": "^2.7.17",
         "angle-input": "^0.0.1",
-        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#ba2990213d72059471752ba42af2bc552e387377",
+        "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#8a6f8ea5259c08215057f82df77310012a4dfb9b",
         "autoprefixer": "^10.3.2",
         "babel-loader": "^8.2.2",
         "core-js": "^3.16.3",
@@ -2557,8 +2557,8 @@
     },
     "node_modules/annotorious-tahqiq": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#ba2990213d72059471752ba42af2bc552e387377",
-      "integrity": "sha512-1CkJZqXZhzZWxViC4ZJrpKDWTvw4rLNUbLM4s5RbLmMv09Jc8S9Oi4Vger2borhkGuTB50d2YhJUqY/zH0Z9Yg==",
+      "resolved": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#8a6f8ea5259c08215057f82df77310012a4dfb9b",
+      "integrity": "sha512-ThptpzC8GtkhW3g66D+21pQoDTZVzo5Z/Manyu+tNggvdmInXB8Pow/i6QOhh+v0152Vtm4UHFpDE/x+f5oetA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
@@ -10912,9 +10912,9 @@
       "integrity": "sha512-jq2/ZAjbS3yoICQuAqMEVty2tJdrS6GW4wRExmqHScqno41II0C/wZ0e8fQ/hJ2xUB7CSpfEcbjC/tec57o/Hg=="
     },
     "annotorious-tahqiq": {
-      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#ba2990213d72059471752ba42af2bc552e387377",
-      "integrity": "sha512-1CkJZqXZhzZWxViC4ZJrpKDWTvw4rLNUbLM4s5RbLmMv09Jc8S9Oi4Vger2borhkGuTB50d2YhJUqY/zH0Z9Yg==",
-      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#ba2990213d72059471752ba42af2bc552e387377",
+      "version": "git+ssh://git@github.com/Princeton-CDH/annotorious-tahqiq.git#8a6f8ea5259c08215057f82df77310012a4dfb9b",
+      "integrity": "sha512-ThptpzC8GtkhW3g66D+21pQoDTZVzo5Z/Manyu+tNggvdmInXB8Pow/i6QOhh+v0152Vtm4UHFpDE/x+f5oetA==",
+      "from": "annotorious-tahqiq@github:Princeton-CDH/annotorious-tahqiq#8a6f8ea5259c08215057f82df77310012a4dfb9b",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@recogito/annotorious": "^2.7.13",
     "@recogito/annotorious-openseadragon": "^2.7.17",
     "angle-input": "^0.0.1",
-    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#ba2990213d72059471752ba42af2bc552e387377",
+    "annotorious-tahqiq": "github:Princeton-CDH/annotorious-tahqiq#8a6f8ea5259c08215057f82df77310012a4dfb9b",
     "autoprefixer": "^10.3.2",
     "babel-loader": "^8.2.2",
     "core-js": "^3.16.3",

--- a/sitemedia/js/controllers/alert_controller.js
+++ b/sitemedia/js/controllers/alert_controller.js
@@ -27,7 +27,7 @@ export default class extends Controller {
         this.element.appendChild(alert);
 
         // longer timeout for error messages for readability
-        const timeout = status === "error" ? 5000 : 3000;
+        const timeout = status === "error" ? 10000 : 3000;
 
         // remove visible class after timeout
         setTimeout(() => {

--- a/sitemedia/scss/components/_alert.scss
+++ b/sitemedia/scss/components/_alert.scss
@@ -20,8 +20,9 @@ div#alerts {
         justify-content: center;
         position: relative;
         min-width: 20rem;
-        height: 1rem;
-        padding: 1.25rem;
+        max-width: 50rem;
+        min-height: 1rem;
+        padding: 0.25rem 1rem;
         margin-bottom: 0.25rem;
         background-color: var(--background-gray);
         color: var(--on-background-light);


### PR DESCRIPTION
## In this PR

Per #965:
- Add method to compute an Annotation's ETag (md5 hash of content)
- Include ETag in `compile` method for use in annotation lists (required in order to associate a single annotation with a single ETag when retrieved via a list)
- Add conditional response for `POST`/`DELETE` using Django `@condition` in a mixin, in order to return 412 when computed ETag does not match `If-Match` header
- Update Tahqiq to version in https://github.com/Princeton-CDH/annotorious-tahqiq/pull/32
- Improve styles for alerts, and make them last longer if they are errors