### PR TITLE
Allow adding new events from Person form (#1512)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -1,4 +1,5 @@
 from adminsortable2.admin import SortableAdminBase, SortableInlineAdminMixin
+from dal import autocomplete
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin.models import LogEntry
@@ -19,7 +20,11 @@ from modeltranslation.admin import TabbedTranslationAdmin
 from geniza.annotations.models import Annotation
 from geniza.common.admin import custom_empty_field_list_filter
 from geniza.corpus.dates import DocumentDateMixin, standard_date_display
-from geniza.corpus.forms import DocumentPersonForm, DocumentPlaceForm
+from geniza.corpus.forms import (
+    DocumentEventWidgetWrapper,
+    DocumentPersonForm,
+    DocumentPlaceForm,
+)
 from geniza.corpus.metadata_export import AdminDocumentExporter, AdminFragmentExporter
 from geniza.corpus.models import (
     Collection,
@@ -390,6 +395,21 @@ class DocumentEventInline(admin.TabularInline):
     formfield_overrides = {
         TextField: {"widget": Textarea(attrs={"rows": "4"})},
     }
+
+    def get_formset(self, request, obj=None, **kwargs):
+        """Override the Event related field widget, so that the new Event form can be saved
+        without attaching a document in the popup."""
+        formset = super().get_formset(request, obj, **kwargs)
+        event_field = formset.form.base_fields["event"]
+        # these args/kwargs are usually populated automatically by django's related model field
+        # processing, but since we are overriding the wrapper we have to manually populate them
+        event_field.widget = DocumentEventWidgetWrapper(
+            autocomplete.ModelSelect2(),
+            rel=DocumentEventRelation._meta.get_field("event").remote_field,
+            admin_site=admin.site,
+        )
+        event_field.widget.can_change_related = True
+        return formset
 
 
 @admin.register(Document)

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -1,5 +1,6 @@
 from dal import autocomplete
 from django import forms
+from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.db.models import Count
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
@@ -444,3 +445,15 @@ class DocumentPlaceForm(forms.ModelForm):
             "place": autocomplete.ModelSelect2(url="entities:place-autocomplete"),
             "type": autocomplete.ModelSelect2(),
         }
+
+
+class DocumentEventWidgetWrapper(RelatedFieldWidgetWrapper):
+    """Override of RelatedFieldWidgetWrapper to insert custom url params into
+    'add new object' link"""
+
+    def get_context(self, name, value, attrs):
+        """Override get_context to insert an additional URL param, from_document,
+        in order to change min_num dynamically"""
+        context = super().get_context(name, value, attrs)
+        context["url_params"] += "&from_document=true"
+        return context

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -257,16 +257,6 @@ class TestPersonPersonRelationTypeChoiceIterator:
         assert (type_a.pk, type_a.name) not in choices[extended_family]
 
 
-class TestPersonEventInline:
-    def test_get_formset(self, admin_client):
-        # there should be no link to a popup to add an event from the Person admin
-        url = reverse("admin:entities_person_add")
-        response = admin_client.get(url)
-        content = str(response.content)
-        # NOTE: confirmed the following assertion fails when get_formset not overridden
-        assert "Add another event" not in content
-
-
 class TestPlaceEventInline:
     def test_get_formset(self, admin_client):
         # there should be no link to a popup to add an event from the Person admin
@@ -287,7 +277,7 @@ class TestEventDocumentInline:
         # however, when accessed via popup from the Document admin, this requirement
         # should be removed
         response = admin_client.get(
-            reverse("admin:entities_event_add"), {"_popup": "1"}
+            reverse("admin:entities_event_add"), {"from_document": "true"}
         )
         content = str(response.content)
         assert 'name="documenteventrelation_set-MIN_NUM_FORMS" value="0"' in content


### PR DESCRIPTION
## In this PR

Per https://github.com/Princeton-CDH/geniza/issues/1512#issuecomment-2043959712:
- Allow adding a new Event from a Person page via popup
- Add a new `from_document=true` URL param to the related widget wrapper "add new Event" button
- Change `EventDocumentInline.get_min_num` behavior such that `min_num` of associated Documents required for a new Event is zero _only_ when the `from_document` param is present, and not just when the `_popup` param is present (as that can now happen via popups launched from Person pages too)