### PR TITLE
Add APD link to doc search on Arabic/JA query (#1697)

### DIFF
--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -157,6 +157,12 @@
             {% if is_paginated %}
                 {% include "corpus/snippets/pagination.html" %}
             {% endif %}
+            {% if apd_link %}
+                <a id="apd" href="{{ apd_link }}">
+                    {# translators: Link to search a document query on the Arabic Papyrology Database #}
+                    {% translate 'View results in the Arabic Papyrology Database' %}
+                </a>
+            {% endif %}
         </section>
     </form>
 {% endblock main %}

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1339,6 +1339,20 @@ class TestDocumentSearchView:
             0
         ] == clean_html("<em>מרכב</em>")
 
+    def test_get_apd_link(self):
+        dsv = DocumentSearchView(kwargs={})
+
+        # no arabic or ja: bail out
+        assert not dsv.get_apd_link(None)
+        assert not dsv.get_apd_link("test")
+
+        # arabic: leave as is
+        arabic = "العبد"
+        assert dsv.get_apd_link(arabic) == f"{dsv.apd_base_url}{arabic}"
+
+        # JA: translate with regex
+        assert dsv.get_apd_link("ואגב") == f"{dsv.apd_base_url}وا[غج]ب"
+
 
 class TestDocumentScholarshipView:
     def test_page_title(self, document, client, source):

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -34,6 +34,19 @@ section#document-list {
             margin-top: spacing.$spacing-md;
         }
     }
+    a#apd {
+        text-align: center;
+        margin: 1.5rem 0;
+        @include breakpoints.for-tablet-landscape-up {
+            margin: 2.25rem 0;
+        }
+    }
+    nav.pagination + a#apd {
+        margin: 0;
+        @include breakpoints.for-tablet-landscape-up {
+            margin: 0;
+        }
+    }
 }
 
 // single result


### PR DESCRIPTION
## In this PR

Per #1697:
- Generate a link to the Arabic Papyrology Database when Arabic or JA are entered in the document search query
- Generate a regex version of a JA-to-Arabic translation for this link, since APD is only in Arabic, and supports regex
- Show the link at the bottom of the search results if it exists
