### PR TITLE
Only add space between em elements in non-regex search (#1700)

### DIFF
--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -163,12 +163,6 @@ section#document-list {
                 font-weight: bold;
                 font-style: normal;
             }
-            /* solr returns multiple matches in text without space between */
-            em + em {
-                &::before {
-                    content: " ";
-                }
-            }
         }
 
         .transcription {
@@ -524,6 +518,24 @@ a.view-link {
         @include breakpoints.for-tablet-landscape-up {
             margin-left: spacing.$spacing-sm;
             font-size: typography.$text-size-2xl;
+        }
+    }
+}
+
+//  solr returns multiple matches in text without space between, so ensure
+//  a space is added.
+//  this only applies to general (non-regex) search, where solr highlights.
+fieldset#query:not(:has(input[value="regex"]:checked))
+    ~ section#document-list
+    .search-result
+    section:first-of-type {
+    .description,
+    .transcription,
+    .translation {
+        em + em {
+            &::before {
+                content: " ";
+            }
         }
     }
 }


### PR DESCRIPTION
## In this PR

Per #1700:
- Fix a bug where space was being inserted with CSS incorrectly on regex highlights

## Notes

Due to the way solr highlights adjacent word matches, spaces were being intentionally inserted with CSS after the fact. This works fine for solr highlights, but was causing problems with our manual regex highlights, where there would be multiple matches in a snippet, with text nodes between them. An example scenario:

Indexed content: "Example phrase"

> General search: `Example phrase`
> Solr highlight: `<em>Example</em><em>phrase</em>`
> Appearance with CSS space rule (`em + em` matches): **Example phrase**

> Regex search: `Example phrase`
> Manual highlight: `<em>Example phrase</em>`
> Appearance with CSS space rule (`em + em` does not match): **Example phrase**

> Regex search: `a`
> Manual highlight: `Ex<em>a</em>mple phr<em>a</em>se`
> Appearance with CSS space rule (`em + em` matches): Ex**a**mple phr **a**se

This PR disables the space rule for regex search.