### PR TITLE
Exempt single-provenance docs from tabular provenance display (#1805)

### DIFF
--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -211,14 +211,18 @@
                 {# Translators: label for the provenance of document fragments #}
                 <dt>{% translate "Provenance" %}</dt>
                 <dd>
-                    <dl>
-                        {% for provenance in provenance_list %}
-                            <dt>{{ provenance.grouper }}</dt>
-                            {% for frag in provenance.list %}
-                                <dd{% if forloop.last %} class="row-end"{% endif %}>{{ frag }}</dd>
+                    {% if provenance_list|length > 1 %}
+                        <dl>
+                            {% for provenance in provenance_list %}
+                                <dt>{{ provenance.grouper }}</dt>
+                                {% for frag in provenance.list %}
+                                    <dd{% if forloop.last %} class="row-end"{% endif %}>{{ frag }}</dd>
+                                {% endfor %}
                             {% endfor %}
-                        {% endfor %}
-                    </dl>
+                        </dl>
+                    {% else %}
+                        {{ provenance_list.0.grouper }}
+                    {% endif %}
                 </dd>
             {% endif %}
             <dt>


### PR DESCRIPTION
**Associated Issue(s):** #1805

### Changes in this PR

- Use the original design (one-line, non-tabular) for provenance when the document only has one provenance across all fragments