### PR TITLE
Fix two issues with RegEx multi-match (#1700)

### DIFF
--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -489,3 +489,18 @@ class TestDocumentSolrQuerySet:
         hl_snippets[0].count("<em>מן</em>") == 1
         # the second snippet should have two highlights in it
         hl_snippets[1].count("<em>מן</em>") == 2
+
+        # multiple adjacent matches separated by space should get the .adjacent-em class
+        dqs.search_qs = ["transcription_regex:/.*\w.*/"]
+        highlight = dqs.get_regex_highlight("test one two three")
+        assert '</em> <em class="adjacent-em">' in highlight
+
+        # matches like the "em" in <em> from the first round of highlighting should not match
+        assert "<<em>em</em>>" not in highlight
+
+        # same with the "br" in <br />
+        dqs.search_qs = ["transcription_regex:/.*(מן|\w).*/"]
+        highlight = dqs.get_regex_highlight(text)
+        assert separator in highlight
+        hl_snippets = highlight.split(separator)
+        assert all(["<em>br</em>" not in snippet for snippet in hl_snippets])

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -539,6 +539,23 @@ fieldset#query:not(:has(input[value="regex"]:checked))
         }
     }
 }
+// on regex search, sometimes the "additional matches" logic will result in
+// two adjacent <em> elements that have a space between them, but the space is
+// clobbered in display. we add an 'adjacent-em' class to those, handled here.
+fieldset#query:has(input[value="regex"]:checked)
+    ~ section#document-list
+    .search-result
+    section:first-of-type {
+    .description,
+    .transcription,
+    .translation {
+        em + em.adjacent-em {
+            &::before {
+                content: " ";
+            }
+        }
+    }
+}
 
 // tweaks for RTL search results for hebrew, arabic
 html[dir="rtl"] .search-result {


### PR DESCRIPTION
## In this PR

Per #1700:
- Fix an issue where `<em>`, `</em>`, and `<br />` could match on the second RegEx pass, breaking the HTML for display
- Fix an issue where two matches could be adjacent and separated by a space, and those `<em>` elements would display without a space between them