### PR TITLE
Bump @hotwired/turbo to v8.0.13 (#1482)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@babel/preset-env": "^7.15.0",
         "@hotwired/stimulus": "^3.0.1",
         "@hotwired/stimulus-webpack-helpers": "^1.0.1",
-        "@hotwired/turbo": "^7.1.0",
+        "@hotwired/turbo": "^8.0.13",
         "@recogito/annotorious": "^2.7.13",
         "@recogito/annotorious-openseadragon": "^2.7.17",
         "annotorious-tahqiq": "^1.5.1",
@@ -1565,9 +1565,12 @@
       }
     },
     "node_modules/@hotwired/turbo": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
-      "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.13.tgz",
+      "integrity": "sha512-M7qXUqcGab6G5PKOiwhgbByTtrPgKPFCTMNQ52QhzUEXEqmp0/ApEguUesh/FPiUjrmFec+3lq98KsWnYY2C7g==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -9980,9 +9983,9 @@
       "requires": {}
     },
     "@hotwired/turbo": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.1.0.tgz",
-      "integrity": "sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA=="
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-8.0.13.tgz",
+      "integrity": "sha512-M7qXUqcGab6G5PKOiwhgbByTtrPgKPFCTMNQ52QhzUEXEqmp0/ApEguUesh/FPiUjrmFec+3lq98KsWnYY2C7g=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.15.0",
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
-    "@hotwired/turbo": "^7.1.0",
+    "@hotwired/turbo": "^8.0.13",
     "@recogito/annotorious": "^2.7.13",
     "@recogito/annotorious-openseadragon": "^2.7.17",
     "annotorious-tahqiq": "^1.5.1",


### PR DESCRIPTION
**Associated Issue(s):** #1482

### Changes in this PR
_Include all key changes in this pull request_

- Upgrade `@hotwired/turbo` to fix an issue where stale page metadata would be persisted across turbo frame loads