### PR TITLE
Add help text to person-person field to avoid relationship dupes (#1639)

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -40,9 +40,8 @@ jobs:
     name: Visual regression tests
     runs-on: ubuntu-latest
     needs: get_commit_msg # grab the output from this job for the commit message
-    # on pull request: only run if the phrase "[run percy]" (including brackets) is present in the commit message
-    # on push to develop: run if the phrase "[skip percy]" (including brackets) is NOT present in the commit message
-    if: ${{ (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip percy]')) || contains(needs.get_commit_msg.outputs.commit_message, '[run percy]') }}
+    # only run if the phrase "[run percy]" (including brackets) is present in the commit message
+    if: ${{ contains(needs.get_commit_msg.outputs.commit_message, '[run percy]') }}
     services:
       postgres:
         image: postgres:12

--- a/geniza/entities/forms.py
+++ b/geniza/entities/forms.py
@@ -66,6 +66,9 @@ class PersonPersonForm(forms.ModelForm):
             "notes": forms.Textarea(attrs={"rows": 4}),
             "to_person": autocomplete.ModelSelect2(url="entities:person-autocomplete"),
         }
+        help_texts = {
+            "to_person": "Please check auto-populated and manually-input people sections to ensure you are not entering the same relationship twice."
+        }
 
 
 class PersonPlaceForm(forms.ModelForm):


### PR DESCRIPTION
also turn off percy unless asked for specifically, since it's now saying there are changes every time we commit on a new date (due to the dated citation at the bottom of doc detail pages)