### PR TITLE
Order list of collections by textblock order (#1674)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -679,15 +679,12 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin):
     def collections(self):
         """collection objects for associated fragments"""
         # use set to ensure unique; sort for reliable output order
-        return sorted(
-            set(
-                [
-                    block.fragment.collection
-                    for block in self.textblock_set.all()
-                    if block.fragment.collection
-                ]
-            ),
-            key=lambda c: c.abbrev,
+        return set(
+            [
+                block.fragment.collection
+                for block in self.textblock_set.all().order_by("order")
+                if block.fragment.collection
+            ]
         )
 
     @property

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -593,6 +593,27 @@ class TestDocument:
         frag2.save()
         assert doc.collection == "CUL, JTS"
 
+    def test_collections(self):
+        cul = Collection.objects.create(library="Cambridge", abbrev="CUL")
+        frag = Fragment.objects.create(shelfmark="T-S 8J22.21", collection=cul)
+        aiu = Collection.objects.create(
+            library="Alliance Israélite Universelle", abbrev="AIU"
+        )
+        frag2 = Fragment.objects.create(shelfmark="AIU VII.A.23", collection=aiu)
+        frag3 = Fragment.objects.create(shelfmark="AIU VII.F.55", collection=aiu)
+        doc = Document.objects.create()
+        TextBlock.objects.create(document=doc, fragment=frag, order=1)
+        TextBlock.objects.create(document=doc, fragment=frag2, order=2)
+        TextBlock.objects.create(document=doc, fragment=frag3, order=3)
+
+        # collections should be length 2 because it's a set
+        assert len(doc.collections) == 2
+        # collections should be listed in textblock order, NOT alphabetically
+        colls = list(doc.collections)
+        assert colls[0].pk == cul.pk
+        assert colls[1].pk == aiu.pk
+        assert doc.collection == "CUL, AIU"
+
     def test_all_languages(self):
         doc = Document.objects.create()
         lang = LanguageScript.objects.create(language="Judaeo-Arabic", script="Hebrew")


### PR DESCRIPTION
## In this PR

Per #1674:
- Always order listed collections by shelfmark order (i.e. `TextBlock.order` property) rather than alphabetically