### PR TITLE
Add keyword search on people's names (#1711)

### DIFF
--- a/geniza/entities/forms.py
+++ b/geniza/entities/forms.py
@@ -117,6 +117,19 @@ class PlacePlaceForm(forms.ModelForm):
 
 
 class PersonListForm(RangeForm):
+    q = forms.CharField(
+        label="Keyword or Phrase",
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                # Translators: placeholder for people keyword search input
+                "placeholder": _("Search for people by name"),
+                # Translators: accessible label for people keyword search input
+                "aria-label": _("word or phrase"),
+                "type": "search",
+            }
+        ),
+    )
     gender = FacetChoiceField(label=_("Gender"))
     has_page = BooleanFacetField(label=_("Detail page available"))
     social_role = FacetChoiceField(label=_("Social role"))
@@ -125,6 +138,8 @@ class PersonListForm(RangeForm):
     date_range = RangeField(label=_("Dates"), required=False, widget=YearRangeWidget())
 
     SORT_CHOICES = [
+        # Translators: label for sort by relevance
+        ("relevance", _("Relevance")),
         # Translators: label for sort by name
         ("name", _("Name")),
         # Translators: label for sort by person activity dates

--- a/geniza/entities/templates/entities/person_list.html
+++ b/geniza/entities/templates/entities/person_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static i18n humanize widget_tweaks %}
+{% load static i18n humanize corpus_extras widget_tweaks %}
 
 {% block meta_title %}{{ page_title }}{% endblock meta_title %}
 {% block meta_description %}{{ page_description }}{% endblock meta_description %}
@@ -8,6 +8,13 @@
     <form data-controller="search" data-turbo-frame="main" data-turbo-action="advance" data-page="person">
         <div class="topheader-row">
             <h1>{{ page_title }}</h1>
