### PR TITLE
WIP person-person relations list (#1595)

### DIFF
--- a/geniza/entities/templates/entities/person_related_people.html
+++ b/geniza/entities/templates/entities/person_related_people.html
@@ -1,0 +1,81 @@
+{% extends 'base.html' %}
+{% load i18n render_bundle_csp fullurl static %}
+
+{% block meta_title %}{{ page_title }}{% endblock meta_title %}
+{% block meta_description %}{{ page_description }}{% endblock meta_description %}
+{% block extrameta %}
+    {# use English page as canonical for search engine crawlers (no redirects) #}
+    {% language "en" %}
+        <link rel="canonical" href="{% fullurl "entities:person-people" person.slug %}" />
+    {% endlanguage %}
+    {% spaceless %}
+        {% for lang_code in PUBLIC_SITE_LANGUAGES %}
+            {% language lang_code %}
+                <link rel="alternate" hreflang="{{ lang_code }}" href="{% fullurl "entities:person-people" person.slug %}" />
+            {% endlanguage %}
+        {% endfor %}
+    {% endspaceless %}
+{% endblock extrameta %}
+
+{% block main %}
+    <!-- person details -->
+    {% include "entities/snippets/person_header.html" %}
+    {# tabs #}
+    {% include "entities/snippets/person_tabs.html" %}
+    <div class="container">
+        <table class="related-table related-people">
+            <thead>
+                <tr>
+                    <th{% if "name" in sort %} class="sorted"{% endif %}>
+                        <a href="?sort=name_{% if sort == "name_asc" %}desc{% else %}asc{% endif %}"{% if "name" in sort %} class="{{ sort }}"{% endif %}>
+                            {# Translators: table header for person name #}
+                            <span>{% translate 'Name' %}</span>
+                            <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        </a>
+                    </th>
+                    <th{% if "relation" in sort %} class="sorted"{% endif %}>
+                        <a href="?sort=relation_{% if sort == "relation_asc" %}desc{% else %}asc{% endif %}"{% if "relation" in sort %} class="{{ sort }}"{% endif %}>
+                            {# Translators: table header for relationship types between people #}
+                            <span>{% translate 'Relation' %}</span>
+                            <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        </a>
+                    </th>
+                    <th{% if "documents" in sort %} class="sorted"{% endif %}>
+                        <a href="?sort=documents_{% if sort == "documents_asc" %}desc{% else %}asc{% endif %}"{% if "documents" in sort %} class="{{ sort }}"{% endif %}>
+                            {# Translators: table header for count of shared documents between people #}
+                            <span class="sr-only">{% translate 'Number of related documents' %}</span>
+                            <svg aria-hidden="true"><use xlink:href="{% static 'img/ui/all/all/related-documents-icon.svg' %}#related-documents" /></svg>
+                            <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        </a>
+                    </th>
+                    <th class="person-notes">
+                        {# Translators: table header for notes on a relationship between people #}
+                        <span>{% translate 'Notes' %}</span>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for rel in related_people %}
+                    <tr>
+                        <td>
+                            {% if rel.to_person.get_absolute_url %}
+                                <a href="{{ rel.to_person.permalink }}" title="{{ rel.to_person }}">
+                                    {{ rel.to_person }}
+                                </a>
+                            {% else %}
+                                {{ rel.to_person }}
+                            {% endif %}
+                        </td>
+                        <td>{{ rel.type }}</td>
+                        <td>
+                            {{ rel.shared_documents }}
+                        </td>
+                        <td class="person-notes">
+                            {{ rel.notes }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock main %}

--- a/geniza/entities/templates/entities/snippets/person_tabs.html
+++ b/geniza/entities/templates/entities/snippets/person_tabs.html
@@ -2,7 +2,7 @@
 <!-- person detail page navigation -->
 {# Translators: accessibility text label for person detail view tabs navigation #}
 <nav aria-label="{% translate "tabs" %}" id="tabs">
-    {% with n_reldocs=person.documents.count n_relpeople=person.relationships.count n_relplaces=person.personplacerelation_set.count %}
+    {% with n_reldocs=person.documents.count n_relpeople=person.to_person.count n_relplaces=person.personplacerelation_set.count %}
         <ul class="tabs">
             {% url 'entities:person' slug=person.slug as person_url %}
             {% translate "Person Details" as details_text %}
@@ -16,8 +16,8 @@
 
             {# Translators: n_relpeople is number of related people #}
             {% blocktranslate asvar relpeople_text %}Related People ({{ n_relpeople }}){% endblocktranslate %}
-            {# <li>{% if n_relpeople > 0 %}<a href="{{ relpeople_url }}"{% if request.path == relpeople_url %} aria-current="page"{% endif %}>{{ relpeople_text }}</a>{% else %}<span disabled aria-disabled="true">{{ relpeople_text }}</span>{% endif %}</li> #}
-            <span disabled aria-disabled="true">{{ relpeople_text }}</span>
+            {% url 'entities:person-people' slug=person.slug as relpeople_url %}
+            <li>{% if n_relpeople > 0 %}<a href="{{ relpeople_url }}"{% if request.path == relpeople_url %} aria-current="page"{% endif %}>{{ relpeople_text }}</a>{% else %}<span disabled aria-disabled="true">{{ relpeople_text }}</span>{% endif %}</li>
 
             {# Translators: n_relplaces is number of related places #}
             {% blocktranslate asvar relplace_text %}Related Places ({{ n_relplaces }}){% endblocktranslate %}
@@ -32,7 +32,9 @@
             <option value="{{ reldoc_url }}"{% if n_reldocs == 0 %} disabled{% elif request.path == reldoc_url %} selected{% endif %}>
                 {{ reldoc_text }}
             </option>
-            <option disabled>{{ relpeople_text }}</option>
+            <option value="{{ relpeople_url }}"{% if n_relpeople == 0 %} disabled{% elif request.path == relpeople_url %} selected{% endif %}>
+                {{ relpeople_text }}
+            </option>
             <option disabled>{{ relplace_text }}</option>
         </select>
     {% endwith %}

--- a/geniza/entities/templates/entities/snippets/related_documents_table.html
+++ b/geniza/entities/templates/entities/snippets/related_documents_table.html
@@ -1,35 +1,35 @@
 {% load static i18n %}
 
 <div class="container">
-    <table class="related-documents">
+    <table class="related-table related-documents">
         <thead>
             <tr>
                 <th{% if "shelfmark" in sort %} class="sorted"{% endif %}>
                     <a href="?sort=shelfmark_{% if sort == "shelfmark_asc" %}desc{% else %}asc{% endif %}"{% if "shelfmark" in sort %} class="{{ sort }}"{% endif %}>
                         {# Translators: table header for document name (shelfmark) #}
                         <span>{% translate 'Document' %}</span>
-                        <svg role="presentation"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
                     </a>
                 </th>
                 <th{% if "doctype" in sort %} class="sorted"{% endif %}>
                     <a href="?sort=doctype_{% if sort == "doctype_asc" %}desc{% else %}asc{% endif %}"{% if "doctype" in sort %} class="{{ sort }}"{% endif %}>
                         {# Translators: table header for document type #}
                         <span>{% translate 'Type' %}</span>
-                        <svg role="presentation"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
                     </a>
                 </th>
                 <th{% if "relation" in sort %} class="sorted"{% endif %}>
                     <a href="?sort=relation_{% if sort == "relation_asc" %}desc{% else %}asc{% endif %}"{% if "relation" in sort %} class="{{ sort }}"{% endif %}>
                         {# Translators: table header for document relation (with a person or place) #}
                         <span>{% translate 'Relation' %}</span>
-                        <svg role="presentation"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
                     </a>
                 </th>
                 <th{% if "date" in sort %} class="sorted"{% endif %}>
                     <a href="?sort=date_{% if sort == "date_asc" %}desc{% else %}asc{% endif %}"{% if "date" in sort %} class="{{ sort }}"{% endif %}>
                         {# Translators: table header for document date #}
                         <span>{% translate 'Date' %}</span>
-                        <svg role="presentation"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
+                        <svg role="presentation" class="sort-icon"><use xlink:href="{% static 'img/ui/desktop/all/caret-up-down.svg' %}#caret-up-down" /></svg>
                     </a>
                 </th>
             </tr>

--- a/geniza/entities/urls.py
+++ b/geniza/entities/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
         name="person-documents",
     ),
     path(
+        "people/<slug:slug>/people/",
+        entities_views.PersonPeopleView.as_view(),
+        name="person-people",
+    ),
+    path(
         "person-autocomplete/",
         entities_views.PersonAutocompleteView.as_view(),
         name="person-autocomplete",

--- a/sitemedia/scss/pages/_related.scss
+++ b/sitemedia/scss/pages/_related.scss
@@ -12,8 +12,8 @@ section#document-list.related-documents {
     @include container.two-column;
 }
 
-main.person table.related-documents,
-main.place table.related-documents {
+main.person table.related-table,
+main.place table.related-table {
     @include typography.related-table;
     max-width: none;
     margin-top: 1.5rem;
@@ -54,13 +54,15 @@ main.place table.related-documents {
                 width: 16px;
                 height: 16px;
                 display: block;
+            }
+            svg.sort-icon {
                 color: var(--disabled-on-background-light);
                 fill: var(--disabled-on-background-light);
             }
-            &[class*="asc"] svg {
+            &[class*="asc"] svg.sort-icon {
                 color: var(--on-background);
             }
-            &[class*="desc"] svg {
+            &[class*="desc"] svg.sort-icon {
                 fill: var(--on-background);
             }
         }
@@ -160,10 +162,39 @@ main.place table.related-documents {
         }
     }
 }
+main.person table.related-people {
+    grid-template-columns: 55% 36% 1fr;
+    @include breakpoints.for-tablet-landscape-up {
+        background-color: var(--background-light);
+        grid-template-columns: 35% 33% 10% 1fr;
+    }
+    gap: 0;
+    thead {
+        display: contents;
+    }
+    tr {
+        display: contents;
+        background-color: transparent;
+        padding: 0;
+    }
+    td {
+        min-height: 3rem;
+        a {
+            font-family: fonts.$primary;
+            font-weight: normal;
+        }
+    }
+    .person-notes {
+        display: none;
+        @include breakpoints.for-tablet-landscape-up {
+            display: table-cell;
+        }
+    }
+}
 
 // RTL overrides
-html[dir="rtl"] main.person table.related-documents,
-html[dir="rtl"] main.place table.related-documents {
+html[dir="rtl"] main.person table.related-table,
+html[dir="rtl"] main.place table.related-table {
     @include breakpoints.for-tablet-landscape-up {
         td {
             padding-left: 1.5rem;


### PR DESCRIPTION
Hi @rlskoeser,

Sorry for the long-winded explanation here, but this one is a Django data modeling doozy! Take however much time you need until you have the bandwidth to take a look at it; plenty else for me to work on in the meantime.

---

I've been working on this view to show all people related to a person via `Person.relationships`, an asymmetrical, self-referential, many-to-many through field. We want a list of each of a person's relationship objects from the intermediary table so we can display the relation type and notes. Listing `person.relationships.all()` only brings up a queryset of `Person` entries, so to get the list of relationship objects I use `person.to_person.all()`.

However, `person.to_person.all()` does not in fact capture all related people. There is another set, `person.from_person.all()`, that may contain relationships to additional people, as well as some of the same people from the `to_person` set. The reasons for this are as follows:

- Sometimes relationships are entered twice, i.e. once for each person in them. For example, in the section labeled "Related people (input manually)," [Nahray b. Nissim](https://geniza.princeton.edu/admin/entities/person/14/change/) has a relationship with Elḥanan with type "maternal cousin." Then on [Elḥanan's page](https://geniza.princeton.edu/admin/entities/person/23/change/), there is another relationship entered for Nahray with type "paternal cousin". Thus, `nahray.to_person.all()` will capture just one of those two, the one entered manually from Nahray, and vice versa for `elhanan.to_person.all()`.
- However, sometimes relationships are only entered on one page. For example, Nahray b. Nissim has a relationship with Nissim b. Isḥāq with type "Parent". But [Nissim b. Isḥāq](https://geniza.princeton.edu/admin/entities/person/15/change/) doesn't have any entries input manually, so their `ishaq.to_person.all()` list is empty, failing to capture that relationship; it can only be accessed through `ishaq.from_person.all()`.

On the admin page, we get around this by displaying both lists, with a read-only list `from_person.all()` labeled "Related people (automatically populated)". When the relationships are entered twice a la Nahray-Elḥanan, that means they actually appear twice on the admin page. But we don't want that on this people list page; we only want each one once, we just want to make sure the full _set_ of related people is captured.

My current implementation ignores `from_person` and only displays the list from `to_person.all()`, i.e. input manually.

Is there a way to achieve showing both using the Django ORM? Here's what I had started to do, but it still results in duplicates. Does it seem like it's on the right track and just needs deduplication?

```py
related_people = PersonPersonRelation.objects.filter(
    Q(from_person__pk=obj.pk) | Q(to_person__pk=obj.pk)
).annotate(
    related_slug=Case(
        When(to_person__pk=obj.pk, then=("from_person__slug")),
        When(from_person__pk=obj.pk, then=("to_person__slug")),
    ),
    relation_type=Case(
        When(to_person__pk=obj.pk, then=("type__name")),
        When(from_person__pk=obj.pk, then=("type__converse_name")),
    ),
)
```

Maybe a simpler option would be some kind of solr index to achieve what I actually need with more flexibility?

Or does this in fact need to be a DB constraint that I overlooked, preventing the relations from being essentially entered twice?