### PR TITLE
Specify collection field order in admin (#1658)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -73,6 +73,7 @@ class CollectionAdmin(admin.ModelAdmin):
     list_display = ("library", "name", "lib_abbrev", "abbrev", "location")
     search_fields = ("library", "location", "name")
     list_display_links = ("library", "name")
+    fields = ("library", "lib_abbrev", "name", "abbrev", "location")
 
 
 @admin.register(LanguageScript)


### PR DESCRIPTION
## In this PR

Per #1658:
- Specify field order in the Collection admin, such that it is the same as before, but with `name` before `abbrev`.