### PR TITLE
Add shelfmark, description, translation regex search options (#1755)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,10 @@
 # Deploy Notes
 
+## 4.21
+
+-   Solr configuration has changed. Ensure Solr configset has been updated
+    and then reindex all content: `python manage.py index`
+
 ## 4.20
 
 -   Solr configuration has changed. Ensure Solr configset has been updated

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -261,7 +261,7 @@ class DocumentSearchForm(RangeForm):
         # # Translators: label for translation RegEx field
         ("translation", _("Translation")),
         # # Translators: label for shelfmark RegEx field
-        # ("shelfmark", _("Shelfmark")),
+        ("shelfmark", _("Shelfmark")),
     ]
 
     # NOTE these are not set by default!

--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -253,6 +253,17 @@ class DocumentSearchForm(RangeForm):
         ("regex", _("RegEx")),
     ]
 
+    REGEX_FIELD_CHOICES = [
+        # Translators: label for transcription RegEx field
+        ("transcription", _("Transcription")),
+        # Translators: label for description RegEx field
+        ("description", _("Description")),
+        # # Translators: label for translation RegEx field
+        ("translation", _("Translation")),
+        # # Translators: label for shelfmark RegEx field
+        # ("shelfmark", _("Shelfmark")),
+    ]
+
     # NOTE these are not set by default!
     error_css_class = "error"
     required_css_class = "required"
@@ -314,6 +325,13 @@ class DocumentSearchForm(RangeForm):
         required=False,
         widget=forms.RadioSelect,
     )
