### PR TITLE
Handle Nones in Person "Related Documents" page doctype sort (#1781)

### DIFF
--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -413,7 +413,8 @@ class RelatedDocumentsMixin:
             doc_pk = rel["document"]
             if doc_pk not in related_documents:
                 # get related items by doc pk
-                doctype_name = doctypes_by_doc.get(doc_pk)
+                # translators: Label for unknown document type
+                doctype_name = doctypes_by_doc.get(doc_pk, _("Unknown type"))
                 doc_datings = datings_by_doc.get(doc_pk, [])
                 shelfmarks = shelfmarks_by_doc.get(doc_pk, set())
                 shelfmark = rel["document__shelfmark_override"] or " + ".join(

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-04-14 11:59-0400\n"
+"POT-Creation-Date: 2025-05-12 14:16-0400\n"
 "PO-Revision-Date: 2025-04-14 16:35\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: ar\n"
@@ -101,7 +102,7 @@ msgstr "النصوص المفرّغة"
 
 #. Translators: label for description RegEx field
 #. Translators: label for document description
-#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:144
 msgid "Description"
 msgstr "الوصف"
 
@@ -139,12 +140,11 @@ msgstr ""
 
 #. Translators: label for document type search form filter
 #: corpus/forms.py:296
-#| msgid "Input date"
 msgid "Document type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:116
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
@@ -165,7 +165,6 @@ msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
 #: corpus/forms.py:323
-#| msgid "Search Documents"
 msgid "Search mode"
 msgstr ""
 
@@ -178,9 +177,10 @@ msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
+#: corpus/forms.py:373 corpus/models.py:1029 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:242
+#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: entities/views.py:417
 msgid "Unknown type"
 msgstr "نوع غير معروف"
 
@@ -190,47 +190,56 @@ msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث �
 
 #: corpus/forms.py:436
 #, python-format
-msgid "Regular expression cannot contain { without a preceding character, without an integer afterwards, or without a closing }. %s"
+msgid ""
+"Regular expression cannot contain { without a preceding character, without "
+"an integer afterwards, or without a closing }. %s"
 msgstr ""
 
 #: corpus/forms.py:445
 #, python-format
-msgid "Regular expression cannot contain * without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain * without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
 #: corpus/forms.py:454
 #, python-format
-msgid "Regular expression cannot contain + without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain + without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
 #: corpus/forms.py:463
 #, python-format
-msgid "Regular expression cannot contain < or use a negative lookbehind query. %s"
+msgid ""
+"Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
 #: corpus/forms.py:473
 #, python-format
-msgid "Regular expression cannot contain the escape character \\ followed by an alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgid ""
+"Regular expression cannot contain the escape character \\ followed by an "
+"alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
-#: corpus/models.py:1128 templates/base.html:21
+#: corpus/models.py:1154 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1130
+#: corpus/models.py:1156
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "تجميع بواسطة %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1133
+#: corpus/models.py:1159
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "التجميع والنسخ بواسطة %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1135
+#: corpus/models.py:1161
 msgid "Additional restrictions may apply."
 msgstr "قد تطبق قيود إضافية."
 
@@ -269,12 +278,12 @@ msgid "Metadata"
 msgstr "بيانات التعريف"
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:56
+#: corpus/templates/corpus/document_detail.html:55
 msgid "Document Date"
 msgstr "تاريخ الوثيقة"
 
 #. Translators: Inferred dating label
-#: corpus/templates/corpus/document_detail.html:67
+#: corpus/templates/corpus/document_detail.html:66
 msgid "Inferred Date"
 msgid_plural "Inferred Dates"
 msgstr[0] ""
@@ -285,7 +294,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:84
+#: corpus/templates/corpus/document_detail.html:83
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "اللغة الأساسية"
@@ -296,7 +305,7 @@ msgstr[4] "اللغات الأساسية"
 msgstr[5] "اللغات الأساسية"
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:97
+#: corpus/templates/corpus/document_detail.html:96
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "اللغة الثانوية"
@@ -307,11 +316,11 @@ msgstr[4] "اللغات الثانوية"
 msgstr[5] "اللغات الثانوية"
 
 #. Translators: label for document content stats (number of translations, transcriptions, images)
-#: corpus/templates/corpus/document_detail.html:114
+#: corpus/templates/corpus/document_detail.html:113
 msgid "What's in the PGP"
 msgstr ""
 
-#: corpus/templates/corpus/document_detail.html:121
+#: corpus/templates/corpus/document_detail.html:120
 #, python-format
 msgid "%(n_transcriptions)s Transcription"
 msgid_plural "%(n_transcriptions)s Transcriptions"
@@ -322,7 +331,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: corpus/templates/corpus/document_detail.html:131
+#: corpus/templates/corpus/document_detail.html:130
 #, python-format
 msgid "%(n_translations)s Translation"
 msgid_plural "%(n_translations)s Translations"
@@ -336,7 +345,7 @@ msgstr[5] ""
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
-#: corpus/templates/corpus/document_detail.html:153
+#: corpus/templates/corpus/document_detail.html:152
 #: corpus/templates/corpus/snippets/document_result.html:113
 #: entities/forms.py:225 entities/forms.py:362
 #: entities/templates/entities/person_list.html:197
@@ -346,8 +355,8 @@ msgid "Related People"
 msgstr ""
 
 #. Translators: label for an uncertain Person-Document identification
-#: corpus/templates/corpus/document_detail.html:161
-#: entities/templates/entities/snippets/related_documents_table.html:53
+#: corpus/templates/corpus/document_detail.html:160
+#: entities/templates/entities/snippets/related_documents_table.html:55
 msgid "(uncertain)"
 msgstr ""
 
@@ -355,7 +364,7 @@ msgstr ""
 #. Translators: label for sort by number of related places
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
-#: corpus/templates/corpus/document_detail.html:173
+#: corpus/templates/corpus/document_detail.html:172
 #: corpus/templates/corpus/snippets/document_result.html:117
 #: entities/forms.py:227 entities/templates/entities/person_list.html:201
 #: entities/templates/entities/person_related_places.html:56
@@ -365,7 +374,7 @@ msgstr ""
 
 #. Translators: label for tags on a document
 #. Translators: Person "tags" column header on the browse page
-#: corpus/templates/corpus/document_detail.html:191
+#: corpus/templates/corpus/document_detail.html:190
 #: corpus/templates/corpus/snippets/document_result.html:130
 #: entities/templates/entities/person_list.html:137
 msgid "Tags"
@@ -376,8 +385,13 @@ msgstr "العلامات"
 msgid "Additional metadata"
 msgstr ""
 
+#. Translators: label for the provenance of document fragments
+#: corpus/templates/corpus/document_detail.html:212
+msgid "Provenance"
+msgstr ""
+
 #. Translators: Document fragment collection(s) label
-#: corpus/templates/corpus/document_detail.html:211
+#: corpus/templates/corpus/document_detail.html:226
 msgid "Collection"
 msgid_plural "Collections"
 msgstr[0] ""
@@ -388,45 +402,46 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: label for historical/old shelfmarks on document fragments
-#: corpus/templates/corpus/document_detail.html:228
+#: corpus/templates/corpus/document_detail.html:243
 msgid "Historical shelfmarks"
 msgstr ""
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:232
+#: corpus/templates/corpus/document_detail.html:247
 msgid "Input date"
 msgstr "تاريخ الإدخال"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:235
+#: corpus/templates/corpus/document_detail.html:250
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    In PGP since %(date)s\n"
 "                "
 msgstr ""
 
 #. Translators: label for a citation for a document detail page
 #. Translators: label for a citation for a person page
-#: corpus/templates/corpus/document_detail.html:250
+#: corpus/templates/corpus/document_detail.html:265
 #: entities/templates/entities/person_detail.html:131
 msgid "How to cite this record:"
 msgstr ""
 
 #. Translators: accessibility label for a citation for a document
 #. Translators: accessibility label for a citation for a person
-#: corpus/templates/corpus/document_detail.html:254
+#: corpus/templates/corpus/document_detail.html:269
 #: entities/templates/entities/person_detail.html:135
 msgid "Citation"
 msgstr ""
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:259
+#: corpus/templates/corpus/document_detail.html:274
 msgid "Link to this document:"
 msgstr ""
 
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/templates/corpus/document_detail.html:266
+#: corpus/templates/corpus/document_detail.html:281
 #: entities/templates/entities/person_detail.html:146
 msgid "Permalink"
 msgstr "رابط دائم"
@@ -455,8 +470,10 @@ msgid "in"
 msgstr ""
 
 #: corpus/templates/corpus/document_list.html:59
-msgid "\n"
-"                            Case sensitive, must match entire shelfmark. Type one shelfmark,\n"
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
 "                            even if part of a join, for best results.\n"
 "                        "
 msgstr ""
@@ -545,13 +562,11 @@ msgid "Jewish Theological Seminary logo"
 msgstr "شعار Jewish Theological Seminary"
 
 #: corpus/templates/corpus/snippets/document_result.html:23
-#| msgid "Input date"
 msgid "Document date"
 msgstr ""
 
 #. Translators: label for inferred date on a document
 #: corpus/templates/corpus/snippets/document_result.html:33
-#| msgid "Input date"
 msgid "Inferred date"
 msgstr ""
 
@@ -571,7 +586,6 @@ msgstr[5] ""
 #: entities/forms.py:223 entities/forms.py:360
 #: entities/templates/entities/person_list.html:193
 #: entities/templates/entities/place_list.html:98
-#| msgid "Search Documents"
 msgid "Related Documents"
 msgstr ""
 
@@ -658,8 +672,10 @@ msgstr ""
 
 #. Translators: general search help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:7
-msgid "\n"
-"        Use keywords or phrases in any language to return matching or similar\n"
+msgid ""
+"\n"
+"        Use keywords or phrases in any language to return matching or "
+"similar\n"
 "        results across all fields. Arabic script searches will return both\n"
 "        Arabic and Judaeo-Arabic transcription content.\n"
 "    "
@@ -673,7 +689,8 @@ msgstr ""
 #. Translators: regular expressions search mode help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:18
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "        Use Hebrew or Arabic script to find precise matches in the\n"
 "        transcriptions. See\n"
 "        <a data-turbo=\"false\" href=\"%(howto_url)s\">How to Search</a>\n"
@@ -688,10 +705,13 @@ msgstr ""
 
 #. Translators: regular expression tip 1
 #: corpus/templates/corpus/snippets/document_search_helptext.html:31
-msgid "\n"
+msgid ""
+"\n"
 "            If you're looking for a word with one missing letter, use a\n"
-"            period. Two missing letters, use two periods or <code>{2}</code>.\n"
-"            Increase the number in the curly brackets to increase the number of\n"
+"            period. Two missing letters, use two periods or <code>{2}</"
+"code>.\n"
+"            Increase the number in the curly brackets to increase the number "
+"of\n"
 "            characters, or insert a range with a comma in between, ex.\n"
 "            <code>{0,5}</code>.\n"
 "        "
@@ -699,7 +719,8 @@ msgstr ""
 
 #. Translators: regular expression tip 2
 #: corpus/templates/corpus/snippets/document_search_helptext.html:41
-msgid "\n"
+msgid ""
+"\n"
 "            If you don't know how many characters are missing, use\n"
 "            <code>.*</code>.\n"
 "        "
@@ -707,8 +728,10 @@ msgstr ""
 
 #. Translators: regular expression tip 3
 #: corpus/templates/corpus/snippets/document_search_helptext.html:48
-msgid "\n"
-"            If you know which characters you want, use square brackets to find\n"
+msgid ""
+"\n"
+"            If you know which characters you want, use square brackets to "
+"find\n"
 "            multiple spellings, ex. <code>[יו]</code> for yud or vav.\n"
 "        "
 msgstr ""
@@ -787,11 +810,11 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:210
+#: corpus/templates/corpus/snippets/document_transcription.html:211
 msgid "Zoom and Rotate"
 msgstr "تكبير و تدوير"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:245
+#: corpus/templates/corpus/snippets/document_transcription.html:246
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "عرض %(related_doc)s"
@@ -825,7 +848,6 @@ msgstr "التالي"
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
 #: corpus/views.py:82 templates/snippets/menu.html:11
-#| msgid "Input date"
 msgid "Documents"
 msgstr "وثائق"
 
@@ -834,18 +856,20 @@ msgstr "وثائق"
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
-#: corpus/views.py:332 entities/views.py:748
+#: corpus/views.py:332 entities/views.py:867
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:334 entities/views.py:750
+#: corpus/views.py:334 entities/views.py:869
 #, python-format
 msgid "Before %s"
 msgstr ""
 
 #: corpus/views.py:405
-msgid "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses."
 msgstr ""
 
 #. Translators: title of document scholarship page
@@ -871,7 +895,7 @@ msgstr[5] "%(count)d سجلات منح دراسية"
 msgid "Related documents for %(doc)s"
 msgstr "المستندات ذات الصلة لـ %(doc)s"
 
-#: corpus/views.py:595 entities/views.py:335
+#: corpus/views.py:595 entities/views.py:339
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -899,7 +923,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:764
+#: entities/forms.py:206 entities/views.py:883
 msgid "Detail page available"
 msgstr ""
 
@@ -954,35 +978,35 @@ msgstr ""
 msgid "Descending"
 msgstr ""
 
-#: entities/models.py:377
+#: entities/models.py:378
 msgid "Male"
 msgstr ""
 
-#: entities/models.py:378
+#: entities/models.py:379
 msgid "Female"
 msgstr ""
 
-#: entities/models.py:379
+#: entities/models.py:380
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1243
+#: entities/models.py:1248
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1244
+#: entities/models.py:1249
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1245
+#: entities/models.py:1250
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1246
+#: entities/models.py:1251
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1247
+#: entities/models.py:1252
 msgid "Ambiguity"
 msgstr ""
 
@@ -1075,7 +1099,8 @@ msgstr ""
 #. Translators: range of search results on the current page, out of total
 #: entities/templates/entities/person_list.html:212
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "        "
 msgstr ""
@@ -1140,7 +1165,8 @@ msgstr ""
 #. Translators: range of search results on the current page, out of total
 #: entities/templates/entities/place_list.html:113
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "                "
 msgstr ""
@@ -1188,7 +1214,6 @@ msgstr ""
 
 #. Translators: table header for document name (shelfmark)
 #: entities/templates/entities/snippets/related_documents_table.html:10
-#| msgid "Input date"
 msgid "Document"
 msgstr ""
 
@@ -1198,18 +1223,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:327
+#: entities/views.py:333
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:422
+#: entities/views.py:539
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:430 entities/views.py:500
+#: entities/views.py:547 entities/views.py:618
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1221,12 +1246,12 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:559
+#: entities/views.py:677
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:567
+#: entities/views.py:685
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1239,23 +1264,23 @@ msgstr[5] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:672 templates/snippets/menu.html:19
+#: entities/views.py:791 templates/snippets/menu.html:19
 msgid "People"
 msgstr "اشخاص"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:674
+#: entities/views.py:793
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:857 templates/snippets/menu.html:26
+#: entities/views.py:976 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "أَماكِن"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:859
+#: entities/views.py:978
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
@@ -1264,14 +1289,21 @@ msgid "Edition"
 msgstr "الطبعة"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "نص بديل للمستخدمين ضعاف البصر\n"
+msgstr ""
+"نص بديل للمستخدمين ضعاف البصر\n"
 "لإيصال الرسالة المقصودة للصورة في هذا السياق بإيجاز."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار الرئيسية من الرسوم. يسمح بفقرات متعددة."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"هذا النص سوف يقرأ فقط للمستخدمين غير المبصرين ويجب أن يصف الرؤى أو الأفكار "
+"الرئيسية من الرسوم. يسمح بفقرات متعددة."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -1401,4 +1433,3 @@ msgstr "العودة إلى القائمة الرئيسية"
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
-

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-04-14 11:59-0400\n"
+"POT-Creation-Date: 2025-05-12 14:16-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -101,7 +101,7 @@ msgstr ""
 
 #. Translators: label for description RegEx field
 #. Translators: label for document description
-#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:144
 msgid "Description"
 msgstr ""
 
@@ -145,7 +145,7 @@ msgid "Document type"
 msgstr "Input date"
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:116
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
@@ -180,9 +180,10 @@ msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
+#: corpus/forms.py:373 corpus/models.py:1029 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:242
+#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: entities/views.py:417
 msgid "Unknown type"
 msgstr ""
 
@@ -224,24 +225,24 @@ msgid ""
 "alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
-#: corpus/models.py:1128 templates/base.html:21
+#: corpus/models.py:1154 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1130
+#: corpus/models.py:1156
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1133
+#: corpus/models.py:1159
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr ""
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1135
+#: corpus/models.py:1161
 msgid "Additional restrictions may apply."
 msgstr ""
 
@@ -272,44 +273,44 @@ msgid "Metadata"
 msgstr ""
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:56
+#: corpus/templates/corpus/document_detail.html:55
 msgid "Document Date"
 msgstr ""
 
 #. Translators: Inferred dating label
-#: corpus/templates/corpus/document_detail.html:67
+#: corpus/templates/corpus/document_detail.html:66
 msgid "Inferred Date"
 msgid_plural "Inferred Dates"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:84
+#: corpus/templates/corpus/document_detail.html:83
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:97
+#: corpus/templates/corpus/document_detail.html:96
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for document content stats (number of translations, transcriptions, images)
-#: corpus/templates/corpus/document_detail.html:114
+#: corpus/templates/corpus/document_detail.html:113
 msgid "What's in the PGP"
 msgstr ""
 
-#: corpus/templates/corpus/document_detail.html:121
+#: corpus/templates/corpus/document_detail.html:120
 #, python-format
 msgid "%(n_transcriptions)s Transcription"
 msgid_plural "%(n_transcriptions)s Transcriptions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: corpus/templates/corpus/document_detail.html:131
+#: corpus/templates/corpus/document_detail.html:130
 #, python-format
 msgid "%(n_translations)s Translation"
 msgid_plural "%(n_translations)s Translations"
@@ -319,7 +320,7 @@ msgstr[1] ""
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
-#: corpus/templates/corpus/document_detail.html:153
+#: corpus/templates/corpus/document_detail.html:152
 #: corpus/templates/corpus/snippets/document_result.html:113
 #: entities/forms.py:225 entities/forms.py:362
 #: entities/templates/entities/person_list.html:197
@@ -329,8 +330,8 @@ msgid "Related People"
 msgstr ""
 
 #. Translators: label for an uncertain Person-Document identification
-#: corpus/templates/corpus/document_detail.html:161
-#: entities/templates/entities/snippets/related_documents_table.html:53
+#: corpus/templates/corpus/document_detail.html:160
+#: entities/templates/entities/snippets/related_documents_table.html:55
 msgid "(uncertain)"
 msgstr ""
 
@@ -338,7 +339,7 @@ msgstr ""
 #. Translators: label for sort by number of related places
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
-#: corpus/templates/corpus/document_detail.html:173
+#: corpus/templates/corpus/document_detail.html:172
 #: corpus/templates/corpus/snippets/document_result.html:117
 #: entities/forms.py:227 entities/templates/entities/person_list.html:201
 #: entities/templates/entities/person_related_places.html:56
@@ -348,7 +349,7 @@ msgstr ""
 
 #. Translators: label for tags on a document
 #. Translators: Person "tags" column header on the browse page
-#: corpus/templates/corpus/document_detail.html:191
+#: corpus/templates/corpus/document_detail.html:190
 #: corpus/templates/corpus/snippets/document_result.html:130
 #: entities/templates/entities/person_list.html:137
 msgid "Tags"
@@ -359,25 +360,30 @@ msgstr ""
 msgid "Additional metadata"
 msgstr ""
 
+#. Translators: label for the provenance of document fragments
+#: corpus/templates/corpus/document_detail.html:212
+msgid "Provenance"
+msgstr ""
+
 #. Translators: Document fragment collection(s) label
-#: corpus/templates/corpus/document_detail.html:211
+#: corpus/templates/corpus/document_detail.html:226
 msgid "Collection"
 msgid_plural "Collections"
 msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: label for historical/old shelfmarks on document fragments
-#: corpus/templates/corpus/document_detail.html:228
+#: corpus/templates/corpus/document_detail.html:243
 msgid "Historical shelfmarks"
 msgstr ""
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:232
+#: corpus/templates/corpus/document_detail.html:247
 msgid "Input date"
 msgstr "Input date"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:235
+#: corpus/templates/corpus/document_detail.html:250
 #, python-format
 msgid ""
 "\n"
@@ -387,26 +393,26 @@ msgstr ""
 
 #. Translators: label for a citation for a document detail page
 #. Translators: label for a citation for a person page
-#: corpus/templates/corpus/document_detail.html:250
+#: corpus/templates/corpus/document_detail.html:265
 #: entities/templates/entities/person_detail.html:131
 msgid "How to cite this record:"
 msgstr ""
 
 #. Translators: accessibility label for a citation for a document
 #. Translators: accessibility label for a citation for a person
-#: corpus/templates/corpus/document_detail.html:254
+#: corpus/templates/corpus/document_detail.html:269
 #: entities/templates/entities/person_detail.html:135
 msgid "Citation"
 msgstr ""
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:259
+#: corpus/templates/corpus/document_detail.html:274
 msgid "Link to this document:"
 msgstr ""
 
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/templates/corpus/document_detail.html:266
+#: corpus/templates/corpus/document_detail.html:281
 #: entities/templates/entities/person_detail.html:146
 msgid "Permalink"
 msgstr ""
@@ -753,11 +759,11 @@ msgid_plural "Translators: %(eds)s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:210
+#: corpus/templates/corpus/snippets/document_transcription.html:211
 msgid "Zoom and Rotate"
 msgstr ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:245
+#: corpus/templates/corpus/snippets/document_transcription.html:246
 #, python-format
 msgid "View %(related_doc)s"
 msgstr ""
@@ -801,12 +807,12 @@ msgstr "Input date"
 msgid "Search and browse Geniza documents."
 msgstr ""
 
-#: corpus/views.py:332 entities/views.py:748
+#: corpus/views.py:332 entities/views.py:867
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:334 entities/views.py:750
+#: corpus/views.py:334 entities/views.py:869
 #, python-format
 msgid "Before %s"
 msgstr ""
@@ -836,7 +842,7 @@ msgstr[1] ""
 msgid "Related documents for %(doc)s"
 msgstr ""
 
-#: corpus/views.py:595 entities/views.py:335
+#: corpus/views.py:595 entities/views.py:339
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -860,7 +866,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:764
+#: entities/forms.py:206 entities/views.py:883
 msgid "Detail page available"
 msgstr ""
 
@@ -915,35 +921,35 @@ msgstr ""
 msgid "Descending"
 msgstr ""
 
-#: entities/models.py:377
+#: entities/models.py:378
 msgid "Male"
 msgstr ""
 
-#: entities/models.py:378
+#: entities/models.py:379
 msgid "Female"
 msgstr ""
 
-#: entities/models.py:379
+#: entities/models.py:380
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1243
+#: entities/models.py:1248
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1244
+#: entities/models.py:1249
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1245
+#: entities/models.py:1250
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1246
+#: entities/models.py:1251
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1247
+#: entities/models.py:1252
 msgid "Ambiguity"
 msgstr ""
 
@@ -1158,18 +1164,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:327
+#: entities/views.py:333
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:422
+#: entities/views.py:539
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:430 entities/views.py:500
+#: entities/views.py:547 entities/views.py:618
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1177,12 +1183,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:559
+#: entities/views.py:677
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:567
+#: entities/views.py:685
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1191,23 +1197,23 @@ msgstr[1] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:672 templates/snippets/menu.html:19
+#: entities/views.py:791 templates/snippets/menu.html:19
 msgid "People"
 msgstr ""
 
 #. Translators: description of people list/browse page
-#: entities/views.py:674
+#: entities/views.py:793
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:857 templates/snippets/menu.html:26
+#: entities/views.py:976 templates/snippets/menu.html:26
 msgid "Places"
 msgstr ""
 
 #. Translators: description of places list/browse page
-#: entities/views.py:859
+#: entities/views.py:978
 msgid "Browse places present in Geniza documents."
 msgstr ""
 

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-04-14 11:59-0400\n"
+"POT-Creation-Date: 2025-05-12 14:16-0400\n"
 "PO-Revision-Date: 2025-04-14 16:35\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: he\n"
@@ -101,7 +102,7 @@ msgstr "תיעתוק"
 
 #. Translators: label for description RegEx field
 #. Translators: label for document description
-#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:145
+#: corpus/forms.py:260 corpus/templates/corpus/document_detail.html:144
 msgid "Description"
 msgstr "תיאור"
 
@@ -139,12 +140,11 @@ msgstr ""
 
 #. Translators: label for document type search form filter
 #: corpus/forms.py:296
-#| msgid "Input date"
 msgid "Document type"
 msgstr ""
 
 #. Translators: label for "has image" search form filter
-#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:117
+#: corpus/forms.py:300 corpus/templates/corpus/document_detail.html:116
 #: corpus/templates/corpus/snippets/document_transcription.html:61
 msgid "Image"
 msgstr ""
@@ -165,7 +165,6 @@ msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
 #: corpus/forms.py:323
-#| msgid "Search Documents"
 msgid "Search mode"
 msgstr ""
 
@@ -178,9 +177,10 @@ msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:373 corpus/models.py:1005 corpus/solr_queryset.py:342
+#: corpus/forms.py:373 corpus/models.py:1029 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
-#: corpus/templates/corpus/snippets/document_transcription.html:242
+#: corpus/templates/corpus/snippets/document_transcription.html:243
+#: entities/views.py:417
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
 
@@ -190,47 +190,56 @@ msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת 
 
 #: corpus/forms.py:436
 #, python-format
-msgid "Regular expression cannot contain { without a preceding character, without an integer afterwards, or without a closing }. %s"
+msgid ""
+"Regular expression cannot contain { without a preceding character, without "
+"an integer afterwards, or without a closing }. %s"
 msgstr ""
 
 #: corpus/forms.py:445
 #, python-format
-msgid "Regular expression cannot contain * without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain * without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
 #: corpus/forms.py:454
 #, python-format
-msgid "Regular expression cannot contain + without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain + without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
 #: corpus/forms.py:463
 #, python-format
-msgid "Regular expression cannot contain < or use a negative lookbehind query. %s"
+msgid ""
+"Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
 #: corpus/forms.py:473
 #, python-format
-msgid "Regular expression cannot contain the escape character \\ followed by an alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgid ""
+"Regular expression cannot contain the escape character \\ followed by an "
+"alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
-#: corpus/models.py:1128 templates/base.html:21
+#: corpus/models.py:1154 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1130
+#: corpus/models.py:1156
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "קובץ על-ידי %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1133
+#: corpus/models.py:1159
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "קובץ ותועתק על-ידי %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1135
+#: corpus/models.py:1161
 msgid "Additional restrictions may apply."
 msgstr "ייתכנו מגבלות נוספות."
 
@@ -265,12 +274,12 @@ msgid "Metadata"
 msgstr "מטא-דאטא"
 
 #. Translators: label for date of this document, if known
-#: corpus/templates/corpus/document_detail.html:56
+#: corpus/templates/corpus/document_detail.html:55
 msgid "Document Date"
 msgstr "תאריך המסמך"
 
 #. Translators: Inferred dating label
-#: corpus/templates/corpus/document_detail.html:67
+#: corpus/templates/corpus/document_detail.html:66
 msgid "Inferred Date"
 msgid_plural "Inferred Dates"
 msgstr[0] ""
@@ -279,7 +288,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: Primary language label
-#: corpus/templates/corpus/document_detail.html:84
+#: corpus/templates/corpus/document_detail.html:83
 msgid "Primary Language"
 msgid_plural "Primary Languages"
 msgstr[0] "שפה עיקרית"
@@ -288,7 +297,7 @@ msgstr[2] "שפות עיקריות"
 msgstr[3] "שפות עיקריות"
 
 #. Translators: Secondary language label
-#: corpus/templates/corpus/document_detail.html:97
+#: corpus/templates/corpus/document_detail.html:96
 msgid "Secondary Language"
 msgid_plural "Secondary Languages"
 msgstr[0] "שפה משנית"
@@ -297,11 +306,11 @@ msgstr[2] "שפות משניות"
 msgstr[3] "שפות משניות"
 
 #. Translators: label for document content stats (number of translations, transcriptions, images)
-#: corpus/templates/corpus/document_detail.html:114
+#: corpus/templates/corpus/document_detail.html:113
 msgid "What's in the PGP"
 msgstr ""
 
-#: corpus/templates/corpus/document_detail.html:121
+#: corpus/templates/corpus/document_detail.html:120
 #, python-format
 msgid "%(n_transcriptions)s Transcription"
 msgid_plural "%(n_transcriptions)s Transcriptions"
@@ -310,7 +319,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: corpus/templates/corpus/document_detail.html:131
+#: corpus/templates/corpus/document_detail.html:130
 #, python-format
 msgid "%(n_translations)s Translation"
 msgid_plural "%(n_translations)s Translations"
@@ -322,7 +331,7 @@ msgstr[3] ""
 #. Translators: heading label for document related people
 #. Translators: label for sort by number of related people
 #. Translators: accessibility label for people list
-#: corpus/templates/corpus/document_detail.html:153
+#: corpus/templates/corpus/document_detail.html:152
 #: corpus/templates/corpus/snippets/document_result.html:113
 #: entities/forms.py:225 entities/forms.py:362
 #: entities/templates/entities/person_list.html:197
@@ -332,8 +341,8 @@ msgid "Related People"
 msgstr ""
 
 #. Translators: label for an uncertain Person-Document identification
-#: corpus/templates/corpus/document_detail.html:161
-#: entities/templates/entities/snippets/related_documents_table.html:53
+#: corpus/templates/corpus/document_detail.html:160
+#: entities/templates/entities/snippets/related_documents_table.html:55
 msgid "(uncertain)"
 msgstr ""
 
@@ -341,7 +350,7 @@ msgstr ""
 #. Translators: label for sort by number of related places
 #. Translators: accessibility label for place list
 #. Translators: heading label for document related places
-#: corpus/templates/corpus/document_detail.html:173
+#: corpus/templates/corpus/document_detail.html:172
 #: corpus/templates/corpus/snippets/document_result.html:117
 #: entities/forms.py:227 entities/templates/entities/person_list.html:201
 #: entities/templates/entities/person_related_places.html:56
@@ -351,7 +360,7 @@ msgstr ""
 
 #. Translators: label for tags on a document
 #. Translators: Person "tags" column header on the browse page
-#: corpus/templates/corpus/document_detail.html:191
+#: corpus/templates/corpus/document_detail.html:190
 #: corpus/templates/corpus/snippets/document_result.html:130
 #: entities/templates/entities/person_list.html:137
 msgid "Tags"
@@ -362,8 +371,13 @@ msgstr "תגים"
 msgid "Additional metadata"
 msgstr ""
 
+#. Translators: label for the provenance of document fragments
+#: corpus/templates/corpus/document_detail.html:212
+msgid "Provenance"
+msgstr ""
+
 #. Translators: Document fragment collection(s) label
-#: corpus/templates/corpus/document_detail.html:211
+#: corpus/templates/corpus/document_detail.html:226
 msgid "Collection"
 msgid_plural "Collections"
 msgstr[0] ""
@@ -372,45 +386,46 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: label for historical/old shelfmarks on document fragments
-#: corpus/templates/corpus/document_detail.html:228
+#: corpus/templates/corpus/document_detail.html:243
 msgid "Historical shelfmarks"
 msgstr ""
 
 #. Translators: Label for date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:232
+#: corpus/templates/corpus/document_detail.html:247
 msgid "Input date"
 msgstr "תאריך קלט"
 
 #. Translators: Date document was first added to the PGP
-#: corpus/templates/corpus/document_detail.html:235
+#: corpus/templates/corpus/document_detail.html:250
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    In PGP since %(date)s\n"
 "                "
 msgstr ""
 
 #. Translators: label for a citation for a document detail page
 #. Translators: label for a citation for a person page
-#: corpus/templates/corpus/document_detail.html:250
+#: corpus/templates/corpus/document_detail.html:265
 #: entities/templates/entities/person_detail.html:131
 msgid "How to cite this record:"
 msgstr ""
 
 #. Translators: accessibility label for a citation for a document
 #. Translators: accessibility label for a citation for a person
-#: corpus/templates/corpus/document_detail.html:254
+#: corpus/templates/corpus/document_detail.html:269
 #: entities/templates/entities/person_detail.html:135
 msgid "Citation"
 msgstr ""
 
 #. Translators: label for permanent link to a document
-#: corpus/templates/corpus/document_detail.html:259
+#: corpus/templates/corpus/document_detail.html:274
 msgid "Link to this document:"
 msgstr ""
 
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/templates/corpus/document_detail.html:266
+#: corpus/templates/corpus/document_detail.html:281
 #: entities/templates/entities/person_detail.html:146
 msgid "Permalink"
 msgstr "קישור קבוע"
@@ -439,8 +454,10 @@ msgid "in"
 msgstr ""
 
 #: corpus/templates/corpus/document_list.html:59
-msgid "\n"
-"                            Case sensitive, must match entire shelfmark. Type one shelfmark,\n"
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
 "                            even if part of a join, for best results.\n"
 "                        "
 msgstr ""
@@ -527,13 +544,11 @@ msgid "Jewish Theological Seminary logo"
 msgstr "סמל Jewish Theological Seminary"
 
 #: corpus/templates/corpus/snippets/document_result.html:23
-#| msgid "Input date"
 msgid "Document date"
 msgstr ""
 
 #. Translators: label for inferred date on a document
 #: corpus/templates/corpus/snippets/document_result.html:33
-#| msgid "Input date"
 msgid "Inferred date"
 msgstr ""
 
@@ -551,7 +566,6 @@ msgstr[3] ""
 #: entities/forms.py:223 entities/forms.py:360
 #: entities/templates/entities/person_list.html:193
 #: entities/templates/entities/place_list.html:98
-#| msgid "Search Documents"
 msgid "Related Documents"
 msgstr ""
 
@@ -632,8 +646,10 @@ msgstr ""
 
 #. Translators: general search help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:7
-msgid "\n"
-"        Use keywords or phrases in any language to return matching or similar\n"
+msgid ""
+"\n"
+"        Use keywords or phrases in any language to return matching or "
+"similar\n"
 "        results across all fields. Arabic script searches will return both\n"
 "        Arabic and Judaeo-Arabic transcription content.\n"
 "    "
@@ -647,7 +663,8 @@ msgstr ""
 #. Translators: regular expressions search mode help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:18
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "        Use Hebrew or Arabic script to find precise matches in the\n"
 "        transcriptions. See\n"
 "        <a data-turbo=\"false\" href=\"%(howto_url)s\">How to Search</a>\n"
@@ -662,10 +679,13 @@ msgstr ""
 
 #. Translators: regular expression tip 1
 #: corpus/templates/corpus/snippets/document_search_helptext.html:31
-msgid "\n"
+msgid ""
+"\n"
 "            If you're looking for a word with one missing letter, use a\n"
-"            period. Two missing letters, use two periods or <code>{2}</code>.\n"
-"            Increase the number in the curly brackets to increase the number of\n"
+"            period. Two missing letters, use two periods or <code>{2}</"
+"code>.\n"
+"            Increase the number in the curly brackets to increase the number "
+"of\n"
 "            characters, or insert a range with a comma in between, ex.\n"
 "            <code>{0,5}</code>.\n"
 "        "
@@ -673,7 +693,8 @@ msgstr ""
 
 #. Translators: regular expression tip 2
 #: corpus/templates/corpus/snippets/document_search_helptext.html:41
-msgid "\n"
+msgid ""
+"\n"
 "            If you don't know how many characters are missing, use\n"
 "            <code>.*</code>.\n"
 "        "
@@ -681,8 +702,10 @@ msgstr ""
 
 #. Translators: regular expression tip 3
 #: corpus/templates/corpus/snippets/document_search_helptext.html:48
-msgid "\n"
-"            If you know which characters you want, use square brackets to find\n"
+msgid ""
+"\n"
+"            If you know which characters you want, use square brackets to "
+"find\n"
 "            multiple spellings, ex. <code>[יו]</code> for yud or vav.\n"
 "        "
 msgstr ""
@@ -757,11 +780,11 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: corpus/templates/corpus/snippets/document_transcription.html:210
+#: corpus/templates/corpus/snippets/document_transcription.html:211
 msgid "Zoom and Rotate"
 msgstr "הגדל וסובב"
 
-#: corpus/templates/corpus/snippets/document_transcription.html:245
+#: corpus/templates/corpus/snippets/document_transcription.html:246
 #, python-format
 msgid "View %(related_doc)s"
 msgstr "ראה %(related_doc)s"
@@ -795,7 +818,6 @@ msgstr "הבא"
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
 #: corpus/views.py:82 templates/snippets/menu.html:11
-#| msgid "Input date"
 msgid "Documents"
 msgstr "מסמכים"
 
@@ -804,18 +826,20 @@ msgstr "מסמכים"
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
-#: corpus/views.py:332 entities/views.py:748
+#: corpus/views.py:332 entities/views.py:867
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:334 entities/views.py:750
+#: corpus/views.py:334 entities/views.py:869
 #, python-format
 msgid "Before %s"
 msgstr ""
 
 #: corpus/views.py:405
-msgid "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses."
 msgstr ""
 
 #. Translators: title of document scholarship page
@@ -839,7 +863,7 @@ msgstr[3] "%(count)d רשומות קשורות"
 msgid "Related documents for %(doc)s"
 msgstr "מסמכים קשורים %(doc)s"
 
-#: corpus/views.py:595 entities/views.py:335
+#: corpus/views.py:595 entities/views.py:339
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -865,7 +889,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:764
+#: entities/forms.py:206 entities/views.py:883
 msgid "Detail page available"
 msgstr ""
 
@@ -920,35 +944,35 @@ msgstr ""
 msgid "Descending"
 msgstr ""
 
-#: entities/models.py:377
+#: entities/models.py:378
 msgid "Male"
 msgstr ""
 
-#: entities/models.py:378
+#: entities/models.py:379
 msgid "Female"
 msgstr ""
 
-#: entities/models.py:379
+#: entities/models.py:380
 msgid "Unknown"
 msgstr ""
 
-#: entities/models.py:1243
+#: entities/models.py:1248
 msgid "Immediate family relations"
 msgstr ""
 
-#: entities/models.py:1244
+#: entities/models.py:1249
 msgid "Extended family"
 msgstr ""
 
-#: entities/models.py:1245
+#: entities/models.py:1250
 msgid "Relatives by marriage"
 msgstr ""
 
-#: entities/models.py:1246
+#: entities/models.py:1251
 msgid "Business and property relationships"
 msgstr ""
 
-#: entities/models.py:1247
+#: entities/models.py:1252
 msgid "Ambiguity"
 msgstr ""
 
@@ -1039,7 +1063,8 @@ msgstr ""
 #. Translators: range of search results on the current page, out of total
 #: entities/templates/entities/person_list.html:212
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "        "
 msgstr ""
@@ -1104,7 +1129,8 @@ msgstr ""
 #. Translators: range of search results on the current page, out of total
 #: entities/templates/entities/place_list.html:113
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "                "
 msgstr ""
@@ -1152,7 +1178,6 @@ msgstr ""
 
 #. Translators: table header for document name (shelfmark)
 #: entities/templates/entities/snippets/related_documents_table.html:10
-#| msgid "Input date"
 msgid "Document"
 msgstr ""
 
@@ -1162,18 +1187,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:327
+#: entities/views.py:333
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:422
+#: entities/views.py:539
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:430 entities/views.py:500
+#: entities/views.py:547 entities/views.py:618
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1183,12 +1208,12 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:559
+#: entities/views.py:677
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:567
+#: entities/views.py:685
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1199,23 +1224,23 @@ msgstr[3] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:672 templates/snippets/menu.html:19
+#: entities/views.py:791 templates/snippets/menu.html:19
 msgid "People"
 msgstr "אנשים"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:674
+#: entities/views.py:793
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:857 templates/snippets/menu.html:26
+#: entities/views.py:976 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "מקומות"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:859
+#: entities/views.py:978
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
@@ -1224,13 +1249,21 @@ msgid "Edition"
 msgstr "מהדורה"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום בהקשר זה."
+msgstr ""
+"טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
+"בהקשר זה."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים "
+"שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -1360,4 +1393,3 @@ msgstr "חזרה לתפריט הראשי"
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
-


### PR DESCRIPTION
**Associated Issue(s):** #1781

### Changes in this PR

- Fix an error in person related documents pages, where `None` would break sorting by doctype
- Regenerate translation files