### PR TITLE
Ensure images do not error before OSD load, and use placeholder if they do (#1751)

### DIFF
--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -1,4 +1,7 @@
-import { Controller } from "@hotwired/stimulus";
+import {
+    Controller,
+    getControllerForElementAndIdentifier,
+} from "@hotwired/stimulus";
 import { useIntersection } from "stimulus-use";
 import * as Annotorious from "@recogito/annotorious-openseadragon";
 import {
@@ -24,7 +27,7 @@ export default class extends Controller {
         // enable intersection behaviors (appear, disappear)
         useIntersection(this);
     }
-    appear() {
+    async appear() {
         // enable deep zoom, annotorious-tahqiq on first appearance
         // (appear may fire subsequently, but nothing should happen then)
         if (
@@ -82,11 +85,11 @@ export default class extends Controller {
 
             // wait for each image to load fully before enabling OSD so we know its full height
             if (this.imageTarget.complete) {
-                this.element.iiif.activateDeepZoom(settings);
+                await this.element.iiif.activateDeepZoom(settings);
                 this.initAnnotorious(settings);
             } else {
-                this.imageTarget.addEventListener("load", () => {
-                    this.element.iiif.activateDeepZoom(settings);
+                this.imageTarget.addEventListener("load", async () => {
+                    await this.element.iiif.activateDeepZoom(settings);
                     this.initAnnotorious(settings);
                 });
             }

--- a/sitemedia/scss/components/_annotation.scss
+++ b/sitemedia/scss/components/_annotation.scss
@@ -57,6 +57,7 @@ main.annotating {
         &.placeholder .deep-zoom-container {
             background-color: var(--background-gray);
             opacity: 1;
+            min-height: 400px;
         }
         // popout open and close buttons
         button.popout-button {


### PR DESCRIPTION
**Associated Issue(s):** #1751

### Changes in this PR

- In the annotation editor, use a `HEAD` request _before_ OSD ever loads on any attempted IIIF image, in order to ensure that it does not error out on load, preventing annotation
- Set the placeholder image if it does encounter an error