### PR TITLE
Improve alignment behavior in editor (#1698)

### DIFF
--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -32,6 +32,11 @@ export default class extends Controller {
         }
         // on resize, retrigger alignment
         window.addEventListener("resize", this.boundResizeHandler);
+        // a bit hacky; on annotation load, short wait for elements to be created, then align
+        // (this is only used in editor environment)
+        document.addEventListener("annotations-loaded", () =>
+            setTimeout(this.boundResizeHandler, 50)
+        );
     }
 
     disconnect() {

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1468,13 +1468,13 @@
 
     &[dir="ltr"] {
         li {
-            margin-left: 1.5em;
+            margin-left: 1.6em;
             padding-left: 1em; /* shift to make space for line numbers */
         }
         p {
             // match alignment of list items
             margin-left: 1em;
-            padding-left: 1.5em;
+            padding-left: 1.6em;
         }
         li > p {
             // if inside a list item, don't pad <p>


### PR DESCRIPTION
## In this PR

Per #1698:
- ensure re-alignment on annotation load in the editor
- a small css tweak for double digit ltr line numbers