### PR TITLE
Ensure order of collection objects is correct (#1674)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -678,14 +678,18 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin):
     @property
     def collections(self):
         """collection objects for associated fragments"""
-        # use set to ensure unique; sort for reliable output order
-        return set(
-            [
+        # append to a list in order.
+        collections = []
+        # cannot cast as set and then order because we need these ordered by
+        # TextBlock.order, which cannot be retrieved from Collection objects
+        # (the objects that would populate the set)
+        for block in self.textblock_set.all().order_by("order"):
+            if (
                 block.fragment.collection
-                for block in self.textblock_set.all().order_by("order")
-                if block.fragment.collection
-            ]
-        )
+                and block.fragment.collection not in collections
+            ):
+                collections.append(block.fragment.collection)
+        return collections
 
     @property
     def collection(self):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -594,11 +594,11 @@ class TestDocument:
         assert doc.collection == "CUL, JTS"
 
     def test_collections(self):
-        cul = Collection.objects.create(library="Cambridge", abbrev="CUL")
-        frag = Fragment.objects.create(shelfmark="T-S 8J22.21", collection=cul)
         aiu = Collection.objects.create(
             library="Alliance Israélite Universelle", abbrev="AIU"
         )
+        cul = Collection.objects.create(library="Cambridge", abbrev="CUL")
+        frag = Fragment.objects.create(shelfmark="T-S 8J22.21", collection=cul)
         frag2 = Fragment.objects.create(shelfmark="AIU VII.A.23", collection=aiu)
         frag3 = Fragment.objects.create(shelfmark="AIU VII.F.55", collection=aiu)
         doc = Document.objects.create()


### PR DESCRIPTION
## In this PR

Per #1674:
- Uses list instead of set for collections, as the required order cannot be maintained with set