+    regex_field = forms.ChoiceField(
+        # translators: label for RegEx search field choice selector
+        label=_("RegEx search field"),
+        choices=REGEX_FIELD_CHOICES,
+        required=False,
+        widget=forms.Select,
+    )
 
     # mapping of solr facet fields to form input
     solr_facet_fields = {
@@ -339,6 +357,13 @@ class DocumentSearchForm(RangeForm):
         # if "has translation" is not selected, language dropdown is disabled
         if not data or not data.get("has_translation", None):
             self.fields["translation_language"].disabled = True
+
+        # in regex mode, change placeholder text
+        if data and data.get("mode", None) == "regex":
+            # translators: placeholder for RegEx search query field
+            self.fields["q"].widget.attrs["placeholder"] = _(
+                "Search by regular expression"
+            )
 
     def get_translated_label(self, field, label):
         """Lookup translated label via db model object when applicable;

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1322,6 +1322,8 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
         transcription_texts_plaintext = []
         transcription_texts_plaintext_names = []
         translation_texts = []
+        translation_texts_plaintext = []
+        translation_texts_plaintext_names = []
         # keep track of translation language for RTL/LTR display
         translation_langcode = ""
         translation_langdir = "ltr"
@@ -1346,6 +1348,11 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                 content = fn.content_html_str
                 if content:
                     translation_texts.append(Footnote.explicit_line_numbers(content))
+                    fn_name = str(fn.source)
+                    for canvas in fn.content_text_canvases:
+                        # index plaintext only, per-canvas, for regex
+                        translation_texts_plaintext.append(canvas)
+                        translation_texts_plaintext_names.append(fn_name)
                     # TODO: Index translations in different languages separately
                     if fn.source.languages.exists():
                         lang = fn.source.languages.first()
@@ -1394,6 +1401,8 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                 "translation_language_direction_s": translation_langdir,
                 # translation content as html
                 "text_translation": translation_texts,
+                "translation_regex": translation_texts_plaintext,
+                "translation_regex_names_ss": translation_texts_plaintext_names,
                 "has_digital_edition_b": bool(counts[Footnote.DIGITAL_EDITION]),
                 "has_digital_translation_b": bool(counts[Footnote.DIGITAL_TRANSLATION]),
                 "has_discussion_b": bool(counts[Footnote.DISCUSSION]),

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -52,6 +52,16 @@
 
                 {# Translators: Search submit button #}
                 <button type="submit"><span>{{ search_label }}</span></button>
+
+                {% if request.GET.regex_field == 'shelfmark' %}
+                    <span class="shelfmark-help">
+                        {# translators: help text for shelfmark regex search #}
+                        {% blocktrans %}
+                            Case sensitive, must match entire shelfmark. Type one shelfmark,
+                            even if part of a join, for best results.
+                        {% endblocktrans %}
+                    </span>
+                {% endif %}
             </fieldset>
         {% endif %}
         <div id="filters-header">

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -8,31 +8,33 @@
     <h1>{{ page_title }}</h1>
     <form data-controller="search" data-turbo-frame="main" data-turbo-action="advance" data-page="document">
         <fieldset id="query">
-            <span class="fieldname">{{ form.mode.label }}</span>
-            <dialog data-search-target="helpDialog">
-                {# Translators: heading for search mode help text #}
-                <h2>
-                    <span>{% translate "How to Search" %}</span>
-                    <button type="button" id="close-search-help" data-action="search#toggleHelpDialog">
-                        {# Translators: accessibility label for button to close search mode help dialog #}
-                        <span class="sr-only">{% translate "Close search mode help" %}</span>
-                    </button>
-                </h2>
-                {% include "corpus/snippets/document_search_helptext.html" %}
-            </dialog>
-            <button type="button" id="search-help" data-action="search#toggleHelpDialog">
-                {# Translators: accessibility label for button to open search mode help dialog #}
-                <span class="sr-only">{% translate "Open search mode help" %}</span>
-            </button>
-            {% render_field form.mode data-action="change->search#update" %}
-
+            <div id="mode-controls">
+                <span class="fieldname">{{ form.mode.label }}</span>
+                <dialog data-search-target="helpDialog">
+                    {# Translators: heading for search mode help text #}
+                    <h2>
+                        <span>{% translate "How to Search" %}</span>
+                        <button type="button" id="close-search-help" data-action="search#toggleHelpDialog">
+                            {# Translators: accessibility label for button to close search mode help dialog #}
+                            <span class="sr-only">{% translate "Close search mode help" %}</span>
+                        </button>
+                    </h2>
+                    {% include "corpus/snippets/document_search_helptext.html" %}
+                </dialog>
+                <button type="button" id="search-help" data-action="search#toggleHelpDialog">
+                    {# Translators: accessibility label for button to open search mode help dialog #}
+                    <span class="sr-only">{% translate "Open search mode help" %}</span>
+                </button>
+                {% render_field form.mode data-action="change->search#update" %}
+            </div>
             {# Translators: Search submit button #}
             {% translate 'Search' as search_label %}
-
             {% if request.GET.mode != 'regex' %}
-                {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
+                <div id="search-input">
+                    {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
 
-                <button type="submit" aria-label="{{ search_label }}" />
+                    <button type="submit" aria-label="{{ search_label }}" />
+                </div>
             {% endif %}
         </fieldset>
         {% if request.GET.mode == 'regex' %}
@@ -40,15 +42,16 @@
                 {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
 
                 {# translators: "in" label between search query form and field dropdown #}
-                <span class="regex-label">{% translate 'in' %}</span>
 
                 <label for="{{ form.regex_field.auto_id }}">
+                    <span class="regex-label">{% translate 'in' %}</span>
+
                     <span class="sr-only">{{ form.regex_field.label }}</span>
                     {% render_field form.regex_field data-action="change->search#update" %}
                 </label>
 
                 {# Translators: Search submit button #}
-                <button type="submit" class="regex-submit"><span>{{ search_label }}</span></button>
+                <button type="submit"><span>{{ search_label }}</span></button>
             </fieldset>
         {% endif %}
         <div id="filters-header">

--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -25,12 +25,32 @@
                 <span class="sr-only">{% translate "Open search mode help" %}</span>
             </button>
             {% render_field form.mode data-action="change->search#update" %}
-            {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
 
             {# Translators: Search submit button #}
-            {% translate 'Submit search' as search_label %}
-            <button type="submit" aria-label="{{ search_label }}" />
+            {% translate 'Search' as search_label %}
+
+            {% if request.GET.mode != 'regex' %}
+                {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
+
+                <button type="submit" aria-label="{{ search_label }}" />
+            {% endif %}
         </fieldset>
+        {% if request.GET.mode == 'regex' %}
+            <fieldset id="regex-search">
+                {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
+
+                {# translators: "in" label between search query form and field dropdown #}
+                <span class="regex-label">{% translate 'in' %}</span>
+
+                <label for="{{ form.regex_field.auto_id }}">
+                    <span class="sr-only">{{ form.regex_field.label }}</span>
+                    {% render_field form.regex_field data-action="change->search#update" %}
+                </label>
+
+                {# Translators: Search submit button #}
+                <button type="submit" class="regex-submit"><span>{{ search_label }}</span></button>
+            </fieldset>
+        {% endif %}
         <div id="filters-header">
             <a href="#filters" role="button" id="filters-button" data-search-target="filtersButton" data-action="click->search#toggleFiltersOpen">
                 <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -93,7 +93,10 @@
                 {% if document_highlights.translation or document.translation %}
                     <div class="translation" lang="{{ lang }}" dir="{{ dir }}">
                         {% if document_highlights.translation %}
-                            {% for snippet in document_highlights.translation %}{{ snippet.strip|safe }}{% endfor %}
+                            {% for snippet in document_highlights.translation %}
+                                {% if snippet.label %}<span class="snippet-label">{{ snippet.label.strip|safe }}</span>{% endif %}
+                                {{ snippet.text.strip|safe }}{% if snippet.text.strip and not forloop.last %}<div class="separator">[…]</div>{% endif %}
+                            {% endfor %}
                         {% elif document.translation %}
                                 {# otherwise, display truncated transcription #}
                                 {# NOTE: might be nice to display N lines instead of using truncatechars #}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1183,7 +1183,7 @@ class TestDocument:
         Annotation.objects.create(
             footnote=digital_translation,
             content={
-                "body": [{"value": "translation lines"}],
+                "body": [{"value": "<ol><li>translation lines</li></ol>"}],
             },
         )
         # other footnotes
@@ -1206,7 +1206,11 @@ class TestDocument:
         assert index_data["has_digital_translation_b"] == True
         assert index_data["scholarship_count_i"] == 3  # unique sources
         assert index_data["text_transcription"] == ["transcrip[ti]on lines"]
-        assert index_data["text_translation"] == ["translation lines"]
+        assert index_data["text_translation"] == [
+            '<ol><li value="1">translation lines</li></ol>'
+        ]
+        assert str(source) in index_data["translation_regex_names_ss"]
+        assert index_data["translation_regex"] == ["translation lines"]
         assert index_data["translation_languages_ss"] == ["English"]
         assert index_data["translation_language_code_s"] == "en"
         assert index_data["translation_language_direction_s"] == "ltr"

--- a/geniza/corpus/tests/test_corpus_solrqueryset.py
+++ b/geniza/corpus/tests/test_corpus_solrqueryset.py
@@ -317,9 +317,9 @@ class TestDocumentSolrQuerySet:
             mock_get_highlighting.return_value = test_highlight
             # translation html should be cleaned
             cleaned_highlight = dqs.get_highlighting()
-            assert cleaned_highlight["doc.1"]["translation"] == [
-                clean_html("<li>bar baz")
-            ]
+            assert cleaned_highlight["doc.1"]["translation"][0]["text"] == clean_html(
+                "<li>bar baz"
+            )
 
     def test_get_highlighting__exact_search(self):
         dqs = DocumentSolrQuerySet()
@@ -433,16 +433,18 @@ class TestDocumentSolrQuerySet:
         dqs = DocumentSolrQuerySet()
         with patch.object(dqs, "search") as mocksearch:
             query = "six apartments"
-            dqs.regex_search(query)
+            field = "transcription_regex"
+            dqs.regex_search(field, query)
             # should surround with wildcards in order to match entire field,
             # and with slashes for Lucene regex syntax
-            mocksearch.assert_called_with(f"transcription_regex:/.*{query}.*/")
+            mocksearch.assert_called_with(f"{field}:/.*{query}.*/")
 
     def test_get_regex_highlight(self):
         dqs = DocumentSolrQuerySet()
-        dqs.search_qs = ["transcription_regex:/.*אלאחרף אן למא.*/"]
+        field = "transcription_regex"
+        dqs.search_qs = [f"{field}:/.*אלאחרף אן למא.*/"]
         # no match -> None
-        assert dqs.get_regex_highlight("test") == None
+        assert dqs.get_regex_highlight(field, "test") == None
         # use a bit of a real example, with > 300 characters, as a test
         text = """Recto:\n בש רח נקול נחן אלשהוד [אלוא]צעין כטוטנא תחת הדה אלאחרף אן למא אן כאן \
 יום אלסבת אלסאדס מן שהר אב יהפך לשמחה שנת אתקו לשטרות בעיר קליוב הסמוכה לעיר המלוכה הס[מו]כה \
@@ -450,7 +452,7 @@ class TestDocumentSolrQuerySet:
 יהי שמו לעולם אנא חצרנא פי אלמוצע אלדי יצלו פיה ענד מוסי ולד אלאהוב וכאן תם חאצר אהל קליוב שצ \
 //ביצלו// פחצר תם מן קאל להם אעלמו באן יצחק אלסקלי ביגתהד פי עודתה אליכם פאן כונתו פי נפסכם \
 מן מקאמה ענדכם דון """
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
 
         # should highlight the matched portion
         assert "<em>אלאחרף אן למא</em>" in highlight
@@ -464,20 +466,20 @@ class TestDocumentSolrQuerySet:
 
         # should support all regex syntax, such as . wildcard and + 1 or more characters
         dqs.search_qs = ["transcription_regex:/.*אלאחרף.+למא.*/"]
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
         assert "<em>אלאחרף אן למא</em>" in highlight
 
         # reserved characters should require escape characters for correct results
         dqs.search_qs = ["transcription_regex:/.*[אלוא]צעין.*/"]
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
         assert highlight is None
         dqs.search_qs = ["transcription_regex:/.*\[אלוא\]צעין.*/"]
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
         assert "<em>[אלוא]צעין</em>" in highlight
 
         # multiple matches for the query should be separated by line breaks and ellipsis
         dqs.search_qs = ["transcription_regex:/.*מן.*/"]
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
         separator = "<br />[…]<br />"
         assert separator in highlight
 
@@ -492,7 +494,7 @@ class TestDocumentSolrQuerySet:
 
         # multiple adjacent matches separated by space should get the .adjacent-em class
         dqs.search_qs = ["transcription_regex:/.*\w.*/"]
-        highlight = dqs.get_regex_highlight("test one two three")
+        highlight = dqs.get_regex_highlight(field, "test one two three")
         assert '</em> <em class="adjacent-em">' in highlight
 
         # matches like the "em" in <em> from the first round of highlighting should not match
@@ -500,7 +502,7 @@ class TestDocumentSolrQuerySet:
 
         # same with the "br" in <br />
         dqs.search_qs = ["transcription_regex:/.*(מן|\w).*/"]
-        highlight = dqs.get_regex_highlight(text)
+        highlight = dqs.get_regex_highlight(field, text)
         assert separator in highlight
         hl_snippets = highlight.split(separator)
         assert all(["<em>br</em>" not in snippet for snippet in hl_snippets])

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -391,36 +391,70 @@ class TestDocumentSearchView:
         # no params
         docsearch_view.request.GET = {}
         assert docsearch_view.get_form_kwargs() == {
-            "initial": {"mode": "general", "sort": "random"},
+            "initial": {
+                "mode": "general",
+                "sort": "random",
+                "regex_field": "transcription",
+            },
             "prefix": None,
-            "data": {"mode": "general", "sort": "random"},
+            "data": {
+                "mode": "general",
+                "sort": "random",
+                "regex_field": "transcription",
+            },
             "range_minmax": {},
         }
 
         # keyword search param
         docsearch_view.request.GET = {"q": "contract"}
         assert docsearch_view.get_form_kwargs() == {
-            "initial": {"mode": "general", "sort": "random"},
+            "initial": {
+                "mode": "general",
+                "sort": "random",
+                "regex_field": "transcription",
+            },
             "prefix": None,
-            "data": {"mode": "general", "q": "contract", "sort": "relevance"},
+            "data": {
+                "mode": "general",
+                "q": "contract",
+                "sort": "relevance",
+                "regex_field": "transcription",
+            },
             "range_minmax": {},
         }
 
         # sort search param
         docsearch_view.request.GET = {"sort": "scholarship_desc"}
         assert docsearch_view.get_form_kwargs() == {
-            "initial": {"mode": "general", "sort": "random"},
+            "initial": {
+                "mode": "general",
+                "sort": "random",
+                "regex_field": "transcription",
+            },
             "prefix": None,
-            "data": {"mode": "general", "sort": "scholarship_desc"},
+            "data": {
+                "mode": "general",
+                "sort": "scholarship_desc",
+                "regex_field": "transcription",
+            },
             "range_minmax": {},
         }
 
         # keyword and sort search params
         docsearch_view.request.GET = {"q": "contract", "sort": "scholarship_desc"}
         assert docsearch_view.get_form_kwargs() == {
-            "initial": {"mode": "general", "sort": "random"},
+            "initial": {
+                "mode": "general",
+                "sort": "random",
+                "regex_field": "transcription",
+            },
             "prefix": None,
-            "data": {"mode": "general", "q": "contract", "sort": "scholarship_desc"},
+            "data": {
+                "mode": "general",
+                "q": "contract",
+                "sort": "scholarship_desc",
+                "regex_field": "transcription",
+            },
             "range_minmax": {},
         }
 
@@ -531,7 +565,9 @@ class TestDocumentSearchView:
             docsearch_view.request.GET = {"q": "six apartments", "mode": "regex"}
             docsearch_view.get_queryset()
             mock_sqs = mock_queryset_cls.return_value
-            mock_sqs.regex_search.assert_called_with("six apartments")
+            mock_sqs.regex_search.assert_called_with(
+                "transcription_regex", "six apartments"
+            )
             mock_sqs.keyword_search.assert_not_called()
             # should not highlight with parasolr
             mock_sqs.regex_search.return_value.highlight.assert_not_called()

--- a/geniza/corpus/tests/test_forms.py
+++ b/geniza/corpus/tests/test_forms.py
@@ -122,6 +122,17 @@ class TestDocumentSearchForm:
         form = DocumentSearchForm(data)
         assert form.fields["translation_language"].disabled == False
 
+        # test placeholder update for regex
+        assert form.fields["q"].widget.attrs["placeholder"] == (
+            "Search all fields by keyword"
+        )
+
+        data = {"q": "illness", "mode": "regex"}
+        form = DocumentSearchForm(data)
+        assert form.fields["q"].widget.attrs["placeholder"] == (
+            "Search by regular expression"
+        )
+
     def test_choices_from_facets(self):
         """A facet dict should produce correct choice labels"""
         fake_facets = {

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -83,7 +83,7 @@ class DocumentSearchView(
     # Translators: description of document search page, for search engines
     page_description = _("Search and browse Geniza documents.")
     paginate_by = 50
-    initial = {"sort": "random", "mode": "general"}
+    initial = {"sort": "random", "mode": "general", "regex_field": "transcription"}
     # NOTE: does not filter on status, since changing status could modify the page
     solr_lastmodified_filters = {"item_type_s": "document"}
     applied_filter_labels = []
@@ -212,8 +212,9 @@ class DocumentSearchView(
             search_opts = form.cleaned_data
 
             if search_opts["q"] and search_opts["mode"] == "regex":
+                regex_field = f"{search_opts['regex_field'] or 'transcription'}_regex"
                 # use regex search if "mode" is "regex"
-                documents = documents.regex_search(search_opts["q"])
+                documents = documents.regex_search(regex_field, search_opts["q"])
 
             elif search_opts["q"]:
                 # NOTE: using requireFieldMatch so that field-specific search

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-01-29 10:50-0500\n"
+"POT-Creation-Date: 2025-04-03 12:07-0400\n"
 "PO-Revision-Date: 2025-01-29 17:57\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: ar\n"
@@ -28,7 +29,7 @@ msgid "Keyword or Phrase"
 msgstr "الكلمة المفتاحية أو العبارة"
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:226 entities/forms.py:211
+#: corpus/forms.py:226 entities/forms.py:214
 msgid "Relevance"
 msgstr "الصلة"
 
@@ -92,104 +93,132 @@ msgstr ""
 msgid "RegEx"
 msgstr ""
 
+#. Translators: label for transcription RegEx field
+#. Translators: label for "has transcription" search form filter
+#: corpus/forms.py:258 corpus/forms.py:304
+#: corpus/templates/corpus/snippets/document_transcription.html:66
+msgid "Transcription"
+msgstr "النصوص المفرّغة"
+
+#. Translators: label for description RegEx field
+#. Translators: label for document description
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+msgid "Description"
+msgstr "الوصف"
+
+#. Translators: label for translation RegEx field
+#. Translators: label for "has translation" search form filter
+#: corpus/forms.py:262 corpus/forms.py:308
+#: corpus/templates/corpus/snippets/document_transcription.html:71
+#: footnotes/models.py:508
+msgid "Translation"
+msgstr "الترجمة"
+
+#. Translators: label for shelfmark RegEx field
+#: corpus/forms.py:264 corpus/templates/corpus/document_detail.html:48
+msgid "Shelfmark"
+msgstr "علامة الرف"
+
 #. Translators: label for form sort field
-#: corpus/forms.py:262 entities/forms.py:228 entities/forms.py:349
+#: corpus/forms.py:273 entities/forms.py:231 entities/forms.py:352
 msgid "Sort by"
 msgstr "الترتيب حسب"
 
 #. Translators: label for filter documents by date range
 #. Translators: label for the dates of a person's appearances in PGP documents
 #. Translators: Person "dates of activity" column header on the browse page
-#: corpus/forms.py:269 entities/forms.py:207
+#: corpus/forms.py:280 entities/forms.py:210
 #: entities/templates/entities/person_detail.html:38
 #: entities/templates/entities/person_list.html:126
 msgid "Dates"
 msgstr ""
 
 #. Translators: label for "exclude inferred dates" search form filter
-#: corpus/forms.py:278
+#: corpus/forms.py:289
 msgid "Exclude inferred dates"
 msgstr ""
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:285
-#| msgid "Input date"
+#: corpus/forms.py:296
 msgid "Document type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:289 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
 
-#. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:293
-#: corpus/templates/corpus/snippets/document_transcription.html:66
-msgid "Transcription"
-msgstr "النصوص المفرّغة"
-
-#. Translators: label for "has translation" search form filter
-#: corpus/forms.py:297
-#: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:495
-msgid "Translation"
-msgstr "الترجمة"
-
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:301 footnotes/models.py:496
+#: corpus/forms.py:312 footnotes/models.py:509
 msgid "Discussion"
 msgstr "المناقشة"
 
 #. Translators: label for document translation language search form filter
-#: corpus/forms.py:305
+#: corpus/forms.py:316
 msgid "Translation language"
 msgstr ""
 
-#: corpus/forms.py:307
+#: corpus/forms.py:318
 msgid "All languages"
 msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
-#: corpus/forms.py:312
-#| msgid "Search Documents"
+#: corpus/forms.py:323
 msgid "Search mode"
 msgstr ""
 
+#: corpus/forms.py:330
+msgid "RegEx search field"
+msgstr ""
+
+#: corpus/forms.py:365
+msgid "Search by regular expression"
+msgstr ""
+
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:348 corpus/models.py:1005 corpus/solr_queryset.py:332
+#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: corpus/templates/corpus/snippets/document_transcription.html:242
 msgid "Unknown type"
 msgstr "نوع غير معروف"
 
-#: corpus/forms.py:395
+#: corpus/forms.py:420
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث بواسطة كلمة مفتاحية."
 
-#: corpus/forms.py:411
+#: corpus/forms.py:436
 #, python-format
-msgid "Regular expression cannot contain { without a preceding character, without an integer afterwards, or without a closing }. %s"
+msgid ""
+"Regular expression cannot contain { without a preceding character, without "
+"an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:420
+#: corpus/forms.py:445
 #, python-format
-msgid "Regular expression cannot contain * without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain * without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:429
+#: corpus/forms.py:454
 #, python-format
-msgid "Regular expression cannot contain + without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain + without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:438
+#: corpus/forms.py:463
 #, python-format
-msgid "Regular expression cannot contain < or use a negative lookbehind query. %s"
+msgid ""
+"Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:448
+#: corpus/forms.py:473
 #, python-format
-msgid "Regular expression cannot contain the escape character \\ followed by an alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgid ""
+"Regular expression cannot contain the escape character \\ followed by an "
+"alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
 #: corpus/models.py:1128 templates/base.html:21
@@ -246,10 +275,6 @@ msgstr[5] "المحررون"
 #: entities/templates/entities/place_detail.html:53
 msgid "Metadata"
 msgstr "بيانات التعريف"
-
-#: corpus/templates/corpus/document_detail.html:48
-msgid "Shelfmark"
-msgstr "علامة الرف"
 
 #. Translators: label for date of this document, if known
 #: corpus/templates/corpus/document_detail.html:56
@@ -316,19 +341,14 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:145
-msgid "Description"
-msgstr "الوصف"
-
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
 #: corpus/templates/corpus/document_detail.html:153
-#: corpus/templates/corpus/snippets/document_result.html:108
-#: entities/forms.py:221 entities/forms.py:344
-#: entities/templates/entities/person_list.html:190
-#: entities/templates/entities/place_list.html:80
+#: corpus/templates/corpus/snippets/document_result.html:113
+#: entities/forms.py:224 entities/forms.py:347
+#: entities/templates/entities/person_list.html:192
+#: entities/templates/entities/place_list.html:103
 #: entities/templates/entities/place_related_people.html:28
 msgid "Related People"
 msgstr ""
@@ -338,16 +358,18 @@ msgstr ""
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
 #: corpus/templates/corpus/document_detail.html:172
-#: corpus/templates/corpus/snippets/document_result.html:112
-#: entities/forms.py:223 entities/templates/entities/person_list.html:194
+#: corpus/templates/corpus/snippets/document_result.html:117
+#: entities/forms.py:226 entities/templates/entities/person_list.html:196
 #: entities/templates/entities/person_related_places.html:56
 #: entities/templates/entities/place_detail.html:93
 msgid "Related Places"
 msgstr ""
 
 #. Translators: label for tags on a document
+#. Translators: Person "tags" column header on the browse page
 #: corpus/templates/corpus/document_detail.html:190
-#: corpus/templates/corpus/snippets/document_result.html:125
+#: corpus/templates/corpus/snippets/document_result.html:130
+#: entities/templates/entities/person_list.html:132
 msgid "Tags"
 msgstr "العلامات"
 
@@ -380,7 +402,8 @@ msgstr "تاريخ الإدخال"
 #. Translators: Date document was first added to the PGP
 #: corpus/templates/corpus/document_detail.html:234
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    In PGP since %(date)s\n"
 "                "
 msgstr ""
@@ -411,58 +434,70 @@ msgstr ""
 msgid "Permalink"
 msgstr "رابط دائم"
 
-#: corpus/templates/corpus/document_list.html:15
+#: corpus/templates/corpus/document_list.html:16
 msgid "How to Search"
 msgstr ""
 
 #. Translators: accessibility label for button to close search mode help dialog
-#: corpus/templates/corpus/document_list.html:18
+#: corpus/templates/corpus/document_list.html:19
 msgid "Close search mode help"
 msgstr ""
 
 #. Translators: accessibility label for button to open search mode help dialog
-#: corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:26
 msgid "Open search mode help"
 msgstr ""
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:31
-#: entities/templates/entities/person_list.html:15
-msgid "Submit search"
-msgstr "إرسال البحث"
+#: corpus/templates/corpus/document_list.html:31 templates/snippets/menu.html:4
+msgid "Search"
+msgstr "بحث"
 
-#: corpus/templates/corpus/document_list.html:37
-#: corpus/templates/corpus/document_list.html:64
+#: corpus/templates/corpus/document_list.html:47
+msgid "in"
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:59
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
+"                            even if part of a join, for best results.\n"
+"                        "
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:70
+#: corpus/templates/corpus/document_list.html:97
 #: entities/templates/entities/person_list.html:29
 #: entities/templates/entities/person_list.html:56
 msgid "Filters"
 msgstr "عوامل التصفية"
 
 #. Translators: label for button to clear all applied filters
-#: corpus/templates/corpus/document_list.html:58
+#: corpus/templates/corpus/document_list.html:91
 #: entities/templates/entities/person_list.html:50
 msgid "Clear all"
 msgstr ""
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:67
+#: corpus/templates/corpus/document_list.html:100
 #: entities/templates/entities/person_list.html:59
 msgid "Close filter options"
 msgstr "إغلاق خيارات التصفية"
 
-#: corpus/templates/corpus/document_list.html:83
+#: corpus/templates/corpus/document_list.html:116
 msgid "Includes"
 msgstr ""
 
 #. Translators: search results section header
-#: corpus/templates/corpus/document_list.html:135
+#: corpus/templates/corpus/document_list.html:168
 #: entities/templates/entities/person_list.html:93
 msgid "Results"
 msgstr ""
 
 #. Translators: number of search results
 #. Translators: number of results
-#: corpus/templates/corpus/document_list.html:139
+#: corpus/templates/corpus/document_list.html:172
 #: entities/templates/entities/person_list.html:97
 #, python-format
 msgid "1 result"
@@ -474,7 +509,7 @@ msgstr[3] "%(count_humanized)s نتائج"
 msgstr[4] "%(count_humanized)s نتائج"
 msgstr[5] "%(count_humanized)s مجموع النتائج"
 
-#: corpus/templates/corpus/document_list.html:163
+#: corpus/templates/corpus/document_list.html:196
 msgid "View results in the Arabic Papyrology Database"
 msgstr ""
 
@@ -515,13 +550,11 @@ msgid "Jewish Theological Seminary logo"
 msgstr "شعار Jewish Theological Seminary"
 
 #: corpus/templates/corpus/snippets/document_result.html:23
-#| msgid "Input date"
 msgid "Document date"
 msgstr ""
 
 #. Translators: label for inferred date on a document
 #: corpus/templates/corpus/snippets/document_result.html:33
-#| msgid "Input date"
 msgid "Inferred date"
 msgstr ""
 
@@ -537,21 +570,20 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: label for sort by number of related documents
-#: corpus/templates/corpus/snippets/document_result.html:116
-#: entities/forms.py:219 entities/forms.py:342
-#: entities/templates/entities/person_list.html:186
-#: entities/templates/entities/place_list.html:75
-#| msgid "Search Documents"
+#: corpus/templates/corpus/snippets/document_result.html:121
+#: entities/forms.py:222 entities/forms.py:345
+#: entities/templates/entities/person_list.html:188
+#: entities/templates/entities/place_list.html:98
 msgid "Related Documents"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:132
-#: entities/templates/entities/person_list.html:180
+#: corpus/templates/corpus/snippets/document_result.html:137
+#: entities/templates/entities/person_list.html:182
 msgid "more"
 msgstr "المزيد"
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:144
+#: corpus/templates/corpus/snippets/document_result.html:149
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -563,7 +595,7 @@ msgstr[4] "%(counter)s نسخ"
 msgstr[5] "%(counter)s نسخ"
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:154
+#: corpus/templates/corpus/snippets/document_result.html:159
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -575,7 +607,7 @@ msgstr[4] "%(counter)s ترجمات"
 msgstr[5] "%(counter)s ترجمات"
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:164
+#: corpus/templates/corpus/snippets/document_result.html:169
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -586,38 +618,38 @@ msgstr[3] "%(counter)s مناقشات"
 msgstr[4] "%(counter)s مناقشات"
 msgstr[5] "%(counter)s مناقشات"
 
-#: corpus/templates/corpus/snippets/document_result.html:172
+#: corpus/templates/corpus/snippets/document_result.html:177
 msgid "No Scholarship Records"
 msgstr "لا توجد ثبت المراجع والمصادر"
 
 #. Translators: label for when no image thumbnail is available
-#: corpus/templates/corpus/snippets/document_result.html:193
+#: corpus/templates/corpus/snippets/document_result.html:198
 #: entities/templates/entities/snippets/related_documents_table.html:45
 msgid "No Image"
 msgstr ""
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:197
+#: corpus/templates/corpus/snippets/document_result.html:202
 msgid "In PGP since"
 msgstr "في PGP منذ"
 
 #. Translators: label for unknown date for date added to PGP
-#: corpus/templates/corpus/snippets/document_result.html:199
+#: corpus/templates/corpus/snippets/document_result.html:204
 msgid "unknown"
 msgstr ""
 
 #. Translators: label for historical/old shelfmark on document fragments
-#: corpus/templates/corpus/snippets/document_result.html:209
+#: corpus/templates/corpus/snippets/document_result.html:214
 msgid "Historical shelfmark"
 msgstr ""
 
 #. Translators: screen-reader label for "view document details" link
-#: corpus/templates/corpus/snippets/document_result.html:219
+#: corpus/templates/corpus/snippets/document_result.html:224
 #, python-format
 msgid "View details for %(document_label)s"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:221
+#: corpus/templates/corpus/snippets/document_result.html:226
 msgid "View document details"
 msgstr "عرض تفاصيل المستند"
 
@@ -628,8 +660,10 @@ msgstr ""
 
 #. Translators: general search help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:7
-msgid "\n"
-"        Use keywords or phrases in any language to return matching or similar\n"
+msgid ""
+"\n"
+"        Use keywords or phrases in any language to return matching or "
+"similar\n"
 "        results across all fields. Arabic script searches will return both\n"
 "        Arabic and Judaeo-Arabic transcription content.\n"
 "    "
@@ -643,7 +677,8 @@ msgstr ""
 #. Translators: regular expressions search mode help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:18
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "        Use Hebrew or Arabic script to find precise matches in the\n"
 "        transcriptions. See\n"
 "        <a data-turbo=\"false\" href=\"%(howto_url)s\">How to Search</a>\n"
@@ -658,10 +693,13 @@ msgstr ""
 
 #. Translators: regular expression tip 1
 #: corpus/templates/corpus/snippets/document_search_helptext.html:31
-msgid "\n"
+msgid ""
+"\n"
 "            If you're looking for a word with one missing letter, use a\n"
-"            period. Two missing letters, use two periods or <code>{2}</code>.\n"
-"            Increase the number in the curly brackets to increase the number of\n"
+"            period. Two missing letters, use two periods or <code>{2}</"
+"code>.\n"
+"            Increase the number in the curly brackets to increase the number "
+"of\n"
 "            characters, or insert a range with a comma in between, ex.\n"
 "            <code>{0,5}</code>.\n"
 "        "
@@ -669,7 +707,8 @@ msgstr ""
 
 #. Translators: regular expression tip 2
 #: corpus/templates/corpus/snippets/document_search_helptext.html:41
-msgid "\n"
+msgid ""
+"\n"
 "            If you don't know how many characters are missing, use\n"
 "            <code>.*</code>.\n"
 "        "
@@ -677,8 +716,10 @@ msgstr ""
 
 #. Translators: regular expression tip 3
 #: corpus/templates/corpus/snippets/document_search_helptext.html:48
-msgid "\n"
-"            If you know which characters you want, use square brackets to find\n"
+msgid ""
+"\n"
+"            If you know which characters you want, use square brackets to "
+"find\n"
 "            multiple spellings, ex. <code>[יו]</code> for yud or vav.\n"
 "        "
 msgstr ""
@@ -761,7 +802,7 @@ msgstr[5] ""
 msgid "Zoom and Rotate"
 msgstr "تكبير و تدوير"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:246
+#: corpus/templates/corpus/snippets/document_transcription.html:245
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "عرض %(related_doc)s"
@@ -795,7 +836,6 @@ msgstr "التالي"
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
 #: corpus/views.py:82 templates/snippets/menu.html:11
-#| msgid "Input date"
 msgid "Documents"
 msgstr "وثائق"
 
@@ -804,27 +844,29 @@ msgstr "وثائق"
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
-#: corpus/views.py:326 entities/views.py:721
+#: corpus/views.py:332 entities/views.py:739
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:328 entities/views.py:723
+#: corpus/views.py:334 entities/views.py:741
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:399
-msgid "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
+#: corpus/views.py:405
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:531
+#: corpus/views.py:540
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "منحة في %(doc)s"
 
-#: corpus/views.py:538
+#: corpus/views.py:547
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -836,12 +878,12 @@ msgstr[4] "%(count)d سجلات منح دراسية"
 msgstr[5] "%(count)d سجلات منح دراسية"
 
 #. Translators: title of related documents page
-#: corpus/views.py:579
+#: corpus/views.py:588
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "المستندات ذات الصلة لـ %(doc)s"
 
-#: corpus/views.py:586 entities/views.py:317
+#: corpus/views.py:595 entities/views.py:335
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -853,34 +895,34 @@ msgstr[4] "%(count)d مستندات ذات صلة"
 msgstr[5] "%(count)d مستندات ذات صلة"
 
 #. Translators: placeholder for people keyword search input
-#: entities/forms.py:195
+#: entities/forms.py:198
 msgid "Search for people by name"
 msgstr ""
 
 #. Translators: accessible label for people keyword search input
-#: entities/forms.py:197
+#: entities/forms.py:200
 msgid "word or phrase"
 msgstr ""
 
 #. Translators: label for a person's gender
 #. Translators: Person "gender" column header on the browse page
-#: entities/forms.py:202 entities/templates/entities/person_detail.html:34
+#: entities/forms.py:205 entities/templates/entities/person_detail.html:34
 #: entities/templates/entities/person_list.html:124
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:203 entities/views.py:737
+#: entities/forms.py:206 entities/views.py:755
 msgid "Detail page available"
 msgstr ""
 
 #. Translators: Label for a person's social role
 #. Translators: Person "social role" column header on the browse page
-#: entities/forms.py:204 entities/templates/entities/person_detail.html:57
+#: entities/forms.py:207 entities/templates/entities/person_detail.html:57
 #: entities/templates/entities/person_list.html:128
 msgid "Social role"
 msgstr ""
 
-#: entities/forms.py:205
+#: entities/forms.py:208
 msgid "Relation to documents"
 msgstr ""
 
@@ -889,34 +931,34 @@ msgstr ""
 #. Translators: table header for person name
 #. Translators: table header for place name
 #. Translators: table header for person name
-#: entities/forms.py:213 entities/forms.py:340
+#: entities/forms.py:216 entities/forms.py:343
 #: entities/templates/entities/person_list.html:120
 #: entities/templates/entities/person_related_people.html:35
 #: entities/templates/entities/person_related_places.html:65
-#: entities/templates/entities/place_list.html:57
+#: entities/templates/entities/place_list.html:80
 #: entities/templates/entities/place_related_people.html:37
 msgid "Name"
 msgstr ""
 
 #. Translators: label for sort by person activity dates
 #. Translators: table header for document date
-#: entities/forms.py:215
+#: entities/forms.py:218
 #: entities/templates/entities/snippets/related_documents_table.html:31
 msgid "Date"
 msgstr ""
 
 #. Translators: label for sort by social role
-#: entities/forms.py:217
+#: entities/forms.py:220
 msgid "Social Role"
 msgstr ""
 
 #. Translators: label for ascending sort
-#: entities/forms.py:236 entities/forms.py:357
+#: entities/forms.py:239 entities/forms.py:360
 msgid "Ascending"
 msgstr ""
 
 #. Translators: label for descending sort
-#: entities/forms.py:238 entities/forms.py:359
+#: entities/forms.py:241 entities/forms.py:362
 msgid "Descending"
 msgstr ""
 
@@ -932,23 +974,23 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1220
+#: entities/models.py:1224
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1221
+#: entities/models.py:1225
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1222
+#: entities/models.py:1226
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1223
+#: entities/models.py:1227
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1224
+#: entities/models.py:1228
 msgid "Ambiguity"
 msgstr ""
 
@@ -997,6 +1039,11 @@ msgstr ""
 msgid "Link to this person:"
 msgstr ""
 
+#. Translators: Search submit button
+#: entities/templates/entities/person_list.html:15
+msgid "Submit search"
+msgstr "إرسال البحث"
+
 #. Translators: label for people browse page list view
 #: entities/templates/entities/person_list.html:21
 msgid "Toggle list view"
@@ -1008,35 +1055,36 @@ msgstr ""
 
 #. Translators: Person "other names" column header on the browse page
 #: entities/templates/entities/person_list.html:122
-#: entities/templates/entities/place_list.html:66
+#: entities/templates/entities/place_list.html:89
 msgid "Other names"
 msgstr ""
 
 #. Translators: Person "document count" column header on the browse page
 #. Translators: table header for count of shared documents between people
-#: entities/templates/entities/person_list.html:133
+#: entities/templates/entities/person_list.html:135
 #: entities/templates/entities/person_related_people.html:49
 msgid "Number of related documents"
 msgstr ""
 
 #. Translators: Person "related people count" column header on the browse page
-#: entities/templates/entities/person_list.html:137
+#: entities/templates/entities/person_list.html:139
 msgid "Number of related people"
 msgstr ""
 
 #. Translators: Person "related place count" column header on the browse page
-#: entities/templates/entities/person_list.html:141
+#: entities/templates/entities/person_list.html:143
 msgid "Number of related places"
 msgstr ""
 
-#: entities/templates/entities/person_list.html:159
+#: entities/templates/entities/person_list.html:161
 msgid "Also known as: "
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/person_list.html:205
+#: entities/templates/entities/person_list.html:207
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "        "
 msgstr ""
@@ -1063,7 +1111,7 @@ msgstr ""
 #. Translators: label for Places map mode button on mobile devices
 #: entities/templates/entities/person_related_places.html:31
 #: entities/templates/entities/place_detail.html:32
-#: entities/templates/entities/place_list.html:101
+#: entities/templates/entities/place_list.html:124
 msgid "Map"
 msgstr ""
 
@@ -1072,26 +1120,45 @@ msgstr ""
 msgid "Coordinates"
 msgstr ""
 
+#: entities/templates/entities/place_list.html:22
+msgid "Map pin icon for regions"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:27
+msgid "Region"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:30
+msgid "Map pin icon for other places"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:35
+#, fuzzy
+#| msgid "Places"
+msgid "Place"
+msgstr "أَماكِن"
+
 #. Translators: accessible label for section showing place metadata, names
-#: entities/templates/entities/place_list.html:56
+#: entities/templates/entities/place_list.html:79
 msgid "metadata"
 msgstr ""
 
 #. Translators: accessible label for section showing counts of entries related to an entity
-#: entities/templates/entities/place_list.html:73
+#: entities/templates/entities/place_list.html:96
 msgid "Related entries"
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/place_list.html:90
+#: entities/templates/entities/place_list.html:113
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "                "
 msgstr ""
 
 #. Translators: label for Places list mode button on mobile devices
-#: entities/templates/entities/place_list.html:99
+#: entities/templates/entities/place_list.html:122
 msgid "List"
 msgstr ""
 
@@ -1133,7 +1200,6 @@ msgstr ""
 
 #. Translators: table header for document name (shelfmark)
 #: entities/templates/entities/snippets/related_documents_table.html:10
-#| msgid "Input date"
 msgid "Document"
 msgstr ""
 
@@ -1143,18 +1209,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:309
+#: entities/views.py:327
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:399
+#: entities/views.py:417
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:407 entities/views.py:477
+#: entities/views.py:425 entities/views.py:495
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1166,12 +1232,12 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:536
+#: entities/views.py:554
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:544
+#: entities/views.py:562
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1184,44 +1250,46 @@ msgstr[5] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:649 templates/snippets/menu.html:19
+#: entities/views.py:667 templates/snippets/menu.html:19
 msgid "People"
 msgstr "اشخاص"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:651
+#: entities/views.py:669
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:827 templates/snippets/menu.html:26
+#: entities/views.py:845 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "أَماكِن"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:829
+#: entities/views.py:847
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
-#. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:259
-msgid "[digital geniza document edition]"
-msgstr "[طبعة وثيقة جينيزا رقمية]"
-
-#: footnotes/models.py:494
+#: footnotes/models.py:507
 msgid "Edition"
 msgstr "الطبعة"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "نص بديل للمستخدمين ضعاف البصر\n"
+msgstr ""
+"نص بديل للمستخدمين ضعاف البصر\n"
 "لإيصال الرسالة المقصودة للصورة في هذا السياق بإيجاز."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار الرئيسية من الرسوم. يسمح بفقرات متعددة."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار "
+"الرئيسية من الرسوم. يسمح بفقرات متعددة."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -1342,10 +1410,6 @@ msgstr "الصفحة الرئيسية لـ Princeton Center for Digital Humaniti
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "قراءة هذه الصفحة في %(language_name)s (%(language_code)s)"
 
-#: templates/snippets/menu.html:4
-msgid "Search"
-msgstr "بحث"
-
 #. Translators: label for main menu back button for mobile navigation
 #: templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
@@ -1356,3 +1420,5 @@ msgstr "العودة إلى القائمة الرئيسية"
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
 
+#~ msgid "[digital geniza document edition]"
+#~ msgstr "[طبعة وثيقة جينيزا رقمية]"

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-01-29 10:50-0500\n"
+"POT-Creation-Date: 2025-04-03 12:07-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -28,7 +28,7 @@ msgid "Keyword or Phrase"
 msgstr ""
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:226 entities/forms.py:211
+#: corpus/forms.py:226 entities/forms.py:214
 msgid "Relevance"
 msgstr ""
 
@@ -92,111 +92,132 @@ msgstr ""
 msgid "RegEx"
 msgstr ""
 
+#. Translators: label for transcription RegEx field
+#. Translators: label for "has transcription" search form filter
+#: corpus/forms.py:258 corpus/forms.py:304
+#: corpus/templates/corpus/snippets/document_transcription.html:66
+msgid "Transcription"
+msgstr ""
+
+#. Translators: label for description RegEx field
+#. Translators: label for document description
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+msgid "Description"
+msgstr ""
+
+#. Translators: label for translation RegEx field
+#. Translators: label for "has translation" search form filter
+#: corpus/forms.py:262 corpus/forms.py:308
+#: corpus/templates/corpus/snippets/document_transcription.html:71
+#: footnotes/models.py:508
+msgid "Translation"
+msgstr ""
+
+#. Translators: label for shelfmark RegEx field
+#: corpus/forms.py:264 corpus/templates/corpus/document_detail.html:48
+msgid "Shelfmark"
+msgstr ""
+
 #. Translators: label for form sort field
-#: corpus/forms.py:262 entities/forms.py:228 entities/forms.py:349
+#: corpus/forms.py:273 entities/forms.py:231 entities/forms.py:352
 msgid "Sort by"
 msgstr ""
 
 #. Translators: label for filter documents by date range
 #. Translators: label for the dates of a person's appearances in PGP documents
 #. Translators: Person "dates of activity" column header on the browse page
-#: corpus/forms.py:269 entities/forms.py:207
+#: corpus/forms.py:280 entities/forms.py:210
 #: entities/templates/entities/person_detail.html:38
 #: entities/templates/entities/person_list.html:126
 msgid "Dates"
 msgstr ""
 
 #. Translators: label for "exclude inferred dates" search form filter
-#: corpus/forms.py:278
+#: corpus/forms.py:289
 msgid "Exclude inferred dates"
 msgstr ""
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:285
+#: corpus/forms.py:296
 #, fuzzy
 #| msgid "Input date"
 msgid "Document type"
 msgstr "Input date"
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:289 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
 
-#. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:293
-#: corpus/templates/corpus/snippets/document_transcription.html:66
-msgid "Transcription"
-msgstr ""
-
-#. Translators: label for "has translation" search form filter
-#: corpus/forms.py:297
-#: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:495
-msgid "Translation"
-msgstr ""
-
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:301 footnotes/models.py:496
+#: corpus/forms.py:312 footnotes/models.py:509
 msgid "Discussion"
 msgstr ""
 
 #. Translators: label for document translation language search form filter
-#: corpus/forms.py:305
+#: corpus/forms.py:316
 msgid "Translation language"
 msgstr ""
 
-#: corpus/forms.py:307
+#: corpus/forms.py:318
 msgid "All languages"
 msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
-#: corpus/forms.py:312
+#: corpus/forms.py:323
 #, fuzzy
 #| msgid "Search Documents"
 msgid "Search mode"
 msgstr "Search Documents"
 
+#: corpus/forms.py:330
+msgid "RegEx search field"
+msgstr ""
+
+#: corpus/forms.py:365
+msgid "Search by regular expression"
+msgstr ""
+
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:348 corpus/models.py:1005 corpus/solr_queryset.py:332
+#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: corpus/templates/corpus/snippets/document_transcription.html:242
 msgid "Unknown type"
 msgstr ""
 
-#: corpus/forms.py:395
+#: corpus/forms.py:420
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
-#: corpus/forms.py:411
+#: corpus/forms.py:436
 #, python-format
 msgid ""
 "Regular expression cannot contain { without a preceding character, without "
 "an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:420
+#: corpus/forms.py:445
 #, python-format
 msgid ""
 "Regular expression cannot contain * without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:429
+#: corpus/forms.py:454
 #, python-format
 msgid ""
 "Regular expression cannot contain + without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:438
+#: corpus/forms.py:463
 #, python-format
 msgid ""
 "Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:448
+#: corpus/forms.py:473
 #, python-format
 msgid ""
 "Regular expression cannot contain the escape character \\ followed by an "
@@ -250,10 +271,6 @@ msgstr[1] ""
 msgid "Metadata"
 msgstr ""
 
-#: corpus/templates/corpus/document_detail.html:48
-msgid "Shelfmark"
-msgstr ""
-
 #. Translators: label for date of this document, if known
 #: corpus/templates/corpus/document_detail.html:56
 msgid "Document Date"
@@ -299,19 +316,14 @@ msgid_plural "%(n_translations)s Translations"
 msgstr[0] ""
 msgstr[1] ""
 
-#. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:145
-msgid "Description"
-msgstr ""
-
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
 #: corpus/templates/corpus/document_detail.html:153
-#: corpus/templates/corpus/snippets/document_result.html:108
-#: entities/forms.py:221 entities/forms.py:344
-#: entities/templates/entities/person_list.html:190
-#: entities/templates/entities/place_list.html:80
+#: corpus/templates/corpus/snippets/document_result.html:113
+#: entities/forms.py:224 entities/forms.py:347
+#: entities/templates/entities/person_list.html:192
+#: entities/templates/entities/place_list.html:103
 #: entities/templates/entities/place_related_people.html:28
 msgid "Related People"
 msgstr ""
@@ -321,16 +333,18 @@ msgstr ""
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
 #: corpus/templates/corpus/document_detail.html:172
-#: corpus/templates/corpus/snippets/document_result.html:112
-#: entities/forms.py:223 entities/templates/entities/person_list.html:194
+#: corpus/templates/corpus/snippets/document_result.html:117
+#: entities/forms.py:226 entities/templates/entities/person_list.html:196
 #: entities/templates/entities/person_related_places.html:56
 #: entities/templates/entities/place_detail.html:93
 msgid "Related Places"
 msgstr ""
 
 #. Translators: label for tags on a document
+#. Translators: Person "tags" column header on the browse page
 #: corpus/templates/corpus/document_detail.html:190
-#: corpus/templates/corpus/snippets/document_result.html:125
+#: corpus/templates/corpus/snippets/document_result.html:130
+#: entities/templates/entities/person_list.html:132
 msgid "Tags"
 msgstr ""
 
@@ -391,58 +405,70 @@ msgstr ""
 msgid "Permalink"
 msgstr ""
 
-#: corpus/templates/corpus/document_list.html:15
+#: corpus/templates/corpus/document_list.html:16
 msgid "How to Search"
 msgstr ""
 
 #. Translators: accessibility label for button to close search mode help dialog
-#: corpus/templates/corpus/document_list.html:18
+#: corpus/templates/corpus/document_list.html:19
 msgid "Close search mode help"
 msgstr ""
 
 #. Translators: accessibility label for button to open search mode help dialog
-#: corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:26
 msgid "Open search mode help"
 msgstr ""
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:31
-#: entities/templates/entities/person_list.html:15
-msgid "Submit search"
+#: corpus/templates/corpus/document_list.html:31 templates/snippets/menu.html:4
+msgid "Search"
 msgstr ""
 
-#: corpus/templates/corpus/document_list.html:37
-#: corpus/templates/corpus/document_list.html:64
+#: corpus/templates/corpus/document_list.html:47
+msgid "in"
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:59
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
+"                            even if part of a join, for best results.\n"
+"                        "
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:70
+#: corpus/templates/corpus/document_list.html:97
 #: entities/templates/entities/person_list.html:29
 #: entities/templates/entities/person_list.html:56
 msgid "Filters"
 msgstr ""
 
 #. Translators: label for button to clear all applied filters
-#: corpus/templates/corpus/document_list.html:58
+#: corpus/templates/corpus/document_list.html:91
 #: entities/templates/entities/person_list.html:50
 msgid "Clear all"
 msgstr ""
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:67
+#: corpus/templates/corpus/document_list.html:100
 #: entities/templates/entities/person_list.html:59
 msgid "Close filter options"
 msgstr ""
 
-#: corpus/templates/corpus/document_list.html:83
+#: corpus/templates/corpus/document_list.html:116
 msgid "Includes"
 msgstr ""
 
 #. Translators: search results section header
-#: corpus/templates/corpus/document_list.html:135
+#: corpus/templates/corpus/document_list.html:168
 #: entities/templates/entities/person_list.html:93
 msgid "Results"
 msgstr ""
 
 #. Translators: number of search results
 #. Translators: number of results
-#: corpus/templates/corpus/document_list.html:139
+#: corpus/templates/corpus/document_list.html:172
 #: entities/templates/entities/person_list.html:97
 #, python-format
 msgid "1 result"
@@ -450,7 +476,7 @@ msgid_plural "%(count_humanized)s results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: corpus/templates/corpus/document_list.html:163
+#: corpus/templates/corpus/document_list.html:196
 msgid "View results in the Arabic Papyrology Database"
 msgstr ""
 
@@ -511,22 +537,22 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for sort by number of related documents
-#: corpus/templates/corpus/snippets/document_result.html:116
-#: entities/forms.py:219 entities/forms.py:342
-#: entities/templates/entities/person_list.html:186
-#: entities/templates/entities/place_list.html:75
+#: corpus/templates/corpus/snippets/document_result.html:121
+#: entities/forms.py:222 entities/forms.py:345
+#: entities/templates/entities/person_list.html:188
+#: entities/templates/entities/place_list.html:98
 #, fuzzy
 #| msgid "Search Documents"
 msgid "Related Documents"
 msgstr "Search Documents"
 
-#: corpus/templates/corpus/snippets/document_result.html:132
-#: entities/templates/entities/person_list.html:180
+#: corpus/templates/corpus/snippets/document_result.html:137
+#: entities/templates/entities/person_list.html:182
 msgid "more"
 msgstr ""
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:144
+#: corpus/templates/corpus/snippets/document_result.html:149
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -534,7 +560,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:154
+#: corpus/templates/corpus/snippets/document_result.html:159
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -542,45 +568,45 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:164
+#: corpus/templates/corpus/snippets/document_result.html:169
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: corpus/templates/corpus/snippets/document_result.html:172
+#: corpus/templates/corpus/snippets/document_result.html:177
 msgid "No Scholarship Records"
 msgstr ""
 
 #. Translators: label for when no image thumbnail is available
-#: corpus/templates/corpus/snippets/document_result.html:193
+#: corpus/templates/corpus/snippets/document_result.html:198
 #: entities/templates/entities/snippets/related_documents_table.html:45
 msgid "No Image"
 msgstr ""
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:197
+#: corpus/templates/corpus/snippets/document_result.html:202
 msgid "In PGP since"
 msgstr ""
 
 #. Translators: label for unknown date for date added to PGP
-#: corpus/templates/corpus/snippets/document_result.html:199
+#: corpus/templates/corpus/snippets/document_result.html:204
 msgid "unknown"
 msgstr ""
 
 #. Translators: label for historical/old shelfmark on document fragments
-#: corpus/templates/corpus/snippets/document_result.html:209
+#: corpus/templates/corpus/snippets/document_result.html:214
 msgid "Historical shelfmark"
 msgstr ""
 
 #. Translators: screen-reader label for "view document details" link
-#: corpus/templates/corpus/snippets/document_result.html:219
+#: corpus/templates/corpus/snippets/document_result.html:224
 #, python-format
 msgid "View details for %(document_label)s"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:221
+#: corpus/templates/corpus/snippets/document_result.html:226
 msgid "View document details"
 msgstr ""
 
@@ -725,7 +751,7 @@ msgstr[1] ""
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:246
+#: corpus/templates/corpus/snippets/document_transcription.html:245
 #, python-format
 msgid "View %(related_doc)s"
 msgstr ""
@@ -769,29 +795,29 @@ msgstr "Input date"
 msgid "Search and browse Geniza documents."
 msgstr ""
 
-#: corpus/views.py:326 entities/views.py:721
+#: corpus/views.py:332 entities/views.py:739
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:328 entities/views.py:723
+#: corpus/views.py:334 entities/views.py:741
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:399
+#: corpus/views.py:405
 msgid ""
 "Error retrieving search results. Check regular expression for errors such as "
 "unescaped or unclosed brackets or parentheses."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:531
+#: corpus/views.py:540
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr ""
 
-#: corpus/views.py:538
+#: corpus/views.py:547
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -799,12 +825,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of related documents page
-#: corpus/views.py:579
+#: corpus/views.py:588
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr ""
 
-#: corpus/views.py:586 entities/views.py:317
+#: corpus/views.py:595 entities/views.py:335
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -812,34 +838,34 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: placeholder for people keyword search input
-#: entities/forms.py:195
+#: entities/forms.py:198
 msgid "Search for people by name"
 msgstr ""
 
 #. Translators: accessible label for people keyword search input
-#: entities/forms.py:197
+#: entities/forms.py:200
 msgid "word or phrase"
 msgstr ""
 
 #. Translators: label for a person's gender
 #. Translators: Person "gender" column header on the browse page
-#: entities/forms.py:202 entities/templates/entities/person_detail.html:34
+#: entities/forms.py:205 entities/templates/entities/person_detail.html:34
 #: entities/templates/entities/person_list.html:124
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:203 entities/views.py:737
+#: entities/forms.py:206 entities/views.py:755
 msgid "Detail page available"
 msgstr ""
 
 #. Translators: Label for a person's social role
 #. Translators: Person "social role" column header on the browse page
-#: entities/forms.py:204 entities/templates/entities/person_detail.html:57
+#: entities/forms.py:207 entities/templates/entities/person_detail.html:57
 #: entities/templates/entities/person_list.html:128
 msgid "Social role"
 msgstr ""
 
-#: entities/forms.py:205
+#: entities/forms.py:208
 msgid "Relation to documents"
 msgstr ""
 
@@ -848,34 +874,34 @@ msgstr ""
 #. Translators: table header for person name
 #. Translators: table header for place name
 #. Translators: table header for person name
-#: entities/forms.py:213 entities/forms.py:340
+#: entities/forms.py:216 entities/forms.py:343
 #: entities/templates/entities/person_list.html:120
 #: entities/templates/entities/person_related_people.html:35
 #: entities/templates/entities/person_related_places.html:65
-#: entities/templates/entities/place_list.html:57
+#: entities/templates/entities/place_list.html:80
 #: entities/templates/entities/place_related_people.html:37
 msgid "Name"
 msgstr ""
 
 #. Translators: label for sort by person activity dates
 #. Translators: table header for document date
-#: entities/forms.py:215
+#: entities/forms.py:218
 #: entities/templates/entities/snippets/related_documents_table.html:31
 msgid "Date"
 msgstr ""
 
 #. Translators: label for sort by social role
-#: entities/forms.py:217
+#: entities/forms.py:220
 msgid "Social Role"
 msgstr ""
 
 #. Translators: label for ascending sort
-#: entities/forms.py:236 entities/forms.py:357
+#: entities/forms.py:239 entities/forms.py:360
 msgid "Ascending"
 msgstr ""
 
 #. Translators: label for descending sort
-#: entities/forms.py:238 entities/forms.py:359
+#: entities/forms.py:241 entities/forms.py:362
 msgid "Descending"
 msgstr ""
 
@@ -891,23 +917,23 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1220
+#: entities/models.py:1224
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1221
+#: entities/models.py:1225
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1222
+#: entities/models.py:1226
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1223
+#: entities/models.py:1227
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1224
+#: entities/models.py:1228
 msgid "Ambiguity"
 msgstr ""
 
@@ -952,6 +978,11 @@ msgstr ""
 msgid "Link to this person:"
 msgstr ""
 
+#. Translators: Search submit button
+#: entities/templates/entities/person_list.html:15
+msgid "Submit search"
+msgstr ""
+
 #. Translators: label for people browse page list view
 #: entities/templates/entities/person_list.html:21
 msgid "Toggle list view"
@@ -963,33 +994,33 @@ msgstr ""
 
 #. Translators: Person "other names" column header on the browse page
 #: entities/templates/entities/person_list.html:122
-#: entities/templates/entities/place_list.html:66
+#: entities/templates/entities/place_list.html:89
 msgid "Other names"
 msgstr ""
 
 #. Translators: Person "document count" column header on the browse page
 #. Translators: table header for count of shared documents between people
-#: entities/templates/entities/person_list.html:133
+#: entities/templates/entities/person_list.html:135
 #: entities/templates/entities/person_related_people.html:49
 msgid "Number of related documents"
 msgstr ""
 
 #. Translators: Person "related people count" column header on the browse page
-#: entities/templates/entities/person_list.html:137
+#: entities/templates/entities/person_list.html:139
 msgid "Number of related people"
 msgstr ""
 
 #. Translators: Person "related place count" column header on the browse page
-#: entities/templates/entities/person_list.html:141
+#: entities/templates/entities/person_list.html:143
 msgid "Number of related places"
 msgstr ""
 
-#: entities/templates/entities/person_list.html:159
+#: entities/templates/entities/person_list.html:161
 msgid "Also known as: "
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/person_list.html:205
+#: entities/templates/entities/person_list.html:207
 #, python-format
 msgid ""
 "\n"
@@ -1019,7 +1050,7 @@ msgstr ""
 #. Translators: label for Places map mode button on mobile devices
 #: entities/templates/entities/person_related_places.html:31
 #: entities/templates/entities/place_detail.html:32
-#: entities/templates/entities/place_list.html:101
+#: entities/templates/entities/place_list.html:124
 msgid "Map"
 msgstr ""
 
@@ -1028,18 +1059,34 @@ msgstr ""
 msgid "Coordinates"
 msgstr ""
 
+#: entities/templates/entities/place_list.html:22
+msgid "Map pin icon for regions"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:27
+msgid "Region"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:30
+msgid "Map pin icon for other places"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:35
+msgid "Place"
+msgstr ""
+
 #. Translators: accessible label for section showing place metadata, names
-#: entities/templates/entities/place_list.html:56
+#: entities/templates/entities/place_list.html:79
 msgid "metadata"
 msgstr ""
 
 #. Translators: accessible label for section showing counts of entries related to an entity
-#: entities/templates/entities/place_list.html:73
+#: entities/templates/entities/place_list.html:96
 msgid "Related entries"
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/place_list.html:90
+#: entities/templates/entities/place_list.html:113
 #, python-format
 msgid ""
 "\n"
@@ -1048,7 +1095,7 @@ msgid ""
 msgstr ""
 
 #. Translators: label for Places list mode button on mobile devices
-#: entities/templates/entities/place_list.html:99
+#: entities/templates/entities/place_list.html:122
 msgid "List"
 msgstr ""
 
@@ -1101,18 +1148,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:309
+#: entities/views.py:327
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:399
+#: entities/views.py:417
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:407 entities/views.py:477
+#: entities/views.py:425 entities/views.py:495
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1120,12 +1167,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:536
+#: entities/views.py:554
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:544
+#: entities/views.py:562
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1134,32 +1181,27 @@ msgstr[1] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:649 templates/snippets/menu.html:19
+#: entities/views.py:667 templates/snippets/menu.html:19
 msgid "People"
 msgstr ""
 
 #. Translators: description of people list/browse page
-#: entities/views.py:651
+#: entities/views.py:669
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:827 templates/snippets/menu.html:26
+#: entities/views.py:845 templates/snippets/menu.html:26
 msgid "Places"
 msgstr ""
 
 #. Translators: description of places list/browse page
-#: entities/views.py:829
+#: entities/views.py:847
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
-#. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:259
-msgid "[digital geniza document edition]"
-msgstr ""
-
-#: footnotes/models.py:494
+#: footnotes/models.py:507
 msgid "Edition"
 msgstr ""
 
@@ -1293,10 +1335,6 @@ msgstr ""
 #: templates/snippets/language_switcher.html:11
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
-msgstr ""
-
-#: templates/snippets/menu.html:4
-msgid "Search"
 msgstr ""
 
 #. Translators: label for main menu back button for mobile navigation

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-01-29 10:50-0500\n"
+"POT-Creation-Date: 2025-04-03 12:07-0400\n"
 "PO-Revision-Date: 2025-01-29 17:57\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: he\n"
@@ -28,7 +29,7 @@ msgid "Keyword or Phrase"
 msgstr "מילת מפתח או ביטוי"
 
 #. Translators: label for sort by relevance
-#: corpus/forms.py:226 entities/forms.py:211
+#: corpus/forms.py:226 entities/forms.py:214
 msgid "Relevance"
 msgstr "רלוונטיות"
 
@@ -92,104 +93,132 @@ msgstr ""
 msgid "RegEx"
 msgstr ""
 
+#. Translators: label for transcription RegEx field
+#. Translators: label for "has transcription" search form filter
+#: corpus/forms.py:258 corpus/forms.py:304
+#: corpus/templates/corpus/snippets/document_transcription.html:66
+msgid "Transcription"
+msgstr "תיעתוק"
+
+#. Translators: label for description RegEx field
+#. Translators: label for document description
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+msgid "Description"
+msgstr "תיאור"
+
+#. Translators: label for translation RegEx field
+#. Translators: label for "has translation" search form filter
+#: corpus/forms.py:262 corpus/forms.py:308
+#: corpus/templates/corpus/snippets/document_transcription.html:71
+#: footnotes/models.py:508
+msgid "Translation"
+msgstr "תרגום"
+
+#. Translators: label for shelfmark RegEx field
+#: corpus/forms.py:264 corpus/templates/corpus/document_detail.html:48
+msgid "Shelfmark"
+msgstr "מספר מדף"
+
 #. Translators: label for form sort field
-#: corpus/forms.py:262 entities/forms.py:228 entities/forms.py:349
+#: corpus/forms.py:273 entities/forms.py:231 entities/forms.py:352
 msgid "Sort by"
 msgstr "מיון לפי"
 
 #. Translators: label for filter documents by date range
 #. Translators: label for the dates of a person's appearances in PGP documents
 #. Translators: Person "dates of activity" column header on the browse page
-#: corpus/forms.py:269 entities/forms.py:207
+#: corpus/forms.py:280 entities/forms.py:210
 #: entities/templates/entities/person_detail.html:38
 #: entities/templates/entities/person_list.html:126
 msgid "Dates"
 msgstr "מסמכים"
 
 #. Translators: label for "exclude inferred dates" search form filter
-#: corpus/forms.py:278
+#: corpus/forms.py:289
 msgid "Exclude inferred dates"
 msgstr ""
 
 #. Translators: label for document type search form filter
-#: corpus/forms.py:285
-#| msgid "Input date"
+#: corpus/forms.py:296
 msgid "Document type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:289 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
 
-#. Translators: label for "has transcription" search form filter
-#: corpus/forms.py:293
-#: corpus/templates/corpus/snippets/document_transcription.html:66
-msgid "Transcription"
-msgstr "תיעתוק"
-
-#. Translators: label for "has translation" search form filter
-#: corpus/forms.py:297
-#: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:495
-msgid "Translation"
-msgstr "תרגום"
-
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:301 footnotes/models.py:496
+#: corpus/forms.py:312 footnotes/models.py:509
 msgid "Discussion"
 msgstr "דיון"
 
 #. Translators: label for document translation language search form filter
-#: corpus/forms.py:305
+#: corpus/forms.py:316
 msgid "Translation language"
 msgstr ""
 
-#: corpus/forms.py:307
+#: corpus/forms.py:318
 msgid "All languages"
 msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
-#: corpus/forms.py:312
-#| msgid "Search Documents"
+#: corpus/forms.py:323
 msgid "Search mode"
 msgstr ""
 
+#: corpus/forms.py:330
+msgid "RegEx search field"
+msgstr ""
+
+#: corpus/forms.py:365
+msgid "Search by regular expression"
+msgstr ""
+
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:348 corpus/models.py:1005 corpus/solr_queryset.py:332
+#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: corpus/templates/corpus/snippets/document_transcription.html:242
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
 
-#: corpus/forms.py:395
+#: corpus/forms.py:420
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת מפתח לחיפוש."
 
-#: corpus/forms.py:411
+#: corpus/forms.py:436
 #, python-format
-msgid "Regular expression cannot contain { without a preceding character, without an integer afterwards, or without a closing }. %s"
+msgid ""
+"Regular expression cannot contain { without a preceding character, without "
+"an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:420
+#: corpus/forms.py:445
 #, python-format
-msgid "Regular expression cannot contain * without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain * without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:429
+#: corpus/forms.py:454
 #, python-format
-msgid "Regular expression cannot contain + without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain + without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:438
+#: corpus/forms.py:463
 #, python-format
-msgid "Regular expression cannot contain < or use a negative lookbehind query. %s"
+msgid ""
+"Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:448
+#: corpus/forms.py:473
 #, python-format
-msgid "Regular expression cannot contain the escape character \\ followed by an alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgid ""
+"Regular expression cannot contain the escape character \\ followed by an "
+"alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
 #: corpus/models.py:1128 templates/base.html:21
@@ -242,10 +271,6 @@ msgstr[3] "עורכים"
 #: entities/templates/entities/place_detail.html:53
 msgid "Metadata"
 msgstr "מטא-דאטא"
-
-#: corpus/templates/corpus/document_detail.html:48
-msgid "Shelfmark"
-msgstr "מספר מדף"
 
 #. Translators: label for date of this document, if known
 #: corpus/templates/corpus/document_detail.html:56
@@ -302,19 +327,14 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#. Translators: label for document description
-#: corpus/templates/corpus/document_detail.html:145
-msgid "Description"
-msgstr "תיאור"
-
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
 #: corpus/templates/corpus/document_detail.html:153
-#: corpus/templates/corpus/snippets/document_result.html:108
-#: entities/forms.py:221 entities/forms.py:344
-#: entities/templates/entities/person_list.html:190
-#: entities/templates/entities/place_list.html:80
+#: corpus/templates/corpus/snippets/document_result.html:113
+#: entities/forms.py:224 entities/forms.py:347
+#: entities/templates/entities/person_list.html:192
+#: entities/templates/entities/place_list.html:103
 #: entities/templates/entities/place_related_people.html:28
 msgid "Related People"
 msgstr ""
@@ -324,16 +344,18 @@ msgstr ""
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
 #: corpus/templates/corpus/document_detail.html:172
-#: corpus/templates/corpus/snippets/document_result.html:112
-#: entities/forms.py:223 entities/templates/entities/person_list.html:194
+#: corpus/templates/corpus/snippets/document_result.html:117
+#: entities/forms.py:226 entities/templates/entities/person_list.html:196
 #: entities/templates/entities/person_related_places.html:56
 #: entities/templates/entities/place_detail.html:93
 msgid "Related Places"
 msgstr ""
 
 #. Translators: label for tags on a document
+#. Translators: Person "tags" column header on the browse page
 #: corpus/templates/corpus/document_detail.html:190
-#: corpus/templates/corpus/snippets/document_result.html:125
+#: corpus/templates/corpus/snippets/document_result.html:130
+#: entities/templates/entities/person_list.html:132
 msgid "Tags"
 msgstr "תגים"
 
@@ -364,7 +386,8 @@ msgstr "תאריך קלט"
 #. Translators: Date document was first added to the PGP
 #: corpus/templates/corpus/document_detail.html:234
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    In PGP since %(date)s\n"
 "                "
 msgstr ""
@@ -395,58 +418,70 @@ msgstr ""
 msgid "Permalink"
 msgstr "קישור קבוע"
 
-#: corpus/templates/corpus/document_list.html:15
+#: corpus/templates/corpus/document_list.html:16
 msgid "How to Search"
 msgstr ""
 
 #. Translators: accessibility label for button to close search mode help dialog
-#: corpus/templates/corpus/document_list.html:18
+#: corpus/templates/corpus/document_list.html:19
 msgid "Close search mode help"
 msgstr ""
 
 #. Translators: accessibility label for button to open search mode help dialog
-#: corpus/templates/corpus/document_list.html:25
+#: corpus/templates/corpus/document_list.html:26
 msgid "Open search mode help"
 msgstr ""
 
 #. Translators: Search submit button
-#: corpus/templates/corpus/document_list.html:31
-#: entities/templates/entities/person_list.html:15
-msgid "Submit search"
+#: corpus/templates/corpus/document_list.html:31 templates/snippets/menu.html:4
+msgid "Search"
 msgstr "חיפוש"
 
-#: corpus/templates/corpus/document_list.html:37
-#: corpus/templates/corpus/document_list.html:64
+#: corpus/templates/corpus/document_list.html:47
+msgid "in"
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:59
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
+"                            even if part of a join, for best results.\n"
+"                        "
+msgstr ""
+
+#: corpus/templates/corpus/document_list.html:70
+#: corpus/templates/corpus/document_list.html:97
 #: entities/templates/entities/person_list.html:29
 #: entities/templates/entities/person_list.html:56
 msgid "Filters"
 msgstr "מסננים"
 
 #. Translators: label for button to clear all applied filters
-#: corpus/templates/corpus/document_list.html:58
+#: corpus/templates/corpus/document_list.html:91
 #: entities/templates/entities/person_list.html:50
 msgid "Clear all"
 msgstr ""
 
 #. Translators: label for 'filters' close button for mobile navigation
-#: corpus/templates/corpus/document_list.html:67
+#: corpus/templates/corpus/document_list.html:100
 #: entities/templates/entities/person_list.html:59
 msgid "Close filter options"
 msgstr "סגור אפשרויות סינון"
 
-#: corpus/templates/corpus/document_list.html:83
+#: corpus/templates/corpus/document_list.html:116
 msgid "Includes"
 msgstr ""
 
 #. Translators: search results section header
-#: corpus/templates/corpus/document_list.html:135
+#: corpus/templates/corpus/document_list.html:168
 #: entities/templates/entities/person_list.html:93
 msgid "Results"
 msgstr ""
 
 #. Translators: number of search results
 #. Translators: number of results
-#: corpus/templates/corpus/document_list.html:139
+#: corpus/templates/corpus/document_list.html:172
 #: entities/templates/entities/person_list.html:97
 #, python-format
 msgid "1 result"
@@ -456,7 +491,7 @@ msgstr[1] "%(count_humanized)s תוצאות"
 msgstr[2] "%(count_humanized)s תוצאות"
 msgstr[3] "%(count_humanized)s תוצאות"
 
-#: corpus/templates/corpus/document_list.html:163
+#: corpus/templates/corpus/document_list.html:196
 msgid "View results in the Arabic Papyrology Database"
 msgstr ""
 
@@ -497,13 +532,11 @@ msgid "Jewish Theological Seminary logo"
 msgstr "סמל Jewish Theological Seminary"
 
 #: corpus/templates/corpus/snippets/document_result.html:23
-#| msgid "Input date"
 msgid "Document date"
 msgstr ""
 
 #. Translators: label for inferred date on a document
 #: corpus/templates/corpus/snippets/document_result.html:33
-#| msgid "Input date"
 msgid "Inferred date"
 msgstr ""
 
@@ -517,21 +550,20 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: label for sort by number of related documents
-#: corpus/templates/corpus/snippets/document_result.html:116
-#: entities/forms.py:219 entities/forms.py:342
-#: entities/templates/entities/person_list.html:186
-#: entities/templates/entities/place_list.html:75
-#| msgid "Search Documents"
+#: corpus/templates/corpus/snippets/document_result.html:121
+#: entities/forms.py:222 entities/forms.py:345
+#: entities/templates/entities/person_list.html:188
+#: entities/templates/entities/place_list.html:98
 msgid "Related Documents"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:132
-#: entities/templates/entities/person_list.html:180
+#: corpus/templates/corpus/snippets/document_result.html:137
+#: entities/templates/entities/person_list.html:182
 msgid "more"
 msgstr "עוד"
 
 #. Translators: number of editions for this document
-#: corpus/templates/corpus/snippets/document_result.html:144
+#: corpus/templates/corpus/snippets/document_result.html:149
 #, python-format
 msgid "1 Transcription"
 msgid_plural "%(counter)s Transcriptions"
@@ -541,7 +573,7 @@ msgstr[2] "%(counter)s תעתוקים"
 msgstr[3] "%(counter)s תעתוקים"
 
 #. Translators: number of translations for this document
-#: corpus/templates/corpus/snippets/document_result.html:154
+#: corpus/templates/corpus/snippets/document_result.html:159
 #, python-format
 msgid "1 Translation"
 msgid_plural "%(counter)s Translations"
@@ -551,7 +583,7 @@ msgstr[2] "%(counter)s תרגומים"
 msgstr[3] "%(counter)s תרגומים"
 
 #. Translators: number of sources that discuss this document
-#: corpus/templates/corpus/snippets/document_result.html:164
+#: corpus/templates/corpus/snippets/document_result.html:169
 #, python-format
 msgid "1 Discussion"
 msgid_plural "%(counter)s Discussions"
@@ -560,38 +592,38 @@ msgstr[1] "%(counter)s דיונים"
 msgstr[2] "%(counter)s דיונים"
 msgstr[3] "%(counter)s דיונים"
 
-#: corpus/templates/corpus/snippets/document_result.html:172
+#: corpus/templates/corpus/snippets/document_result.html:177
 msgid "No Scholarship Records"
 msgstr "אין רשומות קשורות"
 
 #. Translators: label for when no image thumbnail is available
-#: corpus/templates/corpus/snippets/document_result.html:193
+#: corpus/templates/corpus/snippets/document_result.html:198
 #: entities/templates/entities/snippets/related_documents_table.html:45
 msgid "No Image"
 msgstr ""
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/snippets/document_result.html:197
+#: corpus/templates/corpus/snippets/document_result.html:202
 msgid "In PGP since"
 msgstr "נמצא בPGP מאז"
 
 #. Translators: label for unknown date for date added to PGP
-#: corpus/templates/corpus/snippets/document_result.html:199
+#: corpus/templates/corpus/snippets/document_result.html:204
 msgid "unknown"
 msgstr ""
 
 #. Translators: label for historical/old shelfmark on document fragments
-#: corpus/templates/corpus/snippets/document_result.html:209
+#: corpus/templates/corpus/snippets/document_result.html:214
 msgid "Historical shelfmark"
 msgstr ""
 
 #. Translators: screen-reader label for "view document details" link
-#: corpus/templates/corpus/snippets/document_result.html:219
+#: corpus/templates/corpus/snippets/document_result.html:224
 #, python-format
 msgid "View details for %(document_label)s"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_result.html:221
+#: corpus/templates/corpus/snippets/document_result.html:226
 msgid "View document details"
 msgstr "הצגת פרטי מסמך"
 
@@ -602,8 +634,10 @@ msgstr ""
 
 #. Translators: general search help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:7
-msgid "\n"
-"        Use keywords or phrases in any language to return matching or similar\n"
+msgid ""
+"\n"
+"        Use keywords or phrases in any language to return matching or "
+"similar\n"
 "        results across all fields. Arabic script searches will return both\n"
 "        Arabic and Judaeo-Arabic transcription content.\n"
 "    "
@@ -617,7 +651,8 @@ msgstr ""
 #. Translators: regular expressions search mode help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:18
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "        Use Hebrew or Arabic script to find precise matches in the\n"
 "        transcriptions. See\n"
 "        <a data-turbo=\"false\" href=\"%(howto_url)s\">How to Search</a>\n"
@@ -632,10 +667,13 @@ msgstr ""
 
 #. Translators: regular expression tip 1
 #: corpus/templates/corpus/snippets/document_search_helptext.html:31
-msgid "\n"
+msgid ""
+"\n"
 "            If you're looking for a word with one missing letter, use a\n"
-"            period. Two missing letters, use two periods or <code>{2}</code>.\n"
-"            Increase the number in the curly brackets to increase the number of\n"
+"            period. Two missing letters, use two periods or <code>{2}</"
+"code>.\n"
+"            Increase the number in the curly brackets to increase the number "
+"of\n"
 "            characters, or insert a range with a comma in between, ex.\n"
 "            <code>{0,5}</code>.\n"
 "        "
@@ -643,7 +681,8 @@ msgstr ""
 
 #. Translators: regular expression tip 2
 #: corpus/templates/corpus/snippets/document_search_helptext.html:41
-msgid "\n"
+msgid ""
+"\n"
 "            If you don't know how many characters are missing, use\n"
 "            <code>.*</code>.\n"
 "        "
@@ -651,8 +690,10 @@ msgstr ""
 
 #. Translators: regular expression tip 3
 #: corpus/templates/corpus/snippets/document_search_helptext.html:48
-msgid "\n"
-"            If you know which characters you want, use square brackets to find\n"
+msgid ""
+"\n"
+"            If you know which characters you want, use square brackets to "
+"find\n"
 "            multiple spellings, ex. <code>[יו]</code> for yud or vav.\n"
 "        "
 msgstr ""
@@ -731,7 +772,7 @@ msgstr[3] ""
 msgid "Zoom and Rotate"
 msgstr "הגדל וסובב"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:246
+#: corpus/templates/corpus/snippets/document_transcription.html:245
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "ראה %(related_doc)s"
@@ -765,7 +806,6 @@ msgstr "הבא"
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
 #: corpus/views.py:82 templates/snippets/menu.html:11
-#| msgid "Input date"
 msgid "Documents"
 msgstr "מסמכים"
 
@@ -774,27 +814,29 @@ msgstr "מסמכים"
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
-#: corpus/views.py:326 entities/views.py:721
+#: corpus/views.py:332 entities/views.py:739
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:328 entities/views.py:723
+#: corpus/views.py:334 entities/views.py:741
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:399
-msgid "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
+#: corpus/views.py:405
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses."
 msgstr ""
 
 #. Translators: title of document scholarship page
-#: corpus/views.py:531
+#: corpus/views.py:540
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "רשומה קשורה ל-%(doc)s"
 
-#: corpus/views.py:538
+#: corpus/views.py:547
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -804,12 +846,12 @@ msgstr[2] "%(count)d רשומות קשורות"
 msgstr[3] "%(count)d רשומות קשורות"
 
 #. Translators: title of related documents page
-#: corpus/views.py:579
+#: corpus/views.py:588
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "מסמכים קשורים %(doc)s"
 
-#: corpus/views.py:586 entities/views.py:317
+#: corpus/views.py:595 entities/views.py:335
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -819,34 +861,34 @@ msgstr[2] "%(count)d מסמכים קשורים"
 msgstr[3] "%(count)d מסמכים קשורים"
 
 #. Translators: placeholder for people keyword search input
-#: entities/forms.py:195
+#: entities/forms.py:198
 msgid "Search for people by name"
 msgstr ""
 
 #. Translators: accessible label for people keyword search input
-#: entities/forms.py:197
+#: entities/forms.py:200
 msgid "word or phrase"
 msgstr ""
 
 #. Translators: label for a person's gender
 #. Translators: Person "gender" column header on the browse page
-#: entities/forms.py:202 entities/templates/entities/person_detail.html:34
+#: entities/forms.py:205 entities/templates/entities/person_detail.html:34
 #: entities/templates/entities/person_list.html:124
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:203 entities/views.py:737
+#: entities/forms.py:206 entities/views.py:755
 msgid "Detail page available"
 msgstr ""
 
 #. Translators: Label for a person's social role
 #. Translators: Person "social role" column header on the browse page
-#: entities/forms.py:204 entities/templates/entities/person_detail.html:57
+#: entities/forms.py:207 entities/templates/entities/person_detail.html:57
 #: entities/templates/entities/person_list.html:128
 msgid "Social role"
 msgstr ""
 
-#: entities/forms.py:205
+#: entities/forms.py:208
 msgid "Relation to documents"
 msgstr ""
 
@@ -855,34 +897,34 @@ msgstr ""
 #. Translators: table header for person name
 #. Translators: table header for place name
 #. Translators: table header for person name
-#: entities/forms.py:213 entities/forms.py:340
+#: entities/forms.py:216 entities/forms.py:343
 #: entities/templates/entities/person_list.html:120
 #: entities/templates/entities/person_related_people.html:35
 #: entities/templates/entities/person_related_places.html:65
-#: entities/templates/entities/place_list.html:57
+#: entities/templates/entities/place_list.html:80
 #: entities/templates/entities/place_related_people.html:37
 msgid "Name"
 msgstr ""
 
 #. Translators: label for sort by person activity dates
 #. Translators: table header for document date
-#: entities/forms.py:215
+#: entities/forms.py:218
 #: entities/templates/entities/snippets/related_documents_table.html:31
 msgid "Date"
 msgstr ""
 
 #. Translators: label for sort by social role
-#: entities/forms.py:217
+#: entities/forms.py:220
 msgid "Social Role"
 msgstr ""
 
 #. Translators: label for ascending sort
-#: entities/forms.py:236 entities/forms.py:357
+#: entities/forms.py:239 entities/forms.py:360
 msgid "Ascending"
 msgstr ""
 
 #. Translators: label for descending sort
-#: entities/forms.py:238 entities/forms.py:359
+#: entities/forms.py:241 entities/forms.py:362
 msgid "Descending"
 msgstr ""
 
@@ -898,23 +940,23 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1220
+#: entities/models.py:1224
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1221
+#: entities/models.py:1225
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1222
+#: entities/models.py:1226
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1223
+#: entities/models.py:1227
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1224
+#: entities/models.py:1228
 msgid "Ambiguity"
 msgstr ""
 
@@ -961,6 +1003,11 @@ msgstr ""
 msgid "Link to this person:"
 msgstr ""
 
+#. Translators: Search submit button
+#: entities/templates/entities/person_list.html:15
+msgid "Submit search"
+msgstr "חיפוש"
+
 #. Translators: label for people browse page list view
 #: entities/templates/entities/person_list.html:21
 msgid "Toggle list view"
@@ -972,35 +1019,36 @@ msgstr ""
 
 #. Translators: Person "other names" column header on the browse page
 #: entities/templates/entities/person_list.html:122
-#: entities/templates/entities/place_list.html:66
+#: entities/templates/entities/place_list.html:89
 msgid "Other names"
 msgstr ""
 
 #. Translators: Person "document count" column header on the browse page
 #. Translators: table header for count of shared documents between people
-#: entities/templates/entities/person_list.html:133
+#: entities/templates/entities/person_list.html:135
 #: entities/templates/entities/person_related_people.html:49
 msgid "Number of related documents"
 msgstr ""
 
 #. Translators: Person "related people count" column header on the browse page
-#: entities/templates/entities/person_list.html:137
+#: entities/templates/entities/person_list.html:139
 msgid "Number of related people"
 msgstr ""
 
 #. Translators: Person "related place count" column header on the browse page
-#: entities/templates/entities/person_list.html:141
+#: entities/templates/entities/person_list.html:143
 msgid "Number of related places"
 msgstr ""
 
-#: entities/templates/entities/person_list.html:159
+#: entities/templates/entities/person_list.html:161
 msgid "Also known as: "
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/person_list.html:205
+#: entities/templates/entities/person_list.html:207
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "        "
 msgstr ""
@@ -1027,7 +1075,7 @@ msgstr ""
 #. Translators: label for Places map mode button on mobile devices
 #: entities/templates/entities/person_related_places.html:31
 #: entities/templates/entities/place_detail.html:32
-#: entities/templates/entities/place_list.html:101
+#: entities/templates/entities/place_list.html:124
 msgid "Map"
 msgstr ""
 
@@ -1036,26 +1084,45 @@ msgstr ""
 msgid "Coordinates"
 msgstr ""
 
+#: entities/templates/entities/place_list.html:22
+msgid "Map pin icon for regions"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:27
+msgid "Region"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:30
+msgid "Map pin icon for other places"
+msgstr ""
+
+#: entities/templates/entities/place_list.html:35
+#, fuzzy
+#| msgid "Places"
+msgid "Place"
+msgstr "מקומות"
+
 #. Translators: accessible label for section showing place metadata, names
-#: entities/templates/entities/place_list.html:56
+#: entities/templates/entities/place_list.html:79
 msgid "metadata"
 msgstr ""
 
 #. Translators: accessible label for section showing counts of entries related to an entity
-#: entities/templates/entities/place_list.html:73
+#: entities/templates/entities/place_list.html:96
 msgid "Related entries"
 msgstr ""
 
 #. Translators: range of search results on the current page, out of total
-#: entities/templates/entities/place_list.html:90
+#: entities/templates/entities/place_list.html:113
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "                "
 msgstr ""
 
 #. Translators: label for Places list mode button on mobile devices
-#: entities/templates/entities/place_list.html:99
+#: entities/templates/entities/place_list.html:122
 msgid "List"
 msgstr ""
 
@@ -1097,7 +1164,6 @@ msgstr ""
 
 #. Translators: table header for document name (shelfmark)
 #: entities/templates/entities/snippets/related_documents_table.html:10
-#| msgid "Input date"
 msgid "Document"
 msgstr ""
 
@@ -1107,18 +1173,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:309
+#: entities/views.py:327
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:399
+#: entities/views.py:417
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:407 entities/views.py:477
+#: entities/views.py:425 entities/views.py:495
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1128,12 +1194,12 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:536
+#: entities/views.py:554
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:544
+#: entities/views.py:562
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1144,43 +1210,46 @@ msgstr[3] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:649 templates/snippets/menu.html:19
+#: entities/views.py:667 templates/snippets/menu.html:19
 msgid "People"
 msgstr "אנשים"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:651
+#: entities/views.py:669
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:827 templates/snippets/menu.html:26
+#: entities/views.py:845 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "מקומות"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:829
+#: entities/views.py:847
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
-#. Translators: Placeholder for when a work has no title available
-#: footnotes/models.py:259
-msgid "[digital geniza document edition]"
-msgstr "[גרסת מסמך גניזה דיגיטלי]"
-
-#: footnotes/models.py:494
+#: footnotes/models.py:507
 msgid "Edition"
 msgstr "מהדורה"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום בהקשר זה."
+msgstr ""
+"טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
+"בהקשר זה."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים "
+"שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -1301,10 +1370,6 @@ msgstr "Princeton Center for Digital Humanities עמוד הבית"
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "קריאת העמוד ב-%(language_name)s (%(language_code)s)"
 
-#: templates/snippets/menu.html:4
-msgid "Search"
-msgstr "חיפוש"
-
 #. Translators: label for main menu back button for mobile navigation
 #: templates/snippets/sub_menu.html:8
 msgid "Return to main menu"
@@ -1315,3 +1380,5 @@ msgstr "חזרה לתפריט הראשי"
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
 
+#~ msgid "[digital geniza document edition]"
+#~ msgstr "[גרסת מסמך גניזה דיגיטלי]"

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -152,13 +152,14 @@ main.search form {
             }
         }
     }
-    // dropdown in facet filters
-    #filters label:has(select) {
+    // dropdown in facet filters and regex search fields
+    #filters label:has(select),
+    fieldset#regex-search label:has(select) {
         position: relative;
         select {
             border-radius: 5px;
-            height: 40px;
-            width: 260px;
+            height: 2.5rem;
+            width: 16.25rem;
             cursor: pointer;
             background-color: var(--background-light);
             border: 1px solid var(--background-gray);
@@ -183,6 +184,67 @@ main.search form {
         }
         &:has(select:disabled)::after {
             color: var(--disabled);
+        }
+    }
+    // in regex mode, tweak styles for fields
+    fieldset#regex-search {
+        display: flex;
+        flex-flow: row;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        gap: 0.5rem;
+        @include breakpoints.for-tablet-landscape-up {
+            gap: 1.5rem;
+        }
+        input[type="search"] {
+            border-radius: 5px;
+            border: 1px solid var(--background-gray);
+        }
+        // "in" label
+        span {
+            @include typography.body;
+        }
+        // field dropdown
+        label:has(select) {
+            select {
+                margin: 0;
+                padding: 0 2rem 0 0.5rem;
+                width: auto;
+                height: 3rem;
+                overflow: hidden;
+                white-space: nowrap;
+                box-sizing: border-box;
+                text-overflow: ellipsis;
+                @include breakpoints.for-tablet-landscape-up {
+                    width: 16.25rem;
+                    height: 2.5rem;
+                    font-size: typography.$text-size-lg;
+                }
+            }
+            &::after {
+                top: 0.6rem;
+                right: 0.5rem;
+                @include breakpoints.for-tablet-landscape-up {
+                    top: 0.4rem;
+                    right: 1rem;
+                }
+            }
+        }
+        button[type="submit"] {
+            width: auto;
+            border-radius: 5px;
+            gap: 0.5rem;
+            @include typography.body-bold;
+            @include breakpoints.for-phone-only {
+                min-width: 3rem;
+                span {
+                    @include a11y.sr-only;
+                }
+            }
+            @include breakpoints.for-tablet-landscape-up {
+                min-width: auto;
+                padding: 1rem;
+            }
         }
     }
     // error messages
@@ -245,7 +307,7 @@ main.people {
             min-width: 2.5rem;
         }
         // Magnifying glass icon
-        &::after {
+        &::before {
             content: "\f5e6"; // phosphor magnifying glass bold icon
             @include typography.icon-button-md;
             @include breakpoints.for-tablet-landscape-up {

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -215,12 +215,12 @@ main.search form {
     fieldset#regex-search {
         display: flex;
         flex-flow: column;
-        align-items: center;
         margin-bottom: 1.5rem;
         gap: 1rem;
         @include breakpoints.for-tablet-landscape-up {
-            flex-flow: row;
-            gap: 1.5rem;
+            flex-flow: row wrap;
+            align-items: center;
+            gap: 0.5rem 1.5rem;
         }
         input[type="search"] {
             border-radius: 5px;
@@ -229,6 +229,7 @@ main.search form {
             min-height: 2.5rem;
             @include breakpoints.for-tablet-landscape-up {
                 width: auto;
+                flex: 1 1 auto;
             }
         }
         // field dropdown
@@ -283,6 +284,9 @@ main.search form {
                 width: auto;
                 padding: 1rem;
             }
+        }
+        .shelfmark-help {
+            font-size: typography.$text-size-sm;
         }
     }
     // error messages

--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -14,32 +14,57 @@
 main.search form {
     // search query box and button
     fieldset#query {
-        margin-bottom: 1.5rem;
-        // search mode switch label (hidden on mobile)
-        span.fieldname {
-            @include typography.headline-3;
-            display: none;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+        margin-bottom: 1.25rem;
+        @include breakpoints.for-tablet-landscape-up {
+            flex-direction: row;
+            gap: 0;
+            margin-bottom: 1.5rem;
+        }
+        div#mode-controls {
+            display: flex;
+            width: 100%;
+            flex-flow: row nowrap;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 0.5rem;
             @include breakpoints.for-tablet-landscape-up {
+                width: auto;
+                gap: 0;
+            }
+            // search mode switch label
+            span.fieldname {
+                @include typography.headline-3;
                 display: block;
                 white-space: nowrap;
             }
-        }
-        // search mode help (hidden on mobile)
-        button#search-help {
-            display: none;
-            @include breakpoints.for-tablet-landscape-up {
+            // search mode help
+            button#search-help {
                 display: flex;
                 cursor: pointer;
                 border: none;
                 background: transparent;
                 color: var(--on-background);
                 padding: 0;
-                margin-left: 0.5rem;
                 &::before {
                     @include typography.icon-button-md;
                     font-size: typography.$text-size-2xl;
                     content: "\f1e0"; // phosphor info icon
                 }
+                @include breakpoints.for-tablet-landscape-up {
+                    margin-left: 0.5rem;
+                }
+            }
+        }
+        div#search-input {
+            display: flex;
+            flex-flow: row nowrap;
+            flex: 1 0 auto;
+            width: 100%;
+            @include breakpoints.for-tablet-landscape-up {
+                width: auto;
             }
         }
         dialog {
@@ -110,45 +135,45 @@ main.search form {
                 padding: 0 3px;
             }
         }
-        // search mode switch buttons (hidden on mobile)
+        // search mode switch buttons
         ul#id_mode {
-            display: none;
-            @include breakpoints.for-tablet-landscape-up {
+            display: flex;
+            flex-flow: row nowrap;
+            margin-left: auto;
+            background-color: var(--background-light);
+            border: 1px solid var(--background-gray);
+            border-radius: 50px;
+            align-items: center;
+            input {
+                @include a11y.sr-only;
+            }
+            label {
                 display: flex;
                 flex-flow: row nowrap;
-                background-color: var(--background-light);
-                border: 1px solid var(--background-gray);
-                border-radius: 50px;
                 align-items: center;
-                margin: 0 3.25rem 0 1.5rem;
-                input {
-                    @include a11y.sr-only;
+                padding: 0 1rem;
+                height: 2.5rem;
+                border-radius: 50px;
+                cursor: pointer;
+                border: 2px solid transparent;
+                transition: 0.15s border-color ease-in-out;
+                &:hover {
+                    border-color: var(--disabled);
                 }
-                label {
-                    display: flex;
-                    flex-flow: row nowrap;
-                    align-items: center;
-                    padding: 0 1rem;
-                    height: 2.5rem;
-                    border-radius: 50px;
-                    cursor: pointer;
-                    border: 2px solid transparent;
-                    transition: 0.15s border-color ease-in-out;
+                &:has(input:checked) {
+                    @include typography.body-bold;
+                    background-color: var(--on-primary);
+                    border-color: var(--secondary);
                     &:hover {
-                        border-color: var(--disabled);
-                    }
-                    &:has(input:checked) {
-                        @include typography.body-bold;
-                        background-color: var(--on-primary);
-                        border-color: var(--secondary);
-                        &:hover {
-                            border-color: var(--primary);
-                        }
-                    }
-                    &:has(*:focus-visible) {
-                        outline: 2px solid var(--button-focus);
+                        border-color: var(--primary);
                     }
                 }
+                &:has(*:focus-visible) {
+                    outline: 2px solid var(--button-focus);
+                }
+            }
+            @include breakpoints.for-tablet-landscape-up {
+                margin: 0 3.25rem 0 1.5rem;
             }
         }
     }
@@ -189,35 +214,49 @@ main.search form {
     // in regex mode, tweak styles for fields
     fieldset#regex-search {
         display: flex;
-        flex-flow: row;
+        flex-flow: column;
         align-items: center;
         margin-bottom: 1.5rem;
-        gap: 0.5rem;
+        gap: 1rem;
         @include breakpoints.for-tablet-landscape-up {
+            flex-flow: row;
             gap: 1.5rem;
         }
         input[type="search"] {
             border-radius: 5px;
             border: 1px solid var(--background-gray);
-        }
-        // "in" label
-        span {
-            @include typography.body;
+            width: 100%;
+            min-height: 2.5rem;
+            @include breakpoints.for-tablet-landscape-up {
+                width: auto;
+            }
         }
         // field dropdown
         label:has(select) {
+            display: flex;
+            flex-flow: row;
+            align-items: center;
+            gap: 1.5rem;
+            width: 100%;
+            @include breakpoints.for-tablet-landscape-up {
+                width: auto;
+            }
+            // "in" label
+            span {
+                @include typography.body;
+            }
             select {
+                flex-grow: 1;
                 margin: 0;
                 padding: 0 2rem 0 0.5rem;
                 width: auto;
-                height: 3rem;
+                height: 2.5rem;
                 overflow: hidden;
                 white-space: nowrap;
                 box-sizing: border-box;
                 text-overflow: ellipsis;
                 @include breakpoints.for-tablet-landscape-up {
                     width: 16.25rem;
-                    height: 2.5rem;
                     font-size: typography.$text-size-lg;
                 }
             }
@@ -231,18 +270,17 @@ main.search form {
             }
         }
         button[type="submit"] {
-            width: auto;
+            width: 100%;
             border-radius: 5px;
             gap: 0.5rem;
+            height: 2.5rem;
             @include typography.body-bold;
-            @include breakpoints.for-phone-only {
-                min-width: 3rem;
-                span {
-                    @include a11y.sr-only;
-                }
+            &::before {
+                @include typography.icon-button-sm;
             }
             @include breakpoints.for-tablet-landscape-up {
                 min-width: auto;
+                width: auto;
                 padding: 1rem;
             }
         }
@@ -279,19 +317,16 @@ main.people {
         border-bottom-right-radius: 0;
         border: 1px solid var(--background-gray);
         border-right: none;
-        height: 3rem;
+        height: 2.5rem;
         padding: 0 1rem;
         @include typography.body;
         background-color: var(--background-light);
         color: var(--on-background-light);
-        @include breakpoints.for-tablet-landscape-up {
-            height: 2.5rem;
-        }
     }
     button[type="submit"] {
         cursor: pointer;
-        width: 3rem;
-        height: 3rem;
+        width: 2.5rem;
+        height: 2.5rem;
         border-radius: 5px;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
@@ -303,7 +338,6 @@ main.people {
         background-color: var(--secondary);
         color: var(--on-secondary);
         @include breakpoints.for-tablet-landscape-up {
-            height: 2.5rem;
             min-width: 2.5rem;
         }
         // Magnifying glass icon

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -337,14 +337,17 @@
   <copyField source="shelfmark_s" dest="shelfmark_bigram" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_natsort" maxChars="30000" />
+  <copyField source="shelfmark_s" dest="shelfmark_regex" maxChars="30000" />
   <!-- individual shelfmarks -->
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_t" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_bigram" maxChars="30000" />  
+  <copyField source="fragment_shelfmark_ss" dest="shelfmark_regex" maxChars="30000" />
   <!-- old / historic shelfmarks -->
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_t" maxChars="30000" />
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_textnum" maxChars="30000" />
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_bigram" maxChars="30000" />
+  <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_regex" maxChars="30000" />
   
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
   <copyField source="type_s" dest="type_t" maxChars="300" />

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -318,7 +318,6 @@
     <fieldType name="text_regex" class="solr.TextField">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory" />
       </analyzer>
     </fieldType>
 
@@ -353,6 +352,9 @@
   <!-- copy description and transcription to nostem fields for exact matches -->
   <copyField source="description_en_bigram" dest="description_nostem" maxChars="30000" />
   <copyField source="text_transcription" dest="transcription_nostem" maxChars="30000" />
+
+  <!-- copy description and translation to regex fields -->
+  <copyField source="description_en_bigram" dest="description_regex" maxChars="30000" />
 
   <!-- copy people name fields to text fields -->
   <copyField source="name_s" dest="name_bigram" maxChars="30000" />


### PR DESCRIPTION
## In this PR

Per #1755:
- Add shelfmark, description, and translation regex search options
- Refactor regex search functions to be field-agnostic to support those options
- Add a special case to regex search and highlighting to ensure old shelfmarks can match and appear in results
- Restyle with dropdown, add regex search to mobile