+            <fieldset id="query">
+                {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateRadioSort change->search#update" %}
+
+                {# Translators: Search submit button #}
+                {% translate 'Submit search' as search_label %}
+                <button type="submit" aria-label="{{ search_label }}" />
+            </fieldset>
             <label id="people-view-switcher" for="switcher">
                 <input id="switcher" type="checkbox" data-search-target="peopleMode" data-action="click->search#togglePeopleViewMode" />
                 {# Translators: label for people browse page list view #}
@@ -99,7 +106,7 @@
                         <summary>
                             {{ form.get_sort_label|default:"Name" }}
                         </summary>
-                        <div id="sort-options">
+                        <div id="sort-options" data-search-target="radioSort" >
                             {% render_field form.sort data-action="search#update" %}
                             {% render_field form.sort_dir data-action="search#update" %}
                         </div>
@@ -111,6 +118,8 @@
                 <thead>
                     {# Translators: Person "name" column header on the browse page #}
                     <th>{% translate "Name" %}</th>
+                    {# Translators: Person "other names" column header on the browse page #}
+                    {% if highlighting %}<th>{% translate "Other names" %}</th>{% endif %}
                     {# Translators: Person "gender" column header on the browse page #}
                     <th>{% translate "Gender" %}</th>
                     {# Translators: Person "dates of activity" column header on the browse page #}
@@ -142,6 +151,20 @@
                                     <span>{{ person.name }}</span>
                                 {% endif %}
                             </td>
+                            {% with person_highlights=highlighting|dict_item:person.id %}
+                                {% if highlighting %}
+                                    {% spaceless %}
+                                        <td class="other-names">
+                                            {% if person_highlights.other_names %}
+                                                <span class="aka">{% translate "Also known as: " %}</span>
+                                                {% for match in person_highlights.other_names %}
+                                                    <span class="name">{{ match|safe }}</span>{% if not forloop.last %}, {% endif %}
+                                                {% endfor %}
+                                            {% endif %}
+                                        </td>
+                                    {% endspaceless %}
+                                {% endif %}
+                            {% endwith %}
                             <td class="gender">{{ person.gender }}</td>
                             <td class="dates">{{ person.date_str }}</td>
                             <td class="role">{{ person.role }}</td>

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -421,7 +421,7 @@ class TestPersonListView:
                 mock_order_by.assert_called_with("start_dating_i")
 
     def test_get_queryset__keyword_query(
-        self, person, person_diacritic, person_multiname
+        self, person, person_diacritic, person_multiname, empty_solr
     ):
         SolrClient().update.index(
             [

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -420,6 +420,47 @@ class TestPersonListView:
                 personlist_view.get_queryset()
                 mock_order_by.assert_called_with("start_dating_i")
 
+    def test_get_queryset__keyword_query(
+        self, person, person_diacritic, person_multiname
+    ):
+        SolrClient().update.index(
+            [
+                person.index_data(),
+                person_diacritic.index_data(),
+                person_multiname.index_data(),
+            ],
+            commit=True,
+        )
+        personlist_view = PersonListView()
+        with patch.object(personlist_view, "get_form") as mock_get_form:
+            mock_get_form.return_value.cleaned_data = {"q": str(person)}
+            qs = personlist_view.get_queryset()
+            # should return the person
+            assert qs.count() == 1
+            resulting_ids = [result["id"] for result in qs]
+            assert f"person.{person.id}" in resulting_ids
+
+            Name.objects.create(name=str(person), content_object=person_multiname)
+            SolrClient().update.index([person_multiname.index_data()], commit=True)
+            mock_get_form.return_value.cleaned_data = {
+                "q": str(person),
+                "sort": "relevance",
+                "sort_dir": "desc",
+            }
+            qs = personlist_view.get_queryset()
+            # should return both people
+            assert qs.count() == 2
+            resulting_ids = [result["id"] for result in qs]
+            assert f"person.{person.id}" in resulting_ids
+            assert f"person.{person_multiname.id}" in resulting_ids
+            # primary name should be prioritized above other names in relevance
+            assert qs[0]["id"] == f"person.{person.id}"
+            assert qs[0]["score"] > qs[1]["score"]
+            # other names should be highlighted
+            highlights = qs.get_highlighting()
+            assert f"person.{person_multiname.id}" in highlights
+            assert "other_names" in highlights[f"person.{person_multiname.id}"]
+
     def test_get_context_data(self, client, person):
         with patch.object(PersonListForm, "set_choices_from_facets") as mock_setchoices:
             response = client.get(reverse("entities:person-list"))

--- a/sitemedia/scss/components/_peopleform.scss
+++ b/sitemedia/scss/components/_peopleform.scss
@@ -250,6 +250,7 @@ main.search {
                     padding: 1rem;
                     background-color: var(--background);
                     box-shadow: 0px 1px 8px 0px var(--on-background-25);
+                    z-index: 9;
                     ul {
                         display: flex;
                         flex-flow: column;
@@ -267,6 +268,9 @@ main.search {
                                 height: 1rem;
                                 margin: 0 0.5rem 0.2rem 0;
                                 overflow: visible;
+                            }
+                            li:has(:disabled) label {
+                                color: var(--disabled);
                             }
                         }
                         // last UL = ascending/descending only

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -14,8 +14,6 @@
 main.search form {
     // search query box and button
     fieldset#query {
-        display: flex;
-        align-items: center;
         margin-bottom: 1.5rem;
         // search mode switch label (hidden on mobile)
         span.fieldname {
@@ -153,51 +151,6 @@ main.search form {
                 }
             }
         }
-        // search box
-        input[type="search"] {
-            flex-basis: 100%;
-            border: none;
-            border-radius: 5px;
-            border-top-right-radius: 0;
-            border-bottom-right-radius: 0;
-            border: 1px solid var(--background-gray);
-            border-right: none;
-            height: 3rem;
-            padding: 0 1rem;
-            @include typography.body;
-            background-color: var(--background-light);
-            color: var(--on-background-light);
-            @include breakpoints.for-tablet-landscape-up {
-                height: 2.5rem;
-            }
-        }
-        button[type="submit"] {
-            cursor: pointer;
-            width: 3rem;
-            height: 3rem;
-            border-radius: 5px;
-            border-top-left-radius: 0;
-            border-bottom-left-radius: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border: none;
-            margin-left: 0; // Needed to prevent wrapping on mobile
-            background-color: var(--secondary);
-            color: var(--on-secondary);
-            @include breakpoints.for-tablet-landscape-up {
-                height: 2.5rem;
-                min-width: 2.5rem;
-            }
-            // Magnifying glass icon
-            &::after {
-                content: "\f5e6"; // phosphor magnifying glass bold icon
-                @include typography.icon-button-md;
-                @include breakpoints.for-tablet-landscape-up {
-                    @include typography.icon-button-sm;
-                }
-            }
-        }
     }
     // dropdown in facet filters
     #filters label:has(select) {
@@ -250,6 +203,55 @@ main.people {
         flex-flow: column;
         width: 100%;
         padding: 0;
+    }
+    fieldset#query {
+        display: flex;
+        align-items: center;
+    }
+    // search box
+    input[type="search"] {
+        flex-basis: 100%;
+        border: none;
+        border-radius: 5px;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        border: 1px solid var(--background-gray);
+        border-right: none;
+        height: 3rem;
+        padding: 0 1rem;
+        @include typography.body;
+        background-color: var(--background-light);
+        color: var(--on-background-light);
+        @include breakpoints.for-tablet-landscape-up {
+            height: 2.5rem;
+        }
+    }
+    button[type="submit"] {
+        cursor: pointer;
+        width: 3rem;
+        height: 3rem;
+        border-radius: 5px;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        margin-left: 0; // Needed to prevent wrapping on mobile
+        background-color: var(--secondary);
+        color: var(--on-secondary);
+        @include breakpoints.for-tablet-landscape-up {
+            height: 2.5rem;
+            min-width: 2.5rem;
+        }
+        // Magnifying glass icon
+        &::after {
+            content: "\f5e6"; // phosphor magnifying glass bold icon
+            @include typography.icon-button-md;
+            @include breakpoints.for-tablet-landscape-up {
+                @include typography.icon-button-sm;
+            }
+        }
     }
     div#filters-header {
         display: flex;

--- a/sitemedia/scss/pages/_people.scss
+++ b/sitemedia/scss/pages/_people.scss
@@ -19,6 +19,18 @@ main.people {
         align-items: center;
         justify-content: space-between;
         width: 100%;
+        gap: 0.75rem;
+        @include breakpoints.for-tablet-landscape-up {
+            gap: 2rem;
+        }
+        fieldset#query {
+            flex-grow: 1;
+            margin-right: 5.75rem;
+            @include breakpoints.for-tablet-landscape-up {
+                margin-left: 8rem;
+                margin-right: 0;
+            }
+        }
         label#people-view-switcher {
             display: none;
             @include breakpoints.for-tablet-landscape-up {
@@ -231,6 +243,21 @@ main.people {
             }
         }
     }
+    .topheader-row:has(input#switcher:not(:checked))
+        ~ section#person-list
+        table {
+        td.other-names {
+            font-size: typography.$text-size-md;
+            color: var(--date-placeholder);
+            span.name {
+                font-weight: 700;
+            }
+            margin-bottom: 0.25rem;
+            &:empty {
+                display: none;
+            }
+        }
+    }
     @include breakpoints.for-tablet-landscape-up {
         .topheader-row:has(input#switcher:checked) ~ section#person-list table {
             display: table;
@@ -261,6 +288,9 @@ main.people {
                         border-left: 1px solid var(--background-gray);
                         border-top-left-radius: 5px;
                         border-bottom-left-radius: 5px;
+                    }
+                    &.other-names span.aka {
+                        display: none;
                     }
                     &:last-of-type {
                         padding-right: spacing.$spacing-md;

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -24,7 +24,6 @@ main.people {
     // Header
     & > h1,
     .topheader-row h1 {
-        width: 100%;
         font-family: fonts.$primary;
         font-size: typography.$text-size-5xl;
         @include breakpoints.for-tablet-landscape-up {
@@ -35,4 +34,8 @@ main.people {
     .topheader-row {
         margin-bottom: 1rem;
     }
+}
+
+main.search > h1 {
+    width: 100%;
 }

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -354,6 +354,12 @@
   <copyField source="description_en_bigram" dest="description_nostem" maxChars="30000" />
   <copyField source="text_transcription" dest="transcription_nostem" maxChars="30000" />
 
+  <!-- copy people name fields to text fields -->
+  <copyField source="name_s" dest="name_bigram" maxChars="30000" />
+  <copyField source="name_s" dest="name_nostem" maxChars="30000" />
+  <copyField source="other_names_ss" dest="other_names_bigram" maxChars="30000" />
+  <copyField source="other_names_ss" dest="other_names_nostem" maxChars="30000" />
+
   <dynamicField name="*_descendent_path" type="descendent_path" indexed="true" stored="true"/>
   <dynamicField name="*_ancestor_path" type="ancestor_path" indexed="true" stored="true"/>
   <dynamicField name="ignored_*" type="ignored" multiValued="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -1371,7 +1371,6 @@
         <lst name="params">
           <str name="config_param">example config parameter</str>
         </lst>
-        
       </processor>
       <processor class="solr.RunUpdateProcessorFactory" />
     </updateRequestProcessorChain>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -804,6 +804,20 @@
         old_shelfmark_textnum
         old_shelfmark_bigram
       </str>
+
+      <!-- search fields for people -->
+      <str name="people_qf">
+        name_nostem^30
+        name_bigram^20
+        other_names_nostem^10
+        other_names_bigram
+      </str>
+      <str name="people_pf">
+        name_nostem^30
+        name_bigram^20
+        other_names_nostem^10
+        other_names_bigram
+      </str>
     </lst>
 
     <!-- In addition to defaults, "appends" params can be specified
@@ -1357,6 +1371,7 @@
         <lst name="params">
           <str name="config_param">example config parameter</str>
         </lst>
+        
       </processor>
       <processor class="solr.RunUpdateProcessorFactory" />
     </updateRequestProcessorChain>


### PR DESCRIPTION
## In this PR

Per #1711:
- Allow public users to search on people's names
  - Searches primary names and secondary names
  - Primary names get priority; secondary names included in highlights so that they will show up in search results
  - Name fields analyzed by a couple of different analyzers (bigram for basic search, nostem for exact matches)
  - Selects/deselects "relevance descending" sort automatically using the radio button elements based on whether or not a keyword query is entered
