### PR TITLE
Use shelfmark as tiebreaker for score sort (#1752)

### DIFF
--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -266,7 +266,9 @@ class DocumentSearchView(
             documents = documents.order_by(
                 self.get_solr_sort(
                     search_opts["sort"], search_opts.get("exclude_inferred", False)
-                )
+                ),
+                # use shelfmark as tiebreaker
+                self.solr_sort["shelfmark"],
             )
 
             # filter by type if specified


### PR DESCRIPTION
## In this PR

Per #1752:
- Use shelfmark sort as a secondary sort; useful for tiebreaking relevance scores, such as in tag search where relevance scores are often identical