### PR TITLE
Fix possible image selection state mismatch in reorder/rotate field (#1598)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -577,7 +577,9 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
         help_texts = {
             "admin_thumbnails": """Drag image thumbnails to customize order when necessary (i.e.
             image sequence does not follow fragment/shelfmark sequence). Click rotation buttons to
-            rotate images. Changes will be applied on save."""
+            rotate images, and use checkboxes to select or deselect images as part of the document.
+            Changes will be applied on save. NOTE: You cannot deselect ALL images from a fragment. If
+            no images on a fragment are part of the document, the fragment should be removed."""
         }
         kwargs.update({"help_texts": help_texts})
         return super().get_form(request, obj, **kwargs)

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -578,8 +578,9 @@ class DocumentAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin)
             "admin_thumbnails": """Drag image thumbnails to customize order when necessary (i.e.
             image sequence does not follow fragment/shelfmark sequence). Click rotation buttons to
             rotate images, and use checkboxes to select or deselect images as part of the document.
-            Changes will be applied on save. NOTE: You cannot deselect ALL images from a fragment. If
-            no images on a fragment are part of the document, the fragment should be removed."""
+            Changes will be applied on save. NOTE: Deselecting ALL images from a fragment will
+            be treated the same as selecting all images from that fragment, since a fragment must
+            have at least one selected image; if not, the fragment should be removed from the document."""
         }
         kwargs.update({"help_texts": help_texts})
         return super().get_form(request, obj, **kwargs)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -304,7 +304,7 @@ class Fragment(TrackChangesModel):
                 # on Document
                 '<div class="admin-thumbnail%s" %s><img src="%s" loading="lazy" height="%d" title="%s" /></div>'
                 % (
-                    " selected" if i in selected or not len(selected) else "",
+                    " selected" if i in selected else "",
                     f'data-canvas="{list(canvases)[i]}"' if canvases else "",
                     img,
                     img.size.options["height"] if hasattr(img, "size") else 200,
@@ -918,7 +918,6 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             ],
             labels=[img["label"] for img in images],
             canvases=iiif_images.keys(),
-            selected=[i for i, img in enumerate(images) if not img["excluded"]],
         )
 
     admin_thumbnails.short_description = "Image order/rotation overrides"

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -304,7 +304,7 @@ class Fragment(TrackChangesModel):
                 # on Document
                 '<div class="admin-thumbnail%s" %s><img src="%s" loading="lazy" height="%d" title="%s" /></div>'
                 % (
-                    " selected" if i in selected else "",
+                    " selected" if i in selected or not len(selected) else "",
                     f'data-canvas="{list(canvases)[i]}"' if canvases else "",
                     img,
                     img.size.options["height"] if hasattr(img, "size") else 200,

--- a/sitemedia/js/admin.js
+++ b/sitemedia/js/admin.js
@@ -319,7 +319,15 @@ function appendImageControls() {
         // select control
         const selectCheckbox = document.createElement("input");
         selectCheckbox.type = "checkbox";
-        selectCheckbox.checked = div.classList.contains("selected");
+
+        const fragmentImage = document.querySelector(
+            `#textblock_set-group div.admin-thumbnail[data-canvas="${div.dataset.canvas}"]`
+        );
+        // match selected state from fragments inline
+        if (fragmentImage.classList.contains("selected")) {
+            selectCheckbox.checked = true;
+            div.classList.add("selected");
+        }
         div.appendChild(selectCheckbox);
     });
 }


### PR DESCRIPTION
**Associated Issue(s):** #1598

### Changes in this PR

- Fix an issue where selection state could be mismatched due to the way `exclude` is computed in `Document.iiif_images`. Instead, use the actual form selection state from the `TextBlock` inlines to determine the selection state for the reorder/rotate field.