### PR TITLE
Optimizations for Person "Related Documents" front-end (#1781)

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -204,19 +204,19 @@ class DocumentDateMixin(TrackChangesModel):
             [self.doc_date_original, self.get_doc_date_calendar_display()]
         ).strip()
 
-    @property
-    def document_date(self):
+    @classmethod
+    def get_document_date(cls, doc_date_standard, original_date):
         """Generate formatted display of combined original and standardized dates"""
-        if self.doc_date_standard:
-            standardized_date = standard_date_display(self.doc_date_standard)
+        if doc_date_standard:
+            standardized_date = standard_date_display(doc_date_standard)
             # add parentheses to standardized date if original date is also present
-            if self.original_date:
+            if original_date:
                 # NOTE: we want no-wrap for individual dates when displaying as html
                 # may want to split out formatted/unformatted versions
                 return mark_safe(
                     "<span>%s</span> <span>(%s)</span>"
                     % (
-                        self.original_date,
+                        original_date,
                         standardized_date,
                     )
                 )
@@ -224,7 +224,12 @@ class DocumentDateMixin(TrackChangesModel):
             return standardized_date
         else:
             # if there's no standardized date, just display the historical date
-            return self.original_date
+            return original_date
+
+    @property
+    def document_date(self):
+        """Property: formatted display of combined original and standardized dates"""
+        return self.get_document_date(self.doc_date_standard, self.original_date)
 
     def clean(self):
         """

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1016,12 +1016,14 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
         dating_range = [self.start_date or None, self.end_date or None]
 
         # bail out if we don't have any inferred datings
-        if not self.dating_set.exists():
+        # (use list on .all() for prefetch compatibility)
+        inferred_datings = list(self.dating_set.all())
+        if not inferred_datings:
             return tuple(dating_range)
 
         # loop through inferred datings to find min and max among all dates (including both
         # on-document and inferred)
-        for inferred in self.dating_set.all():
+        for inferred in inferred_datings:
             # get start from standardized date range (formatted as "date1/date2" or "date")
             split_date = inferred.standard_date.split("/")
             start = PartialDate(split_date[0])

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -236,7 +236,7 @@ class Fragment(TrackChangesModel):
         """natural key: shelfmark"""
         return (self.shelfmark,)
 
-    def iiif_images(self):
+    def iiif_images(self, allow_network_reqs=True):
         """IIIF image URLs for this fragment. Returns a list of
         :class:`~piffle.image.IIIFImageClient` and corresponding list of labels,
         or None if this fragement has no IIIF url associated."""
@@ -260,7 +260,7 @@ class Fragment(TrackChangesModel):
                     canvases.append(canvas.uri)
 
         # if not cached, load from remote url
-        else:
+        elif allow_network_reqs:
             try:
                 manifest = IIIFPresentation.from_url(self.iiif_url)
                 for canvas in manifest.sequences[0].canvases:
@@ -769,7 +769,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             )
         )
 
-    def iiif_images(self, filter_side=False, with_placeholders=False):
+    def iiif_images(self, filter_side=False, with_placeholders=False, thumbnail=False):
         """
         Dict of IIIF images and labels for images of the Document's Fragments, keyed on canvas.
 
@@ -781,7 +781,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
         textblocks = self.textblock_set.all()
 
         for b in textblocks:
-            frag_images = b.fragment.iiif_images()
+            frag_images = b.fragment.iiif_images(allow_network_reqs=not thumbnail)
             if frag_images is not None:
                 images, labels, canvases = frag_images
                 for i, img in enumerate(images):
@@ -868,7 +868,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
 
     def list_thumbnail(self):
         """generate html for thumbnail of first image, for display in related documents lists"""
