### PR TITLE
Use new property names for range stats on people list

### DIFF
--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -708,8 +708,8 @@ class Person(ModelIndexable, SlugMixin, DocumentDatableMixin, PermalinkMixin):
                 {
                     "date_dr": solr_date_range,
                     "date_str_s": self.date_str,
-                    "start_date_i": (dates[0].numeric_format()),
-                    "end_date_i": (
+                    "start_dating_i": (dates[0].numeric_format()),
+                    "end_dating_i": (
                         (dates[1] if len(dates) > 1 else dates[0]).numeric_format(
                             mode="max"
                         )

--- a/geniza/entities/templates/entities/person_list.html
+++ b/geniza/entities/templates/entities/person_list.html
@@ -49,7 +49,7 @@
                     <span class="fieldname">{{ form.gender.label }}</span>
                     {% render_field form.gender data-action="search#update" %}
                 </label>
-                <label for="{{ form.date_range.auto_id }}">
+                <label for="{{ form.date_range.auto_id }}" class="date-range-label">
                     <span class="fieldname">{{ form.date_range.label }}</span>
                     {% render_field form.date_range data-action="search#update keypress->search#handleDate" %}
                 </label>

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -478,8 +478,8 @@ class TestPerson:
         assert index_data["document_relation_ss"] == [str(pdrtype)]
         assert index_data["date_dr"] == person.solr_date_range()
         assert index_data["date_str_s"] == person.date_str
-        assert index_data["start_date_i"] == PartialDate("1200").numeric_format()
-        assert index_data["end_date_i"] == PartialDate("1300").numeric_format(
+        assert index_data["start_dating_i"] == PartialDate("1200").numeric_format()
+        assert index_data["end_dating_i"] == PartialDate("1300").numeric_format(
             mode="max"
         )
 

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -400,13 +400,13 @@ class TestPersonListView:
                     "sort_dir": "desc",
                 }
                 personlist_view.get_queryset()
-                mock_order_by.assert_called_with("-end_date_i")
+                mock_order_by.assert_called_with("-end_dating_i")
                 mock_get_form.return_value.cleaned_data = {
                     "sort": "date",
                     "sort_dir": "asc",
                 }
                 personlist_view.get_queryset()
-                mock_order_by.assert_called_with("start_date_i")
+                mock_order_by.assert_called_with("start_dating_i")
 
     def test_get_context_data(self, client, person):
         with patch.object(PersonListForm, "set_choices_from_facets") as mock_setchoices:

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -484,8 +484,8 @@ class PersonListView(ListView, FormMixin, SolrDateRangeMixin):
         "documents": "documents_i",
         "people": "people_i",
         "places": "places_i",
-        "date_asc": "start_date_i",
-        "date_desc": "-end_date_i",
+        "date_asc": "start_dating_i",
+        "date_desc": "-end_dating_i",
     }
     initial = {"sort": "name", "sort_dir": "asc"}
 

--- a/sitemedia/scss/components/_peopleform.scss
+++ b/sitemedia/scss/components/_peopleform.scss
@@ -37,7 +37,7 @@ main.search {
             @include breakpoints.for-tablet-landscape-up {
                 // desktop view: grid
                 display: grid;
-                grid-template-columns: 1fr 1fr 1fr;
+                grid-template-columns: repeat(3, minmax(0, 1fr));
                 gap: 2rem;
                 padding: 1.5rem 0;
                 // desktop: in flow


### PR DESCRIPTION
Allows people range stats to populate correctly, prevents visual overflow of date range filter in panel