### PR TITLE
Regex: highlight multi-match in context (#1700)

### DIFF
--- a/geniza/corpus/solr_queryset.py
+++ b/geniza/corpus/solr_queryset.py
@@ -351,11 +351,14 @@ class DocumentSolrQuerySet(AliasedSolrQuerySet):
         # separate multiple matches by HTML line breaks and ellipsis
         separator = "<br />[…]<br />"
         # surround matched portion in <em> so it is visible in search results; join all into string
-        return (
-            separator.join([f"{m[0]}<em>{m[1]}</em>{m[2]}" for m in matches if m])
-            if matches
-            else None
+        joined_string = separator.join(
+            [f"{m[0]}<em>{m[1]}</em>{m[2]}" for m in matches if m]
         )
+        if not matches:
+            return None
+        # highlight any matches in added context
+        additional_matches_query = r"(%s)(?!<\/em>)" % regex_query
+        return re.sub(additional_matches_query, r"<em>\1</em>", joined_string)
 
     def get_highlighting(self):
         """highlight snippets within transcription/translation html may result in

--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -478,4 +478,14 @@ class TestDocumentSolrQuerySet:
         # multiple matches for the query should be separated by line breaks and ellipsis
         dqs.search_qs = ["transcription_regex:/.*מן.*/"]
         highlight = dqs.get_regex_highlight(text)
-        assert "<br />[…]<br />" in highlight
+        separator = "<br />[…]<br />"
+        assert separator in highlight
+
+        # multiple matches in the same ~300 chars context should all be highlighted
+        # check: there should be two snippets here, but three matches
+        hl_snippets = highlight.split(separator)
+        assert len(hl_snippets) == 2
+        # the first snippet should have one highlight in it
+        hl_snippets[0].count("<em>מן</em>") == 1
+        # the second snippet should have two highlights in it
+        hl_snippets[1].count("<em>מן</em>") == 2


### PR DESCRIPTION
## In this PR

Per #1700:
- Fix a bug in RegEx search where additional matches within a context snippet (~300 chars around a match) would not be highlighted