### PR TITLE
Merge tool for person-person relationship types (#1500)

### DIFF
--- a/geniza/entities/forms.py
+++ b/geniza/entities/forms.py
@@ -10,6 +10,7 @@ from geniza.entities.models import (
     PersonDocumentRelationType,
     PersonEventRelation,
     PersonPersonRelation,
+    PersonPersonRelationType,
     PersonPlaceRelation,
     PersonRole,
     PlaceEventRelation,
@@ -54,30 +55,7 @@ class PersonMergeForm(forms.Form):
         )
 
 
-class PersonDocumentRelationTypeChoiceField(forms.ModelChoiceField):
-    """Add a summary of each PersonDocumentRelationType to a form (used for merging)"""
-
-    label_template = get_template(
-        "entities/snippets/persondocumentrelationtype_option_label.html"
-    )
-
-    def label_from_instance(self, relation_type):
-        return self.label_template.render({"relation_type": relation_type})
-
-
-class PersonDocumentRelationTypeMergeForm(forms.Form):
-    primary_relation_type = PersonDocumentRelationTypeChoiceField(
-        label="Select primary person-document relationship",
-        queryset=None,
-        help_text=(
-            "Select the primary person-document relationship, which will be "
-            "used as the canonical entry. All associated relations and log "
-            "entries will be combined on the primary relationship."
-        ),
-        empty_label=None,
-        widget=forms.RadioSelect,
-    )
-
+class RelationTypeMergeFormMixin:
     def __init__(self, *args, **kwargs):
         ids = kwargs.get("ids", [])
 
@@ -90,7 +68,59 @@ class PersonDocumentRelationTypeMergeForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields[
             "primary_relation_type"
-        ].queryset = PersonDocumentRelationType.objects.filter(id__in=ids)
+        ].queryset = self.reltype_model.objects.filter(id__in=ids)
+
+
+class PersonDocumentRelationTypeChoiceField(forms.ModelChoiceField):
+    """Add a summary of each PersonDocumentRelationType to a form (used for merging)"""
+
+    label_template = get_template(
+        "entities/snippets/persondocumentrelationtype_option_label.html"
+    )
+
+    def label_from_instance(self, relation_type):
+        return self.label_template.render({"relation_type": relation_type})
+
+
+class PersonDocumentRelationTypeMergeForm(RelationTypeMergeFormMixin, forms.Form):
+    primary_relation_type = PersonDocumentRelationTypeChoiceField(
+        label="Select primary person-document relationship",
+        queryset=None,
+        help_text=(
+            "Select the primary person-document relationship, which will be "
+            "used as the canonical entry. All associated relations and log "
+            "entries will be combined on the primary relationship."
+        ),
+        empty_label=None,
+        widget=forms.RadioSelect,
+    )
+    reltype_model = PersonDocumentRelationType
+
+
+class PersonPersonRelationTypeChoiceField(forms.ModelChoiceField):
+    """Add a summary of each PersonPersonRelationType to a form (used for merging)"""
+
+    label_template = get_template(
+        "entities/snippets/personpersonrelationtype_option_label.html"
+    )
+
+    def label_from_instance(self, relation_type):
+        return self.label_template.render({"relation_type": relation_type})
+
+
+class PersonPersonRelationTypeMergeForm(RelationTypeMergeFormMixin, forms.Form):
+    primary_relation_type = PersonPersonRelationTypeChoiceField(
+        label="Select primary person-person relationship",
+        queryset=None,
+        help_text=(
+            "Select the primary person-person relationship, which will be "
+            "used as the canonical entry. All associated relations and log "
+            "entries will be combined on the primary relationship."
+        ),
+        empty_label=None,
+        widget=forms.RadioSelect,
+    )
+    reltype_model = PersonPersonRelationType
 
 
 class PersonPersonForm(forms.ModelForm):

--- a/geniza/entities/templates/admin/entities/personpersonrelationtype/merge.html
+++ b/geniza/entities/templates/admin/entities/personpersonrelationtype/merge.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{% static "css/admin-local.css" %}">
 {% endblock %}
 
