### PR TITLE
Highlight nostem matches on exact searches (#1570)

### DIFF
--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -127,7 +127,6 @@ class TestDocumentSolrQuerySet:
         ):
             # should match a DocumentType by name
             result_doc = dqs.get_result_document(mock_doc)
-            print(result_doc["type"])
             assert isinstance(result_doc["type"], DocumentType)
 
         # special case for Unknown type
@@ -167,34 +166,40 @@ class TestDocumentSolrQuerySet:
         # confirm arabic to judaeo-arabic runs here (with boost)
         assert dqs._search_term_cleanup("دينار") == "(دينار^2.0|דינאר)"
         # confirm arabic to judaeo-arabic does not run here
-        assert dqs._search_term_cleanup('"دي[نا]ر"') == 'content_nostem:"دي[نا]ر"'
+        assert (
+            dqs._search_term_cleanup('"دي[نا]ر"')
+            == '(description_nostem:"دي[نا]ر" OR transcription_nostem:"دي[نا]ر")'
+        )
 
     def test_search_term_cleanup__exact_match_regex(self):
         dqs = DocumentSolrQuerySet()
-        # double quotes scoped to fields should not become scoped to content_nostem field
-        assert "content_nostem" not in dqs._search_term_cleanup('shelfmark:"T-S NS"')
-        assert "content_nostem" not in dqs._search_term_cleanup(
+        # double quotes scoped to fields should not become scoped to nostem fields
+        assert "description_nostem" not in dqs._search_term_cleanup(
+            'shelfmark:"T-S NS"'
+        )
+        assert "description_nostem" not in dqs._search_term_cleanup(
             'tag:"marriage payment" shelfmark:"T-S NS"'
         )
 
         # double quotes for fuzzy/proximity searches should also not be scoped
-        assert "content_nostem" not in dqs._search_term_cleanup('"divorced"~20')
-        assert "content_nostem" not in dqs._search_term_cleanup('"he divorced"~20')
+        assert "description_nostem" not in dqs._search_term_cleanup('"divorced"~20')
+        assert "description_nostem" not in dqs._search_term_cleanup('"he divorced"~20')
 
         # double quotes at the beginning of the query or after a space should be scoped (as well
         # as repeated as an unscoped query)
         assert (
-            dqs._search_term_cleanup('"he divorced"') == 'content_nostem:"he divorced"'
+            dqs._search_term_cleanup('"he divorced"')
+            == '(description_nostem:"he divorced" OR transcription_nostem:"he divorced")'
         )
 
-        assert 'content_nostem:"he divorced"' in dqs._search_term_cleanup(
+        assert 'description_nostem:"he divorced"' in dqs._search_term_cleanup(
             'shelfmark:"T-S NS" "he divorced"'
         )
 
         # should preserve order for e.g. boolean searches with exact matches
         assert (
             dqs._search_term_cleanup('"מרכב אלצלטאן" AND "אלמרכב אלצלטאן"')
-            == 'content_nostem:"מרכב אלצלטאן" AND content_nostem:"אלמרכב אלצלטאן"'
+            == '(description_nostem:"מרכב אלצלטאן" OR transcription_nostem:"מרכב אלצלטאן") AND (description_nostem:"אלמרכב אלצלטאן" OR transcription_nostem:"אלמרכב אלצלטאן")'
         )
 
     def test_related_to(self, document, join, fragment, empty_solr):
@@ -268,3 +273,27 @@ class TestDocumentSolrQuerySet:
             assert cleaned_highlight["doc.1"]["translation"] == [
                 clean_html("<li>bar baz")
             ]
+
+    def test_get_highlighting__exact_search(self):
+        dqs = DocumentSolrQuerySet()
+        with patch("geniza.corpus.solr_queryset.super") as mock_super:
+            mock_get_highlighting = mock_super.return_value.get_highlighting
+            test_highlight = {
+                "doc.1": {
+                    "description": ["matched"],
+                    "description_nostem": ["exactly matched"],
+                    "transcription": ["match"],
+                    "transcription_nostem": ["exact match"],
+                }
+            }
+            mock_get_highlighting.return_value = test_highlight
+            # no exact search was made; returned unchanged
+            assert dqs.get_highlighting() == test_highlight
+
+            # an exact search was made; now, the highlighting we actually use in the template
+            # ("description" and "transcription" keys) should be replaced w/ the nostem matches
+            dqs.raw_params["hl_query"] = "exact match"
+            assert dqs.get_highlighting()["doc.1"]["description"] == ["exactly matched"]
+            assert dqs.get_highlighting()["doc.1"]["transcription"][0] == clean_html(
+                "exact match"
+            )

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -171,12 +171,18 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
 
             if search_opts["q"]:
                 # NOTE: using requireFieldMatch so that field-specific search
-                # terms will NOT be usind for highlighting text matches
+                # terms will NOT be used for highlighting text matches
                 # (unless they are in the appropriate field)
                 documents = (
                     documents.keyword_search(search_opts["q"])
                     .highlight(
                         "description",
+                        snippets=3,
+                        method="unified",
+                        requireFieldMatch=True,
+                    )
+                    .highlight(
+                        "description_nostem",
                         snippets=3,
                         method="unified",
                         requireFieldMatch=True,
@@ -196,6 +202,13 @@ class DocumentSearchView(ListView, FormMixin, SolrLastModifiedMixin):
                         method="unified",
                         fragsize=150,
                         requireFieldMatch=True,
+                    )
+                    .highlight(
+                        "transcription_nostem",
+                        method="unified",
+                        fragsize=150,
+                        requireFieldMatch=False,
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
                     )
                     # highlight old shelfmark so we can show match in results
                     .highlight("old_shelfmark", requireFieldMatch=True)

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -342,9 +342,9 @@
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
   <copyField source="type_s" dest="type_t" maxChars="300" />
 
-  <!-- copy description and transcription to a nostem field for exact matches -->
-  <copyField source="description_en_bigram" dest="content_nostem" maxChars="30000" />
-  <copyField source="text_transcription" dest="content_nostem" maxChars="30000" />
+  <!-- copy description and transcription to nostem fields for exact matches -->
+  <copyField source="description_en_bigram" dest="description_nostem" maxChars="30000" />
+  <copyField source="text_transcription" dest="transcription_nostem" maxChars="30000" />
 
   <dynamicField name="*_descendent_path" type="descendent_path" indexed="true" stored="true"/>
   <dynamicField name="*_ancestor_path" type="ancestor_path" indexed="true" stored="true"/>
@@ -401,6 +401,6 @@
   <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
   <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
   <dynamicField name="*_natsort" type="natural_sort" indexed="true" stored="true" sortMissingLast="true"/>
-  <dynamicField name="*_nostem" type="text_nostem" indexed="true" stored="false" multiValued="true"/>
+  <dynamicField name="*_nostem" type="text_nostem" indexed="true" stored="true" multiValued="true"/>
 
 </schema>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -716,7 +716,8 @@
       <!-- keyword search field for geniza prototype -->
       <str name="keyword_qf">
         shelfmark_s^200
-        content_nostem^190
+        description_nostem^190
+        transcription_nostem^190
         shelfmark_bigram^180
         shelfmark_textnum^140
         description_en_bigram^50
@@ -741,7 +742,8 @@
         shelfmark_bigram^9500
         shelfmark_textnum^9500
         description_en_bigram^3500
-        content_nostem^3500
+        description_nostem^3500
+        transcription_nostem^3500
         old_shelfmark_t
         old_shelfmark_textnum
         old_shelfmark_bigram^100


### PR DESCRIPTION
## In this PR

Per #1570:
- Index and store nostem fields
- Split `content_nostem` into `description_nostem` and `transcription_nostem`
- Convert exact searches from scoped `content_nostem:` to `OR` between scoped description/transcription nostem fields
- Highlight new description/transcription nostem fields
- Replace `description` and `transcription` highlights in highlights dict with `description_nostem` and `transcription_nostem` highlights when searching for exact matches