### PR TITLE
Handle shelfmark-only search, improve old shelfmark boost (#1469)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -198,10 +198,10 @@
             </dl>
             <dl class="additional-metadata">
                 {% with document_highlights=highlighting|dict_item:document.id %}
-                    {% if document_highlights.old_shelfmark and document_highlights.old_shelfmark.0 %}
+                    {% if document_highlights.old_shelfmark %}
                         {# Translators: label for historical/old shelfmark on document fragments #}
                         <dt>{% translate "Historical shelfmark" %}</dt>
-                        <dd>{{ document_highlights.old_shelfmark.0|striptags }}</dd>
+                        <dd>{{ document_highlights.old_shelfmark|striptags }}</dd>
                     {% endif %}
                 {% endwith %}
             </dl>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -800,6 +800,9 @@
         shelfmark_t
         shelfmark_bigram
         shelfmark_textnum
+        old_shelfmark_t
+        old_shelfmark_textnum
+        old_shelfmark_bigram
       </str>
     </lst>
 


### PR DESCRIPTION
## In this PR

- When a search term is entered that is only a shelfmark-scoped phrase in quotes, handle differently from normal searches.
  - This is needed due to the nested edismax query issues: it starts applying the other words in the shelfmark quoted phrase to the other query fields. This is fine in searches on more than just shelfmark, but produces unexpected results when searching only on shelfmark.
- Fix issue with old shelfmark appearance in search results
- Add old_shelfmark to fields to shelfmark_qf