-{% block title %} Merge selected person-document relationships {% endblock %}
+{% block title %} Merge selected person-person relationships {% endblock %}
 
 {% block breadcrumbs %}
     {% if not is_popup %}
@@ -17,16 +17,16 @@
             &rsaquo;
             <a href="{% url 'admin:app_list' app_label='entities' %}">Entities</a>
             &rsaquo;
-            <a href="{% url 'admin:entities_persondocumentrelationtype_changelist'%}">Person-Document relationships</a>
+            <a href="{% url 'admin:entities_personpersonrelationtype_changelist'%}">Person-Person relationships</a>
             &rsaquo;
-            Merge selected person-document relationships
+            Merge selected person-person relationships
         </div>
     {% endif %}
 {% endblock %}
 
 
 {% block content_title %}
-    <h1>Merge selected person-document relationships</h1>
+    <h1>Merge selected person-person relationships</h1>
     <h2>Note: there is no automated way to unmerge! Please review to make sure these relationships should be merged before submitting the form.</h2>
 {% endblock %}
 

--- a/geniza/entities/templates/entities/snippets/personpersonrelationtype_option_label.html
+++ b/geniza/entities/templates/entities/snippets/personpersonrelationtype_option_label.html
@@ -1,0 +1,33 @@
+{# template snippet for displaying person-person relationship label on a form #}
+{# used on merge form to provide enough information to merge accurately #}
+
+<div class="merge-document-label">
+    <h2>{{ relation_type }}
+        <a target="_blank" href="{% url 'admin:entities_personpersonrelationtype_change' relation_type.pk %}"
+           title="Go to this relationship's admin edit page">
+            <img src="/static/admin/img/icon-changelink.svg" alt="Change"></a>
+    </h2>
+    <details>
+        <summary>View all {{ relation_type.personpersonrelation_set.count }} {{ relation_type }} relations</summary>
+        <ol>
+            {% for rel in relation_type.personpersonrelation_set.all %}
+                <li>
+                    <div class="form-row">
+                        <label>{{ rel.type }}-{{ rel.type.converse_name|default:rel.type }} relation:</label>
+                        <div>
+                            <a target="_blank" href="{% url 'admin:entities_person_change' rel.from_person.pk %}">{{ rel.from_person }}</a>
+                            and
+                            <a target="_blank" href="{% url 'admin:entities_person_change' rel.to_person.pk %}">{{ rel.to_person }}</a>
+                        </div>
+                    </div>
+                </li>
+            {% empty %}
+                <li>
+                    <div class="form-row">
+                        <label>No relations</label><div></div>
+                    </div>
+                </li>
+            {% endfor %}
+        </ol>
+    </details>
+</div>

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -427,7 +427,7 @@ class TestPersonDocumentRelationTypeAdmin:
         mockrequest = Mock()
         test_ids = ["1", "2", "3"]
         mockrequest.POST.getlist.return_value = test_ids
-        resp = pdr_admin.merge_person_document_relation_types(mockrequest, Mock())
+        resp = pdr_admin.merge_relation_types(mockrequest, Mock())
         assert isinstance(resp, HttpResponseRedirect)
         assert resp.status_code == 303
         assert resp["location"].startswith(
@@ -437,7 +437,7 @@ class TestPersonDocumentRelationTypeAdmin:
 
         test_ids = ["1"]
         mockrequest.POST.getlist.return_value = test_ids
-        resp = pdr_admin.merge_person_document_relation_types(mockrequest, Mock())
+        resp = pdr_admin.merge_relation_types(mockrequest, Mock())
         assert isinstance(resp, HttpResponseRedirect)
         assert resp.status_code == 302
         assert resp["location"] == reverse(

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -708,7 +708,7 @@ class TestPersonDocumentRelation:
 @pytest.mark.django_db
 class TestPersonDocumentRelationType:
     def test_merge_with(self, person, person_multiname, document, join):
-        # create two PersonDocumentRelationTypes and some associations
+        # create three PersonDocumentRelationTypes and some associations
         rel_type = PersonDocumentRelationType.objects.create(name="test")
         type_2 = PersonDocumentRelationType.objects.create(name="to be merged")
         type_3 = PersonDocumentRelationType.objects.create(name="also merge me")
@@ -763,6 +763,75 @@ class TestPersonDocumentRelationType:
         assert LogEntry.objects.filter(
             object_id=rel_type.pk,
             change_message__contains=f"merged with {type_2}, {type_3}",
+        ).exists()
+        assert rel_type.log_entries.count() == 3
+        # based on default sorting, most recent log entry will be first
+        # - should document the merge event
+        merge_log = rel_type.log_entries.first()
+        assert merge_log.action_flag == CHANGE
+
+        # reassociated log entries should include merged type's name, id
+        assert (
+            " [merged type %s (id = %s)]" % (type_2_str, type_2_pk)
+            in rel_type.log_entries.all()[1].change_message
+        )
+        assert (
+            " [merged type %s (id = %s)]" % (type_2_str, type_2_pk)
+            in rel_type.log_entries.all()[2].change_message
+        )
+
+
+@pytest.mark.django_db
+class TestPersonPersonRelationType:
+    def test_merge_with(self, person, person_multiname, person_diacritic):
+        # create two PersonPersonRelationTypes and some associations
+        rel_type = PersonPersonRelationType.objects.create(name="test")
+        type_2 = PersonPersonRelationType.objects.create(name="to be merged")
+        PersonPersonRelation.objects.create(
+            type=rel_type, from_person=person, to_person=person_multiname
+        )
+        PersonPersonRelation.objects.create(
+            type=type_2, from_person=person, to_person=person_diacritic
+        )
+
+        # create some log entries
+        pprtype_contenttype = ContentType.objects.get_for_model(
+            PersonPersonRelationType
+        )
+        creation_date = timezone.make_aware(datetime(2025, 1, 22))
+        creator = User.objects.get_or_create(username="editor")[0]
+        type_2_str = str(type_2)
+        type_2_pk = type_2.pk
+        LogEntry.objects.bulk_create(
+            [
+                LogEntry(
+                    user_id=creator.id,
+                    content_type_id=pprtype_contenttype.pk,
+                    object_id=type_2_pk,
+                    object_repr=type_2_str,
+                    change_message="first input",
+                    action_flag=ADDITION,
+                    action_time=creation_date,
+                ),
+                LogEntry(
+                    user_id=creator.id,
+                    content_type_id=pprtype_contenttype.pk,
+                    object_id=type_2_pk,
+                    object_repr=type_2_str,
+                    change_message="major revision",
+                    action_flag=CHANGE,
+                    action_time=timezone.now(),
+                ),
+            ]
+        )
+        assert rel_type.personpersonrelation_set.count() == 1
+        rel_type.merge_with([type_2])
+        assert rel_type.personpersonrelation_set.count() == 2
+        # should delete other types and create merge log entry
+        assert not type_2.pk
+        assert LogEntry.objects.filter(
+            object_id=rel_type.pk,
+            change_message__contains=f"merged with {type_2}",
         ).exists()
         assert rel_type.log_entries.count() == 3
         # based on default sorting, most recent log entry will be first

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -242,12 +242,12 @@ fieldset.transcriptions-field
     max-height: 350px;
     overflow-y: scroll;
 }
-.merge-document li > label {
+[class^="merge-"] li > label {
     display: flex;
     justify-content: flex-start;
 }
 
-.merge-document .submit-row {
+[class^="merge-"] .submit-row {
     clear: left;
     padding: 12px 14px;
     margin: 20px 0 0;
@@ -279,10 +279,10 @@ fieldset.transcriptions-field
     list-style: auto;
 }
 
-.merge-document input[type="radio"] {
+[class^="merge-"] input[type="radio"] {
     margin-right: 0.5rem;
 }
-.merge-document textarea {
+[class^="merge-"] textarea {
     margin: 0 0 20px 180px;
 }
 


### PR DESCRIPTION
## In this PR

Per #1500:
- Make Person-Document relationship type merge logic as generic as possible through mixins and inheritance
- Reuse for both that and Person-Person relationship types