### PR TITLE
Add citations to the bottom of document detail pages (#1668)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -243,6 +243,17 @@
 
     {# tertiary metadata #}
     <dl class="metadata-list tertiary">
+        <dt id="citation" aria-hidden="true"> {# aria hidden because redundant for screen readers #}
+            <i class="ph-quotes-fill"></i>
+            {# Translators: label for a citation for a document detail page #}
+            {% translate 'How to cite this record:' %}
+        </dt>
+        <dd>
+            {# Translators: accessibility label for a citation for a document #}
+            <span aria-label="{% translate 'Citation' %}">
+                {{ document.formatted_citation }}
+            </span>
+        </dd>
         {# Translators: label for permanent link to a document #}
         {% translate 'Link to this document:' as permalink %}
         <dt id="permalink" aria-hidden="true"> {# aria hidden because redundant for screen readers #}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -676,6 +676,36 @@ class TestDocument:
         del doc.primary_script
         assert doc.primary_script is None
 
+    def test_formatted_citation(self, document, join, fragment, multifragment):
+        # none of these fragments have collections, so they will use shelfmark without
+        # full collection names
+        assert (
+            f"{document.shelfmark}. Available online through the Princeton Geniza Project at {document.permalink}, accessed"
+            in document.formatted_citation
+        )
+        assert (
+            f"{join.shelfmark}. Available online through the Princeton Geniza Project at {join.permalink}, accessed"
+            in join.formatted_citation
+        )
+        # add some collections with names and test again
+        c = Collection.objects.create(
+            library="Cambridge University Library", name="Additional Manuscripts"
+        )
+        fragment.collection = c
+        fragment.save()
+        c2 = Collection.objects.create(
+            library="Cambridge University Library", name="Taylor-Schechter"
+        )
+        multifragment.collection = c2
+        multifragment.save()
+        # should include all the collection libraries and names
+        assert (
+            f"{c.library}, {c.name}, {document.shelfmark}."
+            in document.formatted_citation
+        )
+        assert f"{c.library}, {c.name}" in join.formatted_citation
+        assert f"+ {c2.library}, {c2.name}" in join.formatted_citation
+
     def test_all_tags(self):
         doc = Document.objects.create()
         doc.tags.add("marriage", "women")

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -147,37 +147,6 @@ class TestDocumentDetailTemplate:
         response = admin_client.get(document.get_absolute_url())
         assertContains(response, edit_url)
 
-    def test_editors(self, client, document, source, twoauthor_source):
-        # footnote with no content
-        Footnote.objects.create(
-            content_object=document, source=source, doc_relation=Footnote.EDITION
-        )
-        # No digital editions, so no editors
-        response = client.get(document.get_absolute_url())
-        assertNotContains(response, "Editor")
-
-        # footnote with one author, content
-        Footnote.objects.create(
-            content_object=document,
-            source=source,
-            doc_relation={Footnote.DIGITAL_EDITION},
-        )
-
-        # Digital edition with one author, should have one editor but not multiple
-        response = client.get(document.get_absolute_url())
-        assertContains(response, "Editor")
-        assertNotContains(response, "Editors")
-
-        # footnote with two authors, content
-        Footnote.objects.create(
-            content_object=document,
-            source=twoauthor_source,
-            doc_relation=Footnote.DIGITAL_EDITION,
-        )
-        # Should now be "editors"
-        response = client.get(document.get_absolute_url())
-        assertContains(response, "Editors")
-
     def test_shelfmarks(self, client, document, join, fragment, multifragment):
         # Ensure that shelfmarks are displayed on the page.
         response = client.get(document.get_absolute_url())

--- a/sitemedia/scss/pages/_person.scss
+++ b/sitemedia/scss/pages/_person.scss
@@ -245,6 +245,12 @@ main.document {
             @include breakpoints.for-tablet-landscape-up {
                 margin-top: 3rem;
             }
+            dd + dt {
+                margin-top: spacing.$spacing-md;
+                @include breakpoints.for-tablet-landscape-up {
+                    margin-top: spacing.$spacing-lg;
+                }
+            }
             // hanging phosphor icons before citation and permalink
             dt#citation,
             dt#permalink {
@@ -270,6 +276,7 @@ main.document {
                     a {
                         text-decoration: none;
                     }
+                    max-width: 100%;
                 }
             }
         }


### PR DESCRIPTION
## In this PR

Per #1668:
- Add citation following the given format to the bottom of document detail pages
- Remove unit tests for "editors" information in document detail metadata sections