### PR TITLE
Prevent dupe fragments in public export (#1765)

### DIFF
--- a/geniza/corpus/metadata_export.py
+++ b/geniza/corpus/metadata_export.py
@@ -310,11 +310,16 @@ class PublicFragmentExporter(FragmentExporter):
     """
 
     def get_queryset(self):
-        return super().get_queryset().filter(documents__status=Document.PUBLIC)
+        # must use distinct() as filtering on documents__status produces
+        # duplicate rows for fragments on multiple documents
+        return (
+            super().get_queryset().filter(documents__status=Document.PUBLIC).distinct()
+        )
 
 
 class AdminFragmentExporter(FragmentExporter):
     "Admin fragment export variant; adds notes, review, and admin url fields."
+
     csv_fields = FragmentExporter.csv_fields + ["notes", "needs_review", "url_admin"]
 
     def get_export_data_dict(self, fragment):

--- a/geniza/corpus/tests/test_metadata_export.py
+++ b/geniza/corpus/tests/test_metadata_export.py
@@ -271,6 +271,10 @@ def test_public_fragment_export(fragment, multifragment, document, join):
     # should include both fragments
     assert fragment in qs_frags
     assert multifragment in qs_frags
+    # PublicFragmentExporter should not create duplicate rows for frag
+    # associated with multiple documents (fails without distinct())
+    assert PublicFragmentExporter().get_queryset().count() == 2
+    assert FragmentExporter().get_queryset().count() == 2
 
     # if we suppress join, then multifragment should no longer be included
     join.status = Document.SUPPRESSED

--- a/geniza/footnotes/metadata_export.py
+++ b/geniza/footnotes/metadata_export.py
@@ -25,6 +25,7 @@ class SourceExporter(Exporter):
         "languages",
         "url",
         "notes",
+        "citation",
         "num_footnotes",
     ]
 
@@ -63,6 +64,7 @@ class SourceExporter(Exporter):
             },
             "url": source.url,
             "notes": source.notes,
+            "citation": str(source),
             # count via annotated queryset
             "num_footnotes": source.footnote__count,
         }

--- a/geniza/footnotes/tests/test_footnote_metadata_export.py
+++ b/geniza/footnotes/tests/test_footnote_metadata_export.py
@@ -45,6 +45,9 @@ def test_source_export_data(source):
     data = src_exporter.get_export_data_dict(source_obj)
     assert not data["languages"]
 
+    # should include citation
+    assert data["citation"] == str(source)
+
 
 @pytest.mark.django_db
 def test_admin_source_export_data(source):


### PR DESCRIPTION
**Associated Issue(s):** #1765

### Changes in this PR

- Add `distinct()` call to `PublicFragmentExporter.get_queryset` to dedupe after `documents__status` filter