### PR TITLE
Resolve em conflict with highlight (#1617)

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -108,7 +108,7 @@ class Annotation(TrackChangesModel):
     objects = AnnotationQuerySet.as_manager()
 
     # allowed tags and attributes for annotation body content HTML
-    ALLOWED_TAGS = ["del", "li", "ol", "p", "span", "sup", "em"]
+    ALLOWED_TAGS = ["del", "li", "ol", "p", "span", "sup", "i"]
     ALLOWED_ATTRIBUTES = ["lang"]
 
     # error message for malformed annotations

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hotwired/turbo": "^7.1.0",
         "@recogito/annotorious": "^2.7.13",
         "@recogito/annotorious-openseadragon": "^2.7.17",
-        "annotorious-tahqiq": "^1.5.0",
+        "annotorious-tahqiq": "^1.5.1",
         "autoprefixer": "^10.3.2",
         "babel-loader": "^8.2.2",
         "core-js": "^3.16.3",
@@ -2613,9 +2613,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/annotorious-tahqiq": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.0.tgz",
-      "integrity": "sha512-wQxESZX+5U0wB32pmeGfQu/kv+R6+jjijRwST22UMPKhFuXwgSIYmUhhZFkzQeoOIiKmQK1FTnP+BGCZLKgB5w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.1.tgz",
+      "integrity": "sha512-PmVYtDdSwGBXHbB4pJZ4Xx4YMg8lIpqleBHI4lP2Ax1GJaImz/hEqQDQ/eMODWrsxE0KIkksGSZ/9gs65LH1sA==",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"
@@ -10892,9 +10892,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "annotorious-tahqiq": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.0.tgz",
-      "integrity": "sha512-wQxESZX+5U0wB32pmeGfQu/kv+R6+jjijRwST22UMPKhFuXwgSIYmUhhZFkzQeoOIiKmQK1FTnP+BGCZLKgB5w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.1.tgz",
+      "integrity": "sha512-PmVYtDdSwGBXHbB4pJZ4Xx4YMg8lIpqleBHI4lP2Ax1GJaImz/hEqQDQ/eMODWrsxE0KIkksGSZ/9gs65LH1sA==",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@hotwired/turbo": "^7.1.0",
     "@recogito/annotorious": "^2.7.13",
     "@recogito/annotorious-openseadragon": "^2.7.17",
-    "annotorious-tahqiq": "^1.5.0",
+    "annotorious-tahqiq": "^1.5.1",
     "autoprefixer": "^10.3.2",
     "babel-loader": "^8.2.2",
     "core-js": "^3.16.3",

--- a/sitemedia/scss/base/_global.scss
+++ b/sitemedia/scss/base/_global.scss
@@ -124,7 +124,8 @@ blockquote {
     @include typography.quote;
 }
 
-em {
+em,
+i {
     font-style: italic;
 }
 


### PR DESCRIPTION
## In this PR

Solr uses `em` elements to highlight search results, which was conflicting with #1617 where we added the option to italicize words with `em` tags in the `annotorious-tahqiq` editor.

This PR bumps tahqiq to the new version that uses `i` tags instead, which is more semantically accurate as well, and whitelists `i` tags while removing `em` from the whitelist. It also adds styling to the `i` tag to show it as italic.