### PR TITLE
Show sources of snippets in RegEx search results (#1700)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1320,6 +1320,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
         # collect transcription and translation texts for indexing
         transcription_texts = []
         transcription_texts_plaintext = []
+        transcription_texts_plaintext_names = []
         translation_texts = []
         # keep track of translation language for RTL/LTR display
         translation_langcode = ""
@@ -1336,9 +1337,11 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                 content = fn.content_html_str
                 if content:
                     transcription_texts.append(Footnote.explicit_line_numbers(content))
+                    fn_name = str(fn.source)
                     for canvas in fn.content_text_canvases:
                         # index plaintext only, per-canvas, for regex
                         transcription_texts_plaintext.append(canvas)
+                        transcription_texts_plaintext_names.append(fn_name)
             elif Footnote.DIGITAL_TRANSLATION in fn.doc_relation:
                 content = fn.content_html_str
                 if content:
@@ -1385,6 +1388,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                 "text_transcription": transcription_texts,
                 # transcription content as plaintext
                 "transcription_regex": transcription_texts_plaintext,
+                "transcription_regex_names_ss": transcription_texts_plaintext_names,
                 "translation_languages_ss": translation_languages,
                 "translation_language_code_s": translation_langcode,
                 "translation_language_direction_s": translation_langdir,

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -344,7 +344,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
             .rsplit(".*/", maxsplit=1)[0]
         )
         # get ~150 characters of context plus a word on either side of the matched portion
-        pattern = r"(\b\w+.{0,150})(%s)(.{0,150}\w+\b)" % regex_query
+        pattern = r"(\b\w*.{0,150})(%s)(.{0,150}\w*\b)" % regex_query
         # find all matches in the snippet
         matches = re.findall(pattern, text, flags=re.DOTALL)
         # separate multiple matches by HTML line breaks and ellipsis

--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -93,6 +93,7 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         "related_places": "places_count_i",
         "related_documents": "documents_count_i",
         "transcription_regex": "transcription_regex",
+        "transcription_regex_names": "transcription_regex_names_ss",
     }
 
     # regex to convert field aliases used in search to actual solr fields
@@ -368,17 +369,37 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
             for doc in self.get_results():
                 # highlight per document, keyed on id as expected in results
                 highlights[doc["id"]] = {
+                    # include labels in case of matches across multiple transcriptions
                     "transcription": [
-                        highlighted_block
+                        {
+                            "text": highlighted_block,
+                            "label": transcription_label,
+                        }
                         # this field is split by block-level annotation/group
-                        for highlighted_block in (
-                            self.get_regex_highlight(block)
-                            for block in doc["transcription_regex"]
+                        for (highlighted_block, transcription_label) in (
+                            (
+                                self.get_regex_highlight(block),
+                                # since the order of multivalued fields is stable in solr, we can
+                                # map each entry of the names field to each entry of the text field
+                                (
+                                    doc["transcription_regex_names"][i]
+                                    if "transcription_regex_names" in doc
+                                    else None
+                                ),
+                            )
+                            for i, block in enumerate(doc["transcription_regex"])
                         )
                         # only include a block if it actually has highlights
                         if highlighted_block
                     ]
                 }
+                # dedupe labels
+                last_label = None
+                for snippet in highlights[doc["id"]]["transcription"]:
+                    if snippet["label"] == last_label:
+                        del snippet["label"]
+                    else:
+                        last_label = snippet["label"]
         else:
             is_exact_search = "hl_query" in self.raw_params
             for doc in highlights.keys():
@@ -390,11 +411,17 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
                     ]
                 if is_exact_search and "transcription_nostem" in highlights[doc]:
                     highlights[doc]["transcription"] = [
-                        clean_html(s) for s in highlights[doc]["transcription_nostem"]
+                        {
+                            "text": clean_html(s)
+                            for s in highlights[doc]["transcription_nostem"]
+                        }
                     ]
                 elif "transcription" in highlights[doc]:
                     highlights[doc]["transcription"] = [
-                        clean_html(s) for s in highlights[doc]["transcription"]
+                        {
+                            "text": clean_html(s)
+                            for s in highlights[doc]["transcription"]
+                        }
                     ]
                 if "translation" in highlights[doc]:
                     highlights[doc]["translation"] = [

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -73,9 +73,11 @@
                     <!-- indicate language when possible, or at least change of language (if unknown) for screen readers -->
                 {% if document_highlights.transcription or document.transcription %}
                     <div class="transcription" dir="rtl" lang="{{ lang }}" {% if lang_script %}data-lang-script="{{ lang_script|lower }}"{% endif %}>
-
                         {% if document_highlights.transcription %}
-                            {% for snippet in document_highlights.transcription %}{{ snippet.strip|safe }}{% if snippet.strip and not forloop.last %}...<br />{% endif %}{% endfor %}
+                            {% for snippet in document_highlights.transcription %}
+                                {% if snippet.label %}<span class="snippet-label">{{ snippet.label.strip|safe }}</span>{% endif %}
+                                {{ snippet.text.strip|safe }}{% if snippet.text.strip and not forloop.last %}<div class="separator">[…]</div>{% endif %}
+                            {% endfor %}
                         {% elif document.transcription %}
                                 {# otherwise, display truncated transcription #}
                                 {# NOTE: might be nice to display N lines instead of using truncatechars #}

--- a/geniza/corpus/tests/test_corpus_templates.py
+++ b/geniza/corpus/tests/test_corpus_templates.py
@@ -675,7 +675,8 @@ class TestDocumentResult:
                     "lang": ["jrb"],
                 },
                 "highlighting": {
-                    "document.%d" % document.id: {"transcription": [test_highlight]}
+                    "document.%d"
+                    % document.id: {"transcription": [{"text": test_highlight}]}
                 },
                 "page_obj": self.page_obj,
             }

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1186,7 +1186,7 @@ class TestDocumentSearchView:
         hl = context_data["highlighting"]["document.%d" % document.id]["transcription"]
         assert len(hl) == 1
         assert "<em>العـ[ـبد]</em>" in re.sub(
-            r"\s+", "", hl[0]
+            r"\s+", "", hl[0]["text"]
         )  # rm solr-added whitespace
 
         doc2 = Document.objects.create()
@@ -1215,7 +1215,7 @@ class TestDocumentSearchView:
         context_data = docsearch_view.get_context_data()
         hl = context_data["highlighting"]["document.%d" % doc2.id]["transcription"]
         assert len(hl) == 1
-        highlight = re.sub(r"\s+", "", hl[0])  # rm solr-added whitespace
+        highlight = re.sub(r"\s+", "", hl[0]["text"])  # rm solr-added whitespace
         # should match on all words
         assert all(
             h in highlight for h in ["<em>מ〛תל", "לל[ה]</em>", "<em>תע/א\לי", "<em>דלך"]
@@ -1294,8 +1294,8 @@ class TestDocumentSearchView:
         # no double quotes in search, should highlight entire phrase
         docsearch_view.request.GET = {"q": "אלממ"}
         dqs = docsearch_view.get_queryset()
-        assert dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][
-            0
+        assert dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][0][
+            "text"
         ] == clean_html("<em>אלממחה ... אלממ</em>")
 
         # double quotes in search, should highlight only the exact match
@@ -1304,7 +1304,9 @@ class TestDocumentSearchView:
         assert dqs.raw_params["hl_query"] == '"אלממ"'
         assert (
             clean_html("<em>אלממ</em>")
-            in dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][0]
+            in dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][0][
+                "text"
+            ]
         )
 
     @pytest.mark.django_db
