### PR TITLE
Translingual search: use OR; increase boost (#1679)

### DIFF
--- a/geniza/corpus/ja.py
+++ b/geniza/corpus/ja.py
@@ -134,7 +134,7 @@ def ja_to_arabic(text):
             texts = []
             for option in v:
                 texts.append(re.sub(k, option, text))
-            text = "|".join(texts)
+            text = " OR ".join(texts)
         elif type(v) == str:
             # only one possible translation
             text = re.sub(k, v, text)
@@ -151,7 +151,7 @@ def make_translingual(text, boost, pattern, trans_func):
 
     # rewrite phrasematches using translingual function, boost, and OR query
     translingual_wordphrases = [
-        f"({wordphrase}{'^5.0' if boost else ''}|{trans_func(wordphrase)})"
+        f"({wordphrase}{'^100.0' if boost else ''} OR {trans_func(wordphrase)})"
         for wordphrase in matching_wordphrases
     ]
 
@@ -188,4 +188,4 @@ def arabic_or_ja(text, boost=True):
         texts.append(make_translingual(text, boost, re_HE_WORD_OR_PHRASE, ja_to_arabic))
     if contains_arabic(text):
         texts.append(make_translingual(text, boost, re_AR_WORD_OR_PHRASE, arabic_to_ja))
-    return f"({'|'.join(texts)})" if len(texts) > 1 else texts[0]
+    return f"({' OR '.join(texts)})" if len(texts) > 1 else texts[0]

--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -164,7 +164,7 @@ class TestDocumentSolrQuerySet:
     def test_search_term_cleanup__arabic_to_ja(self):
         dqs = DocumentSolrQuerySet()
         # confirm arabic to judaeo-arabic runs here (with boost)
-        assert dqs._search_term_cleanup("دينار") == "(دينار^5.0|דינאר)"
+        assert dqs._search_term_cleanup("دينار") == "(دينار^100.0 OR דינאר)"
         # confirm arabic to judaeo-arabic does not run here
         assert (
             dqs._search_term_cleanup('"دي[نا]ر"')
@@ -229,7 +229,7 @@ class TestDocumentSolrQuerySet:
         # when cleanup is applied, will also apply JA to Arabic conversion
         assert (
             dqs._search_term_cleanup("אלמרכב")
-            == "((אלמרכב^5.0|المركب|المرخب) OR (מרכב^5.0|مركب|مرخب))"
+            == "((אלמרכב^100.0 OR المركب OR المرخب) OR (מרכב^100.0 OR مركب OR مرخب))"
         )
 
     def test_keyword_search__quoted_shelfmark(self):


### PR DESCRIPTION
## In this PR

Per #1679:
- Set back to `OR` instead of `|`. The pipe was causing results to be excluded incorrectly.
- Increase boost from 5 to 100 for original language. Otherwise, `OR` seemed to cause relevance scores to be higher at times for the transliterated language.