### PR TITLE
Allow tag search in admin (#1731)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -45,6 +45,7 @@ from geniza.entities.models import (
     PersonPlaceRelation,
     PersonPlaceRelationType,
     PersonRole,
+    PersonSolrQuerySet,
     Place,
     PlaceEventRelation,
     PlacePlaceRelation,
@@ -329,31 +330,26 @@ class PersonAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin):
             self.own_pk = None
         return super().get_form(request, obj, **kwargs)
 
-    def get_queryset(self, request):
-        """For autocomplete ONLY, remove self from queryset, so that Person-Person autocomplete
-        does not include self in the list of options"""
-        # also add unaccented name to queryset so we can search on it
-        qs = (
-            super()
-            .get_queryset(request)
-            .annotate(
-                # ArrayAgg to group together related values from related model instances
-                name_unaccented=ArrayAgg("names__name__unaccent", distinct=True),
+    def get_search_results(self, request, queryset, search_term):
+        """Override admin search to use Solr.
+        Adapted from :meth:`DocumentAdmin.get_search_results`."""
+        if search_term:
+            # - return slugs for all matching records
+            sqs = (
+                PersonSolrQuerySet()
+                .keyword_search(search_term)
+                .only("slug")
+                .get_results(rows=10000)
             )
-        )
+            slugs = [r["slug"] for r in sqs]
+            # filter queryset by slug if there are results
+            if sqs:
+                queryset = queryset.filter(slug__in=slugs)
+            else:
+                queryset = queryset.none()
 
-        # only modify if this is the person-person autocomplete request
-        is_autocomplete = request and request.path == "/admin/autocomplete/"
-        is_personperson = (
-            request
-            and request.GET
-            and request.GET.get("model_name") == "personpersonrelation"
-        )
-        if self.own_pk and is_autocomplete and is_personperson:
-            # exclude self from queryset
-            return qs.exclude(pk=int(self.own_pk))
-        # otherwise, return normal queryset
-        return qs
+        # return queryset, use distinct not needed
+        return queryset, False
 
     @admin.display(description="Merge selected people")
     def merge_people(self, request, queryset=None):

--- a/geniza/entities/forms.py
+++ b/geniza/entities/forms.py
@@ -1,4 +1,4 @@
-from dal import autocomplete
+from dal import autocomplete, forward
 from django import forms
 from django.template.loader import get_template
 from django.utils.translation import gettext_lazy as _
@@ -133,7 +133,10 @@ class PersonPersonForm(forms.ModelForm):
         )
         widgets = {
             "notes": forms.Textarea(attrs={"rows": 4}),
-            "to_person": autocomplete.ModelSelect2(url="entities:person-autocomplete"),
+            "to_person": autocomplete.ModelSelect2(
+                url="entities:person-autocomplete",
+                forward=(forward.Const(True, "is_person_person_form"),),
+            ),
         }
         help_texts = {
             "to_person": "Please check auto-populated and manually-input people sections to ensure you are not entering the same relationship twice."


### PR DESCRIPTION
## In this PR

Per #1731:
- Allow tag search in admin by using solr query when searching for people in the admin

Other:
- Fix broken autocomplete on person-person relations. There was a bug in `PersonAdmin.get_queryset` that was meant to exclude the parent person from autocomplete when related people were being added—in other words, to prevent a person from being added as a related person to itself. The autocomplete view's `get_queryset` method was called instead of `PersonAdmin.get_queryset`, so logic there was ignored. This PR uses slightly different logic to achieve the same ends, using `django-autocomplete-light`'s `forward` function and URL parsing to determine when and which person to exclude.