@@ -1335,8 +1337,8 @@ class TestDocumentSearchView:
         # should match word without prefix, smaller than the entered query
         docsearch_view.request.GET = {"q": "אלמרכב"}
         dqs = docsearch_view.get_queryset()
-        assert dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][
-            0
+        assert dqs.get_highlighting()[f"document.{document.pk}"]["transcription"][0][
+            "text"
         ] == clean_html("<em>מרכב</em>")
 
     def test_get_apd_link(self):

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -4,6 +4,7 @@
 
 @use "../base/breakpoints";
 @use "../base/container";
+@use "../base/fonts";
 @use "../base/spacing";
 @use "../base/typography";
 @use "../base/colors";
@@ -186,6 +187,24 @@ section#document-list {
             &[data-lang-script="hebrew"],
             span[lang="he"] {
                 @include typography.transcription-search;
+            }
+            // labels for snippets when applicable
+            span.snippet-label {
+                display: block;
+                direction: ltr;
+                text-align: left;
+                font-family: fonts.$primary;
+                font-size: typography.$text-size-sm;
+                @include breakpoints.for-tablet-landscape-up {
+                    font-size: typography.$text-size-md;
+                }
+            }
+            div.separator + span.snippet-label {
+                margin-top: 1rem;
+            }
+            // prevent […] separator from showing between a snippet and a label
+            div.separator:has(+ span.snippet-label) {
+                display: none;
             }
         }
 


### PR DESCRIPTION
## In this PR

Per #1700:
- Because regex results show all matches across a document's transcription content, the snippets can come from multiple transcription sources. So:
  - Index source labels alongside every transcription snippet. The labels are indexed separately but in the same order, and solr multivalued field order is predictable and persistent.
  - In regex search, match each highlighted snippet with its source label, and display them both on the result.
  - Ensure a source label is only shown once per transcription.

Unrelated:
- Fix a bug where at least one word was required to be both before and after a match in a regex-matched text in order for highlighting to work. In other words, a word that appeared at the very beginning or end of a transcription would not be highlighted. This was part of the logic to display context around the highlighted match, where `\w+` was used instead of `\w*`.