### PR TITLE
Adjust alignment for non-100% zoom levels (#1680)

### DIFF
--- a/.github/workflows/sphinx_docs.yml
+++ b/.github/workflows/sphinx_docs.yml
@@ -29,7 +29,7 @@ jobs:
       # We base the python cache on the hash of all requirements files, so that
       # if any change, the cache is invalidated.
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements/*.txt') }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -58,7 +58,7 @@ jobs:
       # We base the python cache on the hash of all requirements files, so that
       # if any change, the cache is invalidated.
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements/*.txt') }}
@@ -81,7 +81,7 @@ jobs:
           node-version: 16
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -73,7 +73,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
@@ -93,7 +93,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('requirements/*.txt') }}

--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -219,8 +219,7 @@
                                 {% with rotation="rotation:degrees="|add:deg %}
                                     <img class="iiif-image" data-iiif-target="image" data-annotation-target="image" src="{{ image_info.image|iiif_image:"size:width=500"|iiif_image:rotation }}" alt="{{ image_info.label }}" title="{{ image_info.label }}" loading="lazy"
                                          sizes="(max-width: 1440px) 50vw, 94vw"
-                                         srcset="{{ image_info.image|iiif_image:"size:width=300"|iiif_image:rotation }} 300w,
-                                                 {{ image_info.image|iiif_image:"size:width=500"|iiif_image:rotation }} 500w,
+                                         srcset="{{ image_info.image|iiif_image:"size:width=500"|iiif_image:rotation }} 500w,
                                                  {{ image_info.image|iiif_image:"size:width=640"|iiif_image:rotation }} 640w,
                                                  {{ image_info.image|iiif_image:"size:width=1440"|iiif_image:rotation }} 1440w">
                                 {% endwith %}

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -623,30 +623,12 @@
                 margin: 0;
                 padding: 0;
             }
-            li[data-lines="1"] {
-                min-height: calc(1 * 34 / 22 * 1.375rem);
-                max-height: calc(1 * 34 / 22 * 1.375rem);
-            }
-            li[data-lines="2"] {
-                // li, height of two lines (line height = 34 / 22, font size = 1.375rem)
-                min-height: calc(2 * 34 / 22 * 1.375rem);
-                max-height: calc(2 * 34 / 22 * 1.375rem);
-            }
-            li[data-lines="3"] {
-                min-height: calc(3 * 34 / 22 * 1.375rem);
-                max-height: calc(3 * 34 / 22 * 1.375rem);
-            }
-            li[data-lines="4"] {
-                min-height: calc(4 * 34 / 22 * 1.375rem);
-                max-height: calc(4 * 34 / 22 * 1.375rem);
-            }
-            li[data-lines="5"] {
-                min-height: calc(5 * 34 / 22 * 1.375rem);
-                max-height: calc(5 * 34 / 22 * 1.375rem);
-            }
-            li[data-lines="6"] {
-                min-height: calc(6 * 34 / 22 * 1.375rem);
-                max-height: calc(6 * 34 / 22 * 1.375rem);
+            @for $n from 1 through 30 {
+                // li, height of $n lines (line height = 34 / 22, font size = 1.375rem)
+                li[data-lines="#{$n}"] {
+                    min-height: calc(#{$n} * 34 / 22 * 1.375rem);
+                    max-height: calc(#{$n} * 34 / 22 * 1.375rem);
+                }
             }
             span.current-transcription,
             span.current-translation {


### PR DESCRIPTION
## In this PR

Per #1680:
- Add a short 50ms timeout before starting alignment in order to fix alignment on Chrome and Firefox at non-100% zoom levels (delaying bounding box calculations this amount seems to always result in the correct dimensions)
- For Safari, calculate the window's pixel zoom ratio using `window.outerWidth / window.innerWidth` and apply the ratio accordingly to bounding box calculations (this _doesn't_ work in Chrome/Firefox)
- Also, because we now have translation lines that will sometimes be upwards of 20 lines long (after wrapping at 125% zoom), programmatically generate up to 30 lines worth of CSS line height rules using SCSS `@for`