### PR TITLE
Add language facet filter to document search (#1402)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -88,20 +88,7 @@ class FacetFieldMixin:
     def __init__(self, *args, **kwargs):
         if "required" not in kwargs:
             kwargs["required"] = False
-
-        # get custom kwarg and remove before passing to MultipleChoiceField
-        # super method, which would cause an error
-        if hasattr(self.widget, "legend"):
-            self.widget.legend = None
-            if "legend" in kwargs:
-                self.widget.legend = kwargs["legend"]
-                del kwargs["legend"]
-
         super().__init__(*args, **kwargs)
-
-        # if no custom legend, set it from label
-        if hasattr(self.widget, "legend") and not self.widget.legend:
-            self.widget.legend = self.label
 
     def valid_value(self, value):
         return True
@@ -112,6 +99,20 @@ class FacetChoiceField(FacetFieldMixin, forms.ChoiceField):
 
     # use a custom widget so we can add facet count as a data attribute
     widget = CheckboxSelectWithCount
+
+    def __init__(self, *args, **kwargs):
+        # get custom kwarg and remove before passing to MultipleChoiceField
+        # super method, which would cause an error
+        self.widget.legend = None
+        if "legend" in kwargs:
+            self.widget.legend = kwargs["legend"]
+            del kwargs["legend"]
+
+        super().__init__(*args, **kwargs)
+
+        # if no custom legend, set it from label
+        if not self.widget.legend:
+            self.widget.legend = self.label
 
     def populate_from_facets(self, facet_dict):
         """

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1300,6 +1300,8 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin):
         # keep track of translation language for RTL/LTR display
         translation_langcode = ""
         translation_langdir = "ltr"
+        # keep track of translation language names for faceted filtering
+        translation_languages = []
 
         # dict of sets of relations; keys are each source attached to any footnote on this document
         source_relations = defaultdict(set)
@@ -1322,6 +1324,11 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin):
                         lang = fn.source.languages.first()
                         translation_langcode = lang.code
                         translation_langdir = lang.direction
+                        translation_languages = [
+                            l.name
+                            for l in fn.source.languages.all()
+                            if "Unspecified" not in l.name
+                        ]
             # add any doc relations to this footnote's source's set in source_relations
             source_relations[fn.source] = source_relations[fn.source].union(
                 fn.doc_relation
@@ -1354,6 +1361,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin):
                 "text_transcription": transcription_texts,
                 # transcription content as plaintext
                 "transcription_regex": transcription_texts_plaintext,
+                "translation_languages_ss": translation_languages,
                 "translation_language_code_s": translation_langcode,
                 "translation_language_direction_s": translation_langdir,
                 # translation content as html

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -75,6 +75,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "language_script": "language_script_s",
         "languages": "language_name_ss",
         "translation": "text_translation",
+        "translation_language": "translation_languages_ss",
         "translation_language_code": "translation_language_code_s",
         "translation_language_direction": "translation_language_direction_s",
         "iiif_images": "iiif_images_ss",

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -99,6 +99,10 @@
                             {% render_field form.has_translation data-action="search#update" %}
                             {{ form.has_translation.label }}
                         </label>
+                        <label for="{{ form.translation_language.auto_id }}">
+                            <span class="sr-only">{{ form.translation_language.label }}</span>
+                            {% render_field form.translation_language data-action="search#update" %}
+                        </label>
                     </li>
                     <li>
                         <label for="{{ form.has_discussion.auto_id }}">

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1144,6 +1144,7 @@ class TestDocument:
         assert index_data["scholarship_count_i"] == 3  # unique sources
         assert index_data["text_transcription"] == ["transcrip[ti]on lines"]
         assert index_data["text_translation"] == ["translation lines"]
+        assert index_data["translation_languages_ss"] == ["English"]
         assert index_data["translation_language_code_s"] == "en"
         assert index_data["translation_language_direction_s"] == "ltr"
 

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -490,6 +490,7 @@ class TestDocumentSearchView:
                 "has_discussion": "on",
                 "has_translation": "on",
                 "has_image": "on",
+                "translation_language": "English",
             }
             qs = docsearch_view.get_queryset()
             mock_sqs = mock_queryset_cls.return_value

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -12,6 +12,8 @@ from geniza.corpus.forms import (
     DocumentMergeForm,
     DocumentSearchForm,
     FacetChoiceField,
+    FacetChoiceSelectField,
+    SelectWithCount,
     SelectWithDisabled,
     TagChoiceField,
     TagMergeForm,
@@ -45,7 +47,7 @@ class TestFacetChoiceField:
     # test adapted from ppa-django
 
     def test_init(self):
-        fcf = FacetChoiceField(legend="Document type")
+        fcf = FacetChoiceField()
         # uses RadioSelectWithCount
         fcf.widget == CheckboxSelectWithCount
         # not required by default
@@ -60,6 +62,36 @@ class TestFacetChoiceField:
         assert fcf.valid_value("foo")
 
 
+class TestFacetChoiceSelectField:
+    # similar to FacetChoiceField, but slightly different formatting and using a Select widget
+
+    def test_init(self):
+        fcf = FacetChoiceSelectField()
+        assert not fcf.empty_label
+        fcf = FacetChoiceSelectField(empty_label="Select...")
+        assert fcf.empty_label == "Select..."
+        # uses SelectWithCount
+        assert fcf.widget.__class__ == SelectWithCount
+        # not required by default
+        assert not fcf.required
+        # still can override required with a kwarg
+        fcf = FacetChoiceField(required=True)
+        assert fcf.required
+
+    def test_populate_from_facets(self):
+        fcf = FacetChoiceSelectField()
+        # should format like "label (count)"
+        fcf.populate_from_facets({"example": ("label", 1)})
+        assert fcf.choices == [
+            ("example", '<span>label</span> (<span class="count">1</span>)')
+        ]
+        # should add a choice with the empty label if provided
+        fcf = FacetChoiceSelectField(empty_label="Select...")
+        fcf.populate_from_facets({"example": ("label", 1)})
+        assert len(fcf.choices) == 2
+        assert ("", "Select...") in fcf.choices
+
+
 class TestDocumentSearchForm:
     # test adapted from ppa-django
 
@@ -68,6 +100,7 @@ class TestDocumentSearchForm:
         # has query, relevance enabled
         form = DocumentSearchForm(data)
         assert form.fields["sort"].widget.choices[0] == form.SORT_CHOICES[0]
+        assert form.fields["translation_language"].disabled == True
 
         # empty query, relevance disabled
         data["q"] = ""
@@ -84,6 +117,10 @@ class TestDocumentSearchForm:
             "relevance",
             {"label": "Relevance", "disabled": True},
         )
+
+        data = {"q": "illness", "has_translation": True}
+        form = DocumentSearchForm(data)
+        assert form.fields["translation_language"].disabled == False
 
     def test_choices_from_facets(self):
         """A facet dict should produce correct choice labels"""

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -47,7 +47,7 @@ class TestFacetChoiceField:
     # test adapted from ppa-django
 
     def test_init(self):
-        fcf = FacetChoiceField()
+        fcf = FacetChoiceField(legend="Document type")
         # uses RadioSelectWithCount
         fcf.widget == CheckboxSelectWithCount
         # not required by default

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -194,6 +194,7 @@ class DocumentSearchView(
                 "has_digital_translation",
                 "has_discussion",
             )
+            .facet_field("translation_language", sort="value")
             .facet_field("type", exclude="type", sort="value")
         )
         self.applied_filter_labels = []
@@ -272,6 +273,14 @@ class DocumentSearchView(
                 documents = documents.filter(type__in=quoted_typelist, tag="type")
                 self.applied_filter_labels += self.get_applied_filter_labels(
                     form, "doctype", typelist
+                )
+
+            # filter by translation language if specified
+            if search_opts["translation_language"]:
+                lang = search_opts["translation_language"]
+                documents = documents.filter(translation_language=lang)
+                self.applied_filter_labels += self.get_applied_filter_labels(
+                    form, "translation_language", [lang]
                 )
 
             # image filter

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -97,10 +97,17 @@ export default class extends Controller {
             if (filterValue === "on") {
                 selector = "checked";
             }
-            const appliedFilter = this.filterModalTarget.querySelector(
+            let appliedFilter = this.filterModalTarget.querySelector(
                 `label[for*="${filterName}"] input[${selector}]`
             );
-            appliedFilter.checked = false;
+            if (appliedFilter) {
+                appliedFilter.checked = false;
+            } else {
+                appliedFilter = this.filterModalTarget.querySelector(
+                    `label[for*="${filterName}"] option[${selector}]`
+                );
+                appliedFilter.selected = false;
+            }
         } else if (
             ["date_range", "docdate"].includes(filterName) &&
             (searchParams.has("date_range_0") ||

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -198,6 +198,39 @@ main.search form {
             }
         }
     }
+    // dropdown in facet filters
+    #filters label:has(select) {
+        position: relative;
+        select {
+            border-radius: 5px;
+            height: 40px;
+            width: 260px;
+            cursor: pointer;
+            background-color: var(--background-light);
+            border: 1px solid var(--background-gray);
+            font-family: fonts.$primary;
+            font-weight: 400;
+            font-size: typography.$text-size-md;
+            margin: 0.25rem 0 0.25rem 1.75rem;
+            padding: 0 1rem;
+            -webkit-appearance: none;
+            appearance: none;
+            &:disabled {
+                cursor: default;
+            }
+        }
+        &::after {
+            position: absolute;
+            @include typography.icon-button-sm;
+            content: "\f0c2"; // phosphor caret-down icon
+            top: 0.6rem;
+            right: 1rem;
+            pointer-events: none;
+        }
+        &:has(select:disabled)::after {
+            color: var(--disabled);
+        }
+    }
     // error messages
     ul#search-errors {
         margin-top: spacing.$spacing-md;
@@ -499,6 +532,17 @@ html[dir="rtl"] main.search form {
         }
         ul#id_mode {
             margin: 0 1.5rem 0 3.25rem;
+        }
+    }
+    // dropdown in facet filters
+    #filters label:has(select) {
+        select {
+            margin-right: 1.75rem;
+            margin-left: 0;
+        }
+        &::after {
+            right: auto;
+            left: 1rem;
         }
     }
 }


### PR DESCRIPTION
## In this PR

Per #1402:
- Index all languages of translation footnotes (by name) per document
- Add `Select` facet filter form field type
- Use that facet to select languages of translation
- Disable form control unless "has translation" is checked