### PR TITLE
Fix bug with facet counts after sorting (people list view)

### DIFF
--- a/geniza/entities/forms.py
+++ b/geniza/entities/forms.py
@@ -202,13 +202,7 @@ class PersonListForm(forms.Form):
     def filters_active(self):
         """Check if any filters are active; returns true if form fields are set"""
         if self.is_valid():
-            return bool(
-                {
-                    k: v
-                    for k, v in self.cleaned_data.items()
-                    if k not in ["sort", "sort_dir"] and bool(v)
-                }
-            )
+            return bool({k: v for k, v in self.cleaned_data.items() if bool(v)})
         return False
 
 

--- a/geniza/entities/tests/test_entities_forms.py
+++ b/geniza/entities/tests/test_entities_forms.py
@@ -80,9 +80,9 @@ class TestPersonListForm:
         assert form.filters_active() == False
         form = PersonListForm({"gender": [Person.FEMALE]})
         assert form.filters_active() == True
-        # sort should not count as a filter
-        form = PersonListForm({"sort": "gender"})
-        assert form.filters_active() == False
+        # sort SHOULD count as a filter (required for accurate facet counts after sorting)
+        form = PersonListForm({"sort": "role"})
+        assert form.filters_active() == True
 
     def test_get_sort_label(self):
         form = PersonListForm({})

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -274,7 +274,7 @@ class PersonListView(ListView, FormMixin):
             relations = literal_eval(search_opts["document_relation"])
             people = people.filter(persondocumentrelation__type__name__in=relations)
             self.applied_filter_count += len(relations)
-        if "sort" in search_opts and search_opts["sort"]:
+        if search_opts.get("sort"):
             order_by = self.sort_fields[search_opts["sort"]]
             # default is ascending; handle descending by appending a - in django order_by
             if "sort_dir" in search_opts and search_opts["sort_dir"] == "desc":


### PR DESCRIPTION
Consider filters to be active if a sort is applied, as otherwise facet counts are inaccurate.