### PR TITLE
Alphabetize Document type dropdown (#1496)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -566,6 +566,12 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
     class Media:
         css = {"all": ("css/admin-local.css",)}
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # override to alphabetize doctype dropdown
+        if db_field.name == "doctype":
+            kwargs["queryset"] = DocumentType.objects.order_by("name")
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
     def get_form(self, request, obj=None, **kwargs):
         # Override to inject help text into display field
         help_texts = {

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -37,6 +37,7 @@ from geniza.corpus.admin import (
 from geniza.corpus.models import (
     Collection,
     Document,
+    DocumentType,
     Fragment,
     LanguageScript,
     Provenance,
@@ -376,6 +377,19 @@ class TestDocumentAdmin:
         response = admin_client.get(url)
         assert footnote_log_entry not in response.context["footnote_action_list"]
         assert annotation_log_entry not in response.context["annotation_action_list"]
+
+    @pytest.mark.django_db
+    def test_formfield_for_foreignkey(self):
+        doc_admin = DocumentAdmin(model=Document, admin_site=admin.site)
+        doctype_field = Document._meta.get_field("doctype")
+        doctype_z = DocumentType.objects.create(name="ZZZ")
+        doctype_a = DocumentType.objects.create(name="000")
+        formfield = doc_admin.formfield_for_foreignkey(
+            doctype_field, Mock(), queryset=None
+        )
+        # queryset should be sorted alphabetically
+        assert formfield.queryset.first().pk == doctype_a.pk
+        assert formfield.queryset.last().pk == doctype_z.pk
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Associated Issue(s):** #1496

### Changes in this PR

- Order the form field dropdown for document type alphabetically