### PR TITLE
Person list view: add missing "Tags" header, fix icon css (#1741)

### DIFF
--- a/geniza/entities/templates/entities/person_list.html
+++ b/geniza/entities/templates/entities/person_list.html
@@ -128,6 +128,8 @@
                     <th>{% translate "Social role" %}</th>
                     {# Translators: Person "description / bio" column header on the browse page #}
                     <th class="description">{% translate "Description / Bio" %}</th>
+                    {# Translators: Person "tags" column header on the browse page #}
+                    <th class="tags">{% translate "Tags" %}</th>
                     <th class="related documents">
                         {# Translators: Person "document count" column header on the browse page #}
                         <span class="sr-only">{% translate "Number of related documents" %}</span>

--- a/sitemedia/scss/pages/_people.scss
+++ b/sitemedia/scss/pages/_people.scss
@@ -211,7 +211,6 @@ main.people {
                     }
                 }
             }
-            th.related,
             td.related {
                 .label {
                     display: none;


### PR DESCRIPTION
## In this PR

Per #1741:
- Fix css bug that was hiding icons on `th` for related records in the Person list view
- Add "Tags" `th` header that was missing from Person list view