-        iiif_images = self.iiif_images()
+        iiif_images = self.iiif_images(thumbnail=True)
         if not iiif_images:
             return ""
         img = list(iiif_images.values())[0]

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -27,6 +27,7 @@ from unidecode import unidecode
 from geniza.common.models import TaggableMixin, TrackChangesModel, cached_class_property
 from geniza.corpus.dates import DocumentDateMixin, PartialDate, standard_date_display
 from geniza.corpus.models import (
+    Dating,
     DisplayLabelMixin,
     Document,
     LanguageScript,
@@ -671,7 +672,9 @@ class Person(
             type__name__icontains="deceased"
         )
         doc_ids = relations.values_list("document__pk", flat=True)
-        docs = Document.objects.filter(pk__in=doc_ids)
+        docs = Document.objects.filter(pk__in=doc_ids).prefetch_related(
+            Prefetch("dating_set", queryset=Dating.objects.only("standard_date"))
+        )
         return self.get_date_range(docs)
 
     @property
@@ -682,7 +685,9 @@ class Person(
             type__name__icontains="deceased"
         )
         doc_ids = relations.values_list("document__pk", flat=True)
-        docs = Document.objects.filter(pk__in=doc_ids)
+        docs = Document.objects.filter(pk__in=doc_ids).prefetch_related(
+            Prefetch("dating_set", queryset=Dating.objects.only("standard_date"))
+        )
         return self.get_date_range(docs)
 
     def merge_with(self, merge_people, user=None):

--- a/geniza/entities/templates/entities/snippets/related_documents_table.html
+++ b/geniza/entities/templates/entities/snippets/related_documents_table.html
@@ -44,7 +44,7 @@
                             {# Translators: label for when no image thumbnail is available #}
                             <span class="no-image">{% translate 'No Image' %}</span>
                         {% endif %}
-                        <a href="{{ document.pk }}" title="{{ document.shelfmark }}">
+                        <a href="{{ document.url }}" title="{{ document.shelfmark }}">
                             {{ document.shelfmark }}
                         </a>
                     </td>

--- a/geniza/entities/templates/entities/snippets/related_documents_table.html
+++ b/geniza/entities/templates/entities/snippets/related_documents_table.html
@@ -35,24 +35,28 @@
             </tr>
         </thead>
         <tbody>
-            {% for rel in relations %}
+            {% for document in relations %}
                 <tr>
                     <td class="document-title">
-                        {% if rel.document.list_thumbnail %}
-                            {{ rel.document.list_thumbnail }}
+                        {% if document.thumbnail %}
+                            {{ document.thumbnail }}
                         {% else %}
                             {# Translators: label for when no image thumbnail is available #}
                             <span class="no-image">{% translate 'No Image' %}</span>
                         {% endif %}
-                        <a href="{{ rel.document.permalink }}" title="{{ rel.document.shelfmark_display }}">
-                            {{ rel.document.shelfmark_display }}
+                        <a href="{{ document.pk }}" title="{{ document.shelfmark }}">
+                            {{ document.shelfmark }}
                         </a>
                     </td>
-                    <td>{{ rel.document.doctype }}</td>
+                    <td>{{ document.doctype }}</td>
                     {# Translators: label for an uncertain Person-Document identification #}
-                    <td><span>{{ rel.type }}{% if rel.uncertain %} <em class="uncertain">{% translate '(uncertain)' %}</em>{% endif %}</span></td>
+                    <td class="reltype">
+                        {% for reltype in document.relations %}
+                            <span>{% if not forloop.first %}{{ reltype.name|lower }}{% else %}{{ reltype.name }}{% endif %}{% if reltype.uncertain %} <em class="uncertain">{% translate '(uncertain)' %}</em>{% endif %}{% if not forloop.last %},{% endif %}</span>
+                        {% endfor %}
+                    </td>
                     <td class="document-date">
-                        {{ rel.document.dating_set.first.display_date|default:rel.document.document_date }}
+                        {{ document.date.label }}
                     </td>
                 </tr>
             {% endfor %}

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -814,40 +814,41 @@ class TestPersonDocumentsView:
             ],
         )
 
-        # get_related should return an iterable with both relationships
+        # get_related should return an iterable with both documents
         response = client.get(reverse("entities:person-documents", args=(person.slug,)))
-        related_docs_qs = response.context.get("related_documents")
-        assert legal_doc_relation in related_docs_qs
-        assert state_doc_relation in related_docs_qs
+        related_docs_list = response.context.get("related_documents")
+        related_doc_pks = [doc["pk"] for doc in related_docs_list]
+        assert document.pk in related_doc_pks
+        assert state_doc.pk in related_doc_pks
 
         # by default, should sort alphabetically by shelfmark, ascending
         assert response.context.get("sort") == "shelfmark_asc"
         # legal doc shelfmark starts with CUL, state doc shelfmark starts with T-S
-        assert related_docs_qs.first().pk == legal_doc_relation.pk
+        assert related_docs_list[0]["pk"] == legal_doc_relation.document.pk
 
         # sort alphabetically by shelfmark, descending
         response = client.get(
             reverse("entities:person-documents", args=(person.slug,)),
             {"sort": "shelfmark_desc"},
         )
-        related_docs_qs = response.context.get("related_documents")
-        assert related_docs_qs.first().pk == state_doc_relation.pk
+        related_docs_list = response.context.get("related_documents")
+        assert related_docs_list[0]["pk"] == state_doc_relation.document.pk
 
         # sort alphabetically by doctype, ascending (Legal, then State)
         response = client.get(
             reverse("entities:person-documents", args=(person.slug,)),
             {"sort": "doctype_asc"},
         )
-        related_docs_qs = response.context.get("related_documents")
-        assert related_docs_qs.first().pk == legal_doc_relation.pk
+        related_docs_list = response.context.get("related_documents")
+        assert related_docs_list[0]["pk"] == legal_doc_relation.document.pk
 
         # sort alphabetically by relation, ascending (Author, then Recipient)
         response = client.get(
             reverse("entities:person-documents", args=(person.slug,)),
             {"sort": "relation_asc"},
         )
-        related_docs_qs = response.context.get("related_documents")
-        assert related_docs_qs.first().pk == legal_doc_relation.pk
+        related_docs_list = response.context.get("related_documents")
+        assert related_docs_list[0]["pk"] == legal_doc_relation.document.pk
 
         # add some on-document and inferred dates to the documents
         document.doc_date_original = "5 Elul 5567"
@@ -871,20 +872,20 @@ class TestPersonDocumentsView:
             reverse("entities:person-documents", args=(person.slug,)),
             {"sort": "date_asc"},
         )
-        related_docs_qs = response.context.get("related_documents")
+        related_docs_list = response.context.get("related_documents")
         # date sort returns a list due to additional calculations needed
-        assert related_docs_qs[0].pk == state_doc_relation.pk
+        assert related_docs_list[0]["pk"] == state_doc_relation.document.pk
         # undated should be sorted last
-        assert related_docs_qs[-1].pk == undated_doc_relation.pk
+        assert related_docs_list[-1]["pk"] == undated_doc_relation.document.pk
         # sort by date descending
         response = client.get(
             reverse("entities:person-documents", args=(person.slug,)),
             {"sort": "date_desc"},
         )
-        related_docs_qs = response.context.get("related_documents")
-        assert related_docs_qs[0].pk == legal_doc_relation.pk
+        related_docs_list = response.context.get("related_documents")
+        assert related_docs_list[0]["pk"] == legal_doc_relation.document.pk
         # undated should still be sorted last
-        assert related_docs_qs[-1].pk == undated_doc_relation.pk
+        assert related_docs_list[-1]["pk"] == undated_doc_relation.document.pk
 
     def test_get_context_data(self, client):
         # should 404 when no documents related to person

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -1,5 +1,4 @@
 import re
-import time
 from ast import literal_eval
 from collections import defaultdict
 from urllib.parse import urlparse

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -1,5 +1,6 @@
 import re
 from ast import literal_eval
+from collections import defaultdict
 from urllib.parse import urlparse
 
 from dal import autocomplete
@@ -7,7 +8,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import Count, Q
+from django.db.models import Count, Prefetch, Q
 from django.forms import ValidationError
 from django.http import Http404, HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.urls import resolve, reverse
@@ -17,8 +18,10 @@ from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 from django.views.generic import DetailView, FormView, ListView
 from django.views.generic.edit import FormMixin
+from natsort import natsort_key
 
-from geniza.corpus.dates import PartialDate
+from geniza.corpus.dates import DocumentDateMixin, standard_date_display
+from geniza.corpus.models import Dating, Document, DocumentType, TextBlock
 from geniza.corpus.views import SolrDateRangeMixin
 from geniza.entities.forms import (
     PersonDocumentRelationTypeMergeForm,
@@ -328,8 +331,7 @@ class RelatedDocumentsMixin:
 
     def page_description(self):
         """Description of an entity related documents page, with count"""
-        obj = self.get_object()
-        count = getattr(obj, self.relation_field).count()
+        count = len(self.get_related())
         # Translators: description of related documents page, for search engines
         return ngettext(
             "%(count)d related document",
@@ -342,57 +344,164 @@ class RelatedDocumentsMixin:
     def get_related(self):
         """Get and process the queryset of related documents"""
         obj = self.get_object()
-        related_documents = getattr(obj, self.relation_field).all()
 
-        sort = self.request.GET.get("sort", "shelfmark_asc")
+        # values() fields we want, including uncertain if person-doc relation
+        fields = [
+            "document",
+            "document__shelfmark_override",
+            "document__doctype",
+            "document__doc_date_original",
+            "document__doc_date_standard",
+            "document__doc_date_calendar",
+            "type",
+            "uncertain" if "person" in self.relation_field else None,
+        ]
+        doc_relations = getattr(obj, self.relation_field).values(
+            *[f for f in fields if f]
+        )
 
-        sort_dir = "-" if sort.endswith("desc") else ""
+        # get needed related items in batch queries
+        doc_pks = doc_relations.values_list("document", flat=True)
 
-        if "shelfmark" in sort:
-            # annotate and sort by combined shelfmarks
-            related_documents = related_documents.annotate(
-                shelfmk_all=ArrayAgg("document__textblock__fragment__shelfmark")
-            ).order_by(f"{sort_dir}shelfmk_all")
+        # get textblocks so we can get all shelfmarks per document
+        textblocks = TextBlock.objects.filter(
+            certain=True, document__pk__in=doc_pks
+        ).values("document__pk", "fragment__shelfmark")
+        shelfmarks_by_doc = defaultdict(set)
+        for tb in textblocks:
+            shelfmarks_by_doc[tb["document__pk"]].add(tb["fragment__shelfmark"])
 
-        if "doctype" in sort:
-            # sort by doc type (display label first then name)
-            related_documents = related_documents.order_by(
-                f"{sort_dir}document__doctype__display_label",
-                f"{sort_dir}document__doctype__name",
+        # just for thumbnail generation, use prefetching on Document instances
+        thumbnail_docs = Document.objects.filter(pk__in=doc_pks).prefetch_related(
+            Prefetch(
+                "textblock_set",
+                queryset=TextBlock.objects.filter(certain=True)
+                .select_related("fragment__manifest")
+                .prefetch_related("fragment__manifest__canvases"),
+            )
+        )
+        thumbnail_docs_by_pk = {doc.pk: doc for doc in thumbnail_docs}
+
+        # get document types
+        doctypes = DocumentType.objects.filter(document__pk__in=doc_pks).values(
+            "document__pk", "name", "display_label"
+        )
+        doctypes_by_doc = {
+            d["document__pk"]: (d["display_label"] or d["name"]) for d in doctypes
+        }
+
+        # get datings
+        datings = Dating.objects.filter(document__pk__in=doc_pks).values(
+            "document__pk", "display_date", "standard_date"
+        )
+        datings_by_doc = defaultdict(list)
+        for d in datings:
+            datings_by_doc[d["document__pk"]].append(d)
+
+        # get relationship types
+        reltype_pks = doc_relations.values_list("type", flat=True)
+        reltypes = self.relation_type_class.objects.filter(pk__in=reltype_pks).values(
+            "pk", "name"
+        )
+        reltypes_by_pk = {r["pk"]: r["name"] for r in reltypes}
+
+        # produce the set to render; use dict keyed on pk for deduplication
+        related_documents = {}
+        for rel in doc_relations:
+            doc_pk = rel["document"]
+            if doc_pk not in related_documents:
+                # get related items by doc pk
+                doctype_name = doctypes_by_doc.get(doc_pk)
+                doc_datings = datings_by_doc.get(doc_pk, [])
+                shelfmarks = shelfmarks_by_doc.get(doc_pk, set())
+                shelfmark = rel["document__shelfmark_override"] or " + ".join(
+                    shelfmarks
+                )
+                thumbnail_doc = thumbnail_docs_by_pk.get(doc_pk)
+                thumbnail = thumbnail_doc.list_thumbnail() if thumbnail_doc else ""
+
+                # get default date display without loading entire Document into memory (as it creates sub-queries)
+                original_date = (
+                    " ".join(
+                        [
+                            rel["document__doc_date_original"],
+                            dict(DocumentDateMixin.CALENDAR_CHOICES).get(
+                                rel["document__doc_date_calendar"]
+                            ),
+                        ]
+                    ).strip()
+                    if rel["document__doc_date_original"]
+                    else None
+                )
+                document_date = DocumentDateMixin.get_document_date(
+                    rel["document__doc_date_standard"], original_date
+                )
+                if document_date:
+                    # value for sorting, label for display
+                    document_date = {
+                        "value": rel["document__doc_date_standard"],
+                        "label": document_date,
+                    }
+                elif doc_datings:
+                    # use inferred date if one exists and no doc date
+                    dating = doc_datings[0]
+                    document_date = {
+                        "value": dating["standard_date"],
+                        "label": dating["display_date"]
+                        or standard_date_display(dating["standard_date"]),
+                    }
+
+                # build the initial dict for this doc
+                related_documents[doc_pk] = {
+                    "pk": doc_pk,
+                    "shelfmark": shelfmark,
+                    "doctype": doctype_name,
+                    "relations": [],
+                    "uncertain": rel.get("uncertain", None),
+                    "date": document_date,
+                    "thumbnail": thumbnail,
+                }
+
+            # add this relationship type to the relations list, including uncertain
+            relation_name = reltypes_by_pk.get(rel["type"])
+            related_documents[doc_pk]["relations"].append(
+                {
+                    "name": relation_name,
+                    "uncertain": rel.get("uncertain", None),
+                }
+            )
+            related_documents[doc_pk]["relations"] = sorted(
+                related_documents[doc_pk]["relations"], key=lambda r: r["name"]
             )
 
-        if "relation" in sort:
-            order = [
-                # sort by document-entity relation type name
-                f"{sort_dir}type__name",
-                # if this list is Person-Document relations, sort uncertains separately
-                "uncertain" if isinstance(obj, Person) else None,
-            ]
-            related_documents = related_documents.order_by(*[o for o in order if o])
+        sort, dir = self.request.GET.get("sort", "shelfmark_asc").split("_")
+        reverse = dir == "desc"
 
+        # sort by passed sort, and fallback to shelfmark as tiebreaker
         if "date" in sort:
-            # sort by start or end of date range
-            if sort_dir == "-":
-                # sort nones at the bottom, i.e., give them the lowest date
-                none = PartialDate("0001").numeric_format(mode="min")
-                # sort by maximum possible date for the end of the range, descending
-                (mode, idx, reverse) = ("max", 1, True)
-            else:
-                # sort nones at the bottom, i.e., give them the highest date
-                none = PartialDate("9999").numeric_format(mode="max")
-                # sort by minimum possible date for the start of the range, ascending
-                (mode, idx, reverse) = ("min", 0, False)
-
-            # NOTE: is there a way to do this with in-DB sorting?
-            related_documents = sorted(
-                related_documents,
-                key=lambda t: (
-                    t.document.dating_range()[idx].numeric_format(mode=mode)
-                    if t.document.dating_range()[idx]
-                    else none
-                ),
-                reverse=reverse,
+            # sort nones at the bottom, i.e., give them the lowest date if reversed,
+            # give them the highest date if not
+            none_date = "0" if reverse else "9999"
+            sort_fn = lambda doc: (
+                doc["date"]["value"] if doc["date"] else none_date,
+                natsort_key(doc["shelfmark"]),
             )
+        elif "relation" in sort:
+            # sort uncertains after relation name
+            sort_fn = lambda doc: (
+                ", ".join(
+                    f"{r['name']}{' (uncertain)' if r['uncertain'] else ''}"
+                    for r in doc["relations"]
+                ),
+                natsort_key(doc["shelfmark"]),
+            )
+        elif "shelfmark" in sort:
+            sort_fn = lambda doc: natsort_key(doc["shelfmark"])
+        else:
+            sort_fn = lambda doc: (doc.get(sort, ""), natsort_key(doc["shelfmark"]))
+        related_documents = sorted(
+            related_documents.values(), key=sort_fn, reverse=reverse
+        )
 
         return related_documents
 
@@ -482,6 +591,7 @@ class PersonDocumentsView(RelatedDocumentsMixin, PersonDetailView):
     template_name = "entities/person_related_documents.html"
     viewname = "entities:person-documents"
     relation_field = "persondocumentrelation_set"
+    relation_type_class = PersonDocumentRelationType
 
 
 class PersonPeopleView(RelatedPeopleMixin, PersonDetailView):
@@ -651,6 +761,7 @@ class PlaceDocumentsView(RelatedDocumentsMixin, PlaceDetailView):
     template_name = "entities/place_related_documents.html"
     viewname = "entities:place-documents"
     relation_field = "documentplacerelation_set"
+    relation_type_class = PersonDocumentRelationType
 
 
 class PlacePeopleView(RelatedPeopleMixin, PlaceDetailView):

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -31,6 +31,7 @@ from geniza.entities.forms import (
     PlaceListForm,
 )
 from geniza.entities.models import (
+    DocumentPlaceRelationType,
     PastPersonSlug,
     PastPlaceSlug,
     Person,
@@ -766,7 +767,7 @@ class PlaceDocumentsView(RelatedDocumentsMixin, PlaceDetailView):
     template_name = "entities/place_related_documents.html"
     viewname = "entities:place-documents"
     relation_field = "documentplacerelation_set"
-    relation_type_class = PersonDocumentRelationType
+    relation_type_class = DocumentPlaceRelationType
 
 
 class PlacePeopleView(RelatedPeopleMixin, PlaceDetailView):

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -456,6 +456,7 @@ class RelatedDocumentsMixin:
                 # build the initial dict for this doc
                 related_documents[doc_pk] = {
                     "pk": doc_pk,
+                    "url": reverse("corpus:document", args=[str(doc_pk)]),
                     "shelfmark": shelfmark,
                     "doctype": doctype_name,
                     "relations": [],
@@ -477,13 +478,13 @@ class RelatedDocumentsMixin:
             )
 
         sort, dir = self.request.GET.get("sort", "shelfmark_asc").split("_")
-        reverse = dir == "desc"
+        desc = dir == "desc"
 
         # sort by passed sort, and fallback to shelfmark as tiebreaker
         if "date" in sort:
             # sort nones at the bottom, i.e., give them the lowest date if reversed,
             # give them the highest date if not
-            none_date = "0" if reverse else "9999"
+            none_date = "0" if desc else "9999"
             sort_fn = lambda doc: (
                 doc["date"]["value"] if doc["date"] else none_date,
                 natsort_key(doc["shelfmark"]),
@@ -502,7 +503,7 @@ class RelatedDocumentsMixin:
         else:
             sort_fn = lambda doc: (doc.get(sort, ""), natsort_key(doc["shelfmark"]))
         related_documents = sorted(
-            related_documents.values(), key=sort_fn, reverse=reverse
+            related_documents.values(), key=sort_fn, reverse=desc
         )
 
         self.set_page_description(len(related_documents))

--- a/sitemedia/scss/pages/_related.scss
+++ b/sitemedia/scss/pages/_related.scss
@@ -135,6 +135,9 @@ main.place table.related-table {
                 font-weight: 700;
             }
         }
+        &.reltype {
+            gap: 0.25rem;
+        }
     }
     .admin-thumbnail {
         max-height: 60px;


### PR DESCRIPTION
## In this PR

Per #1781:
- For a Person's (or Place's!) front-end Related Documents page:
   - Batch queries for document shelfmarks (`Fragment.shelfmark` related to document by `TextBlock`), dates (`Dating`), types (`DocumentType`), and relationship names (`PersonDocumentRelationType` / `DocumentPlaceRelationType`)
   - Make date calculation independent from `Dating` model lookups so that the logic can be used on prefetched records
   - Prevent network requests for IIIF manifests during lookups for document thumbnails, so as only to use cached manifests
   - Prevent additional query for page description count
   - Update template and unit tests to account for changes
- For a Person's main detail page, use `prefetch_related` to batch the queries for document dates, in order to get person's active and deceased dates

This optimization takes us from multiple queries per record to a handful of queries total, regardless of the number of records.