### PR TITLE
Fix transcription/translation alignment during editing (#1698)

### DIFF
--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -161,7 +161,7 @@ export default class extends Controller {
             } else {
                 // allow alignment in transcription edit mode (i.e. no selectedTranscriptionInput)
                 transcriptionChunks = document.querySelectorAll(
-                    ".tahqiq-body-display"
+                    ".annotate.transcription"
                 );
             }
             const selectedTranslationInput = document.querySelector(
@@ -174,7 +174,7 @@ export default class extends Controller {
             } else {
                 // allow alignment in translation edit mode (i.e. no selectedTranslationInput)
                 translationChunks = document.querySelectorAll(
-                    ".tahqiq-body-display"
+                    ".annotate.translation"
                 );
             }
 


### PR DESCRIPTION
## In this PR

Per #1698:
- Fix a bug where the transcription/translation "chunks" were being counted differently during editing, thus leading to mismatches when trying to align the two