### PR TITLE
Use placeholder for annotation if tileSource fails to load (#1751)

### DIFF
--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -1040,6 +1040,8 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     "italic_enabled": self.doc_relation == "translation",
                     # line-by-line mode for eScriptorium sourced transcriptions
                     "line_mode": "model" in source.source_type.type,
+                    # placeholder url for annotating a broken image
+                    "placeholder_img": Document.PLACEHOLDER_CANVAS["image"]["info"],
                 },
                 # TODO: Add Footnote notes to the following display, if present
                 "source_detail": (

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -175,6 +175,12 @@ export default class extends Controller {
         anno.on("createSelection", () => this.setNavigatorVisible(true));
         anno.on("cancelSelected", () => this.setNavigatorVisible(true));
 
+        // use a placeholder and show error if opening a tilesource fails
+        viewer.addHandler("open-failed", ({ eventSource, message, source }) => {
+            storagePlugin.alert(`${message}: ${source}`, "error");
+            eventSource.open({ type: "image", url: config.placeholder_img });
+        });
+
         return viewer;
     }
 }


### PR DESCRIPTION
## In this PR

Per #1751:
- In case of institutional outages: Add a handler for OpenSeadragon's `open-failed` event that replaces the failed image with a placeholder, in annotation mode only