### PR TITLE
Improve original language boost for translingual search (#1679)

### DIFF
--- a/geniza/corpus/ja.py
+++ b/geniza/corpus/ja.py
@@ -134,7 +134,7 @@ def ja_to_arabic(text):
             texts = []
             for option in v:
                 texts.append(re.sub(k, option, text))
-            text = " OR ".join(texts)
+            text = "|".join(texts)
         elif type(v) == str:
             # only one possible translation
             text = re.sub(k, v, text)
@@ -151,7 +151,7 @@ def make_translingual(text, boost, pattern, trans_func):
 
     # rewrite phrasematches using translingual function, boost, and OR query
     translingual_wordphrases = [
-        f"({wordphrase}{'^2.0' if boost else ''} OR {trans_func(wordphrase)})"
+        f"({wordphrase}{'^5.0' if boost else ''}|{trans_func(wordphrase)})"
         for wordphrase in matching_wordphrases
     ]
 
@@ -188,4 +188,4 @@ def arabic_or_ja(text, boost=True):
         texts.append(make_translingual(text, boost, re_HE_WORD_OR_PHRASE, ja_to_arabic))
     if contains_arabic(text):
         texts.append(make_translingual(text, boost, re_AR_WORD_OR_PHRASE, arabic_to_ja))
-    return f"({' OR '.join(texts)})" if len(texts) > 1 else texts[0]
+    return f"({'|'.join(texts)})" if len(texts) > 1 else texts[0]

--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -164,7 +164,7 @@ class TestDocumentSolrQuerySet:
     def test_search_term_cleanup__arabic_to_ja(self):
         dqs = DocumentSolrQuerySet()
         # confirm arabic to judaeo-arabic runs here (with boost)
-        assert dqs._search_term_cleanup("دينار") == "(دينار^2.0 OR דינאר)"
+        assert dqs._search_term_cleanup("دينار") == "(دينار^5.0|דינאר)"
         # confirm arabic to judaeo-arabic does not run here
         assert (
             dqs._search_term_cleanup('"دي[نا]ر"')
@@ -229,7 +229,7 @@ class TestDocumentSolrQuerySet:
         # when cleanup is applied, will also apply JA to Arabic conversion
         assert (
             dqs._search_term_cleanup("אלמרכב")
-            == "((אלמרכב^2.0 OR المركب OR المرخب) OR (מרכב^2.0 OR مركب OR مرخب))"
+            == "((אלמרכב^5.0|المركب|المرخب) OR (מרכב^5.0|مركب|مرخب))"
         )
 
     def test_keyword_search__quoted_shelfmark(self):

--- a/geniza/corpus/tests/test_ja.py
+++ b/geniza/corpus/tests/test_ja.py
@@ -31,10 +31,10 @@ def test_contains_hebrew():
 
 
 def test_ja_to_arabic():
-    assert ja_to_arabic("דינאר") == "دىنار OR ذىنار OR دينار OR ذينار"
-    assert ja_to_arabic("מצחף") == "مصحف OR مضحف"
-    assert ja_to_arabic("סנה") == "سنة OR سنه"
-    assert ja_to_arabic("טבאךֹ") == "طباكֹ OR ظباكֹ OR طباخֹ OR ظباخֹ"
+    assert ja_to_arabic("דינאר") == "دىنار|ذىنار|دينار|ذينار"
+    assert ja_to_arabic("מצחף") == "مصحف|مضحف"
+    assert ja_to_arabic("סנה") == "سنة|سنه"
+    assert ja_to_arabic("טבאךֹ") == "طباكֹ|ظباكֹ|طباخֹ|ظباخֹ"
     assert ja_to_arabic("מ") == "م"
     assert ja_to_arabic("") == ""
     assert ja_to_arabic("english text") == "english text"
@@ -49,61 +49,54 @@ def test_arabic_or_ja__no_arabic_or_ja():
 
 def test_arabic_or_ja__arabic():
     # single word — should return match for arabic or judaeo-arabic
-    assert arabic_or_ja("دينار", boost=False) == "(دينار OR דינאר)"
+    assert arabic_or_ja("دينار", boost=False) == "(دينار|דינאר)"
     # multiple words — should return match for arabic or judaeo-arabic
-    assert arabic_or_ja("دينار مصحف", boost=False) == "(دينار OR דינאר) (مصحف OR מצחף)"
+    assert arabic_or_ja("دينار مصحف", boost=False) == "(دينار|דינאר) (مصحف|מצחף)"
     # mixed english and arabic
-    assert arabic_or_ja("help مصحف", boost=False) == "help (مصحف OR מצחף)"
+    assert arabic_or_ja("help مصحف", boost=False) == "help (مصحف|מצחף)"
     # with boosting
-    assert arabic_or_ja("دينار") == "(دينار^2.0 OR דינאר)"
+    assert arabic_or_ja("دينار") == "(دينار^5.0|דינאר)"
 
 
 def test_arabic_or_ja__ja():
     # single word — should return match for arabic or judaeo-arabic
-    assert (
-        arabic_or_ja("דינאר", boost=False)
-        == "(דינאר OR دىنار OR ذىنار OR دينار OR ذينار)"
-    )
+    assert arabic_or_ja("דינאר", boost=False) == "(דינאר|دىنار|ذىنار|دينار|ذينار)"
     # multiple words — should return match for arabic or judaeo-arabic
     assert (
         arabic_or_ja("דינאר מצחף", boost=False)
-        == "(דינאר OR دىنار OR ذىنار OR دينار OR ذينار) (מצחף OR مصحف OR مضحف)"
+        == "(דינאר|دىنار|ذىنار|دينار|ذينار) (מצחף|مصحف|مضحف)"
     )
     # mixed english and judaeo-arabic
-    assert arabic_or_ja("help מצחף", boost=False) == "help (מצחף OR مصحف OR مضحف)"
+    assert arabic_or_ja("help מצחף", boost=False) == "help (מצחף|مصحف|مضحف)"
     # with boosting
-    assert arabic_or_ja("דינאר") == "(דינאר^2.0 OR دىنار OR ذىنار OR دينار OR ذينار)"
+    assert arabic_or_ja("דינאר") == "(דינאר^5.0|دىنار|ذىنار|دينار|ذينار)"
 
 
 def test_arabic_or_ja_exact_phrase():
     # make sure basic exact quote is working
-    assert arabic_or_ja('"تعطل شغله"', boost=False) == '("تعطل شغله" OR "תעטל שגלה")'
+    assert arabic_or_ja('"تعطل شغله"', boost=False) == '("تعطل شغله"|"תעטל שגלה")'
 
     # make sure broken quotes are ignored and arabic words are converted
-    assert arabic_or_ja('"تعطل شغله', boost=False) == '"(تعطل OR תעטל) (شغله OR שגלה)'
+    assert arabic_or_ja('"تعطل شغله', boost=False) == '"(تعطل|תעטל) (شغله|שגלה)'
 
     # to test what would happen if we had 1+ arabic phrases
     # (within quotation marks) and 1+ arabic words (not inside quotes)
     assert (
         arabic_or_ja('"تعطل شغله" etc etc شغله', boost=False)
-        == '("تعطل شغله" OR "תעטל שגלה") etc etc (شغله OR שגלה)'
+        == '("تعطل شغله"|"תעטל שגלה") etc etc (شغله|שגלה)'
     )
 
     # proximity
-    assert (
-        arabic_or_ja('"تعطل شغله"~10', boost=False) == '("تعطل شغله" OR "תעטל שגלה")~10'
-    )
+    assert arabic_or_ja('"تعطل شغله"~10', boost=False) == '("تعطل شغله"|"תעטל שגלה")~10'
 
     # with boosting
-    assert (
-        arabic_or_ja("تعطل شغله", boost=True) == "(تعطل^2.0 OR תעטל) (شغله^2.0 OR שגלה)"
-    )
-    assert arabic_or_ja('"تعطل شغله"', boost=True) == '("تعطل شغله"^2.0 OR "תעטל שגלה")'
+    assert arabic_or_ja("تعطل شغله", boost=True) == "(تعطل^5.0|תעטל) (شغله^5.0|שגלה)"
+    assert arabic_or_ja('"تعطل شغله"', boost=True) == '("تعطل شغله"^5.0|"תעטל שגלה")'
 
     # make sure query string is working
     assert (
         arabic_or_ja('transcription:("تعطل شغله") etc etc شغله', boost=False)
-        == 'transcription:(("تعطل شغله" OR "תעטל שגלה")) etc etc (شغله OR שגלה)'
+        == 'transcription:(("تعطل شغله"|"תעטל שגלה")) etc etc (شغله|שגלה)'
     )
 
     # make sure non-arabic field query is left unchanged


### PR DESCRIPTION
## In this PR
Per https://github.com/Princeton-CDH/geniza/issues/1679#issuecomment-2510415548:
- Improve original language boosting across the board
- Also revert the style back to using the pipe operator instead of `OR`