### PR TITLE
Fix nav hover indicator issue with chrome (#1794)

### DIFF
--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -445,7 +445,7 @@ nav#site-nav {
             content: "\00000a"; // Newline
             white-space: pre;
             order: 2;
-            flex: 1 0 117px;
+            flex: 1 1 117px;
             display: block;
             height: 16px;
             opacity: 0;


### PR DESCRIPTION
**Associated Issue(s):** #1794

### Changes in this PR

- Edit the `flex-grow`/`flex-shrink` for navbar hover indicators to resolve the issue with wrapping in Chrome