### PR TITLE
Remove delete butons from "type" fields in relation inlines (#1688)

### DIFF
--- a/geniza/common/admin.py
+++ b/geniza/common/admin.py
@@ -15,6 +15,16 @@ from geniza.common.models import UserProfile
 from geniza.corpus.views import TagMerge
 
 
+class TypedRelationInline:
+    """admin inline for a relation referencing a separate model for relationship type"""
+
+    def get_formset(self, request, obj=None, **kwargs):
+        """Override in order to remove the delete button from the type field"""
+        formset = super().get_formset(request, obj, **kwargs)
+        formset.form.base_fields["type"].widget.can_delete_related = False
+        return formset
+
+
 class UserProfileInline(admin.StackedInline):
     """admin inline for editing custom user profile information"""
 
@@ -110,7 +120,8 @@ class CustomTagAdmin(TagAdmin):
     @admin.display(description="Merge selected tags")
     def merge_tags(self, request, queryset=None):
         """Admin action to merge selected tags. This action redirects to an intermediate
-        page, which displays a form to review for confirmation and choose the primary tag before merging."""
+        page, which displays a form to review for confirmation and choose the primary tag before merging.
+        """
         # Adapted from corpus.admin.DocumentAdmin.merge_documents
 
         # NOTE: using selected ids from form and ignoring queryset

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -18,7 +18,7 @@ from django.utils.html import format_html
 from modeltranslation.admin import TabbedTranslationAdmin
 
 from geniza.annotations.models import Annotation
-from geniza.common.admin import custom_empty_field_list_filter
+from geniza.common.admin import TypedRelationInline, custom_empty_field_list_filter
 from geniza.corpus.dates import DocumentDateMixin, standard_date_display
 from geniza.corpus.forms import (
     DocumentEventWidgetWrapper,
@@ -39,7 +39,7 @@ from geniza.corpus.models import (
 from geniza.corpus.solr_queryset import DocumentSolrQuerySet
 from geniza.corpus.views import DocumentMerge
 from geniza.entities.admin import PersonInline, PlaceInline
-from geniza.entities.models import DocumentPlaceRelation, Event, PersonDocumentRelation
+from geniza.entities.models import DocumentPlaceRelation, PersonDocumentRelation
 from geniza.footnotes.admin import DocumentFootnoteInline
 from geniza.footnotes.models import Footnote
 
@@ -367,14 +367,14 @@ class DocumentDatingInline(admin.TabularInline):
     }
 
 
-class DocumentPersonInline(PersonInline):
+class DocumentPersonInline(TypedRelationInline, PersonInline):
     """Inline for people related to a document"""
 
     model = PersonDocumentRelation
     form = DocumentPersonForm
 
 
-class DocumentPlaceInline(PlaceInline):
+class DocumentPlaceInline(TypedRelationInline, PlaceInline):
     """Inline for places related to a document"""
 
     model = DocumentPlaceRelation

--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -13,6 +13,7 @@ from django.http import HttpResponseRedirect
 from django.urls import path, reverse
 from modeltranslation.admin import TabbedTranslationAdmin
 
+from geniza.common.admin import TypedRelationInline
 from geniza.corpus.dates import standard_date_display
 from geniza.corpus.models import DocumentEventRelation
 from geniza.entities.forms import (
@@ -89,6 +90,12 @@ class NameInline(GenericTabularInline):
         TextField: {"widget": Textarea(attrs={"rows": 4})},
     }
 
+    def get_formset(self, request, obj=None, **kwargs):
+        """Override in order to remove the delete button from the language field"""
+        formset = super().get_formset(request, obj, **kwargs)
+        formset.form.base_fields["language"].widget.can_delete_related = False
+        return formset
+
 
 class PersonInline(admin.TabularInline):
     """Generic inline for people related to other objects"""
@@ -147,7 +154,7 @@ class DocumentInline(admin.TabularInline):
         return standard_date_display("/".join(dating_range)) or "-"
 
 
-class PersonDocumentInline(DocumentInline):
+class PersonDocumentInline(TypedRelationInline, DocumentInline):
     """Related documents inline for the Person admin"""
 
     model = PersonDocumentRelation
@@ -161,7 +168,7 @@ class PlaceInline(admin.TabularInline):
     extra = 1
 
 
-class PersonPlaceInline(PlaceInline):
+class PersonPlaceInline(TypedRelationInline, PlaceInline):
     """Inline for places related to people"""
 
     model = PersonPlaceRelation
@@ -438,20 +445,20 @@ class DocumentPlaceRelationTypeAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     ordering = ("name",)
 
 
-class DocumentPlaceInline(DocumentInline):
+class DocumentPlaceInline(TypedRelationInline, DocumentInline):
     """Related documents inline for the Person admin"""
 
     model = DocumentPlaceRelation
 
 
-class PlacePersonInline(PersonInline):
+class PlacePersonInline(TypedRelationInline, PersonInline):
     """Inline for people related to a place"""
 
     model = PersonPlaceRelation
     form = PlacePersonForm
 
 
-class PlacePlaceInline(admin.TabularInline):
+class PlacePlaceInline(TypedRelationInline, admin.TabularInline):
     """Place-Place relationships inline for the Place admin"""
 
     model = PlacePlaceRelation


### PR DESCRIPTION
## In this PR

Per #1688:
- Create a new `TypedRelationInline` mixin for relationships that have a "type" field, with an overridden `get_formset` method to remove the "delete" button for that type field
   - This is to prevent inadvertently deleting the entire type, rather than just the relationship. The delete button does not need to be here, a type should be deleted from its own model page in the admin
- Do the same for "language" on Name, for the same reason