### PR TITLE
Allow use of italics in translation editor (#1617)

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -108,7 +108,7 @@ class Annotation(TrackChangesModel):
     objects = AnnotationQuerySet.as_manager()
 
     # allowed tags and attributes for annotation body content HTML
-    ALLOWED_TAGS = ["del", "li", "ol", "p", "span", "sup"]
+    ALLOWED_TAGS = ["del", "li", "ol", "p", "span", "sup", "em"]
     ALLOWED_ATTRIBUTES = ["lang"]
 
     # error message for malformed annotations

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -1025,6 +1025,7 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     if self.doc_relation == "transcription"
                     else "translating",
                     "text_direction": text_direction,
+                    "italic_enabled": self.doc_relation == "translation",
                     # line-by-line mode for eScriptorium sourced transcriptions
                     "line_mode": "model" in source.source_type.type,
                 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hotwired/turbo": "^7.1.0",
         "@recogito/annotorious": "^2.7.13",
         "@recogito/annotorious-openseadragon": "^2.7.17",
-        "annotorious-tahqiq": "^1.3.0",
+        "annotorious-tahqiq": "^1.5.0",
         "autoprefixer": "^10.3.2",
         "babel-loader": "^8.2.2",
         "core-js": "^3.16.3",
@@ -2613,9 +2613,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/annotorious-tahqiq": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.3.0.tgz",
-      "integrity": "sha512-KjpptMfpW0djhe7oUXvIKanf3B26kZMdr24VHjIFa7Fb/kho5u8kQ9iKaEwQ2F1yL2DjYPLTiHguTw57FZM4pg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.0.tgz",
+      "integrity": "sha512-wQxESZX+5U0wB32pmeGfQu/kv+R6+jjijRwST22UMPKhFuXwgSIYmUhhZFkzQeoOIiKmQK1FTnP+BGCZLKgB5w==",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"
@@ -7290,9 +7290,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -10892,9 +10892,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "annotorious-tahqiq": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.3.0.tgz",
-      "integrity": "sha512-KjpptMfpW0djhe7oUXvIKanf3B26kZMdr24VHjIFa7Fb/kho5u8kQ9iKaEwQ2F1yL2DjYPLTiHguTw57FZM4pg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.0.tgz",
+      "integrity": "sha512-wQxESZX+5U0wB32pmeGfQu/kv+R6+jjijRwST22UMPKhFuXwgSIYmUhhZFkzQeoOIiKmQK1FTnP+BGCZLKgB5w==",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"
@@ -14430,9 +14430,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "requires": {
         "randombytes": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hotwired/turbo": "^7.1.0",
     "@recogito/annotorious": "^2.7.13",
     "@recogito/annotorious-openseadragon": "^2.7.17",
-    "annotorious-tahqiq": "^1.3.0",
+    "annotorious-tahqiq": "^1.5.0",
     "autoprefixer": "^10.3.2",
     "babel-loader": "^8.2.2",
     "core-js": "^3.16.3",

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -136,8 +136,9 @@ export default class extends Controller {
             storagePlugin,
             annotationContainer,
             this.element.querySelector(".tahqiq-toolbar"), // toolbar container fieldset
+            config.tiny_api_key,
             config.text_direction,
-            config.tiny_api_key
+            config.italic_enabled
         );
 
         if (window.tinyConfig) {


### PR DESCRIPTION
## In this PR

Per #1617:
- Update `annotorious-tahqiq` and use its new config option to enable italics, only on the translation editor
- Whitelist the resulting `em` tags in the annotation cleaning logic