### PR TITLE
Fragment "shelfmarks_historic" column name (#1810)

### DIFF
--- a/geniza/corpus/metadata_export.py
+++ b/geniza/corpus/metadata_export.py
@@ -242,7 +242,7 @@ class FragmentExporter(Exporter):
     csv_fields = [
         "shelfmark",
         "pgpids",
-        "old_shelfmarks",
+        "shelfmarks_historic",
         "collection",
         "library",
         "library_abbrev",
@@ -279,7 +279,7 @@ class FragmentExporter(Exporter):
         data = {
             "shelfmark": fragment.shelfmark,
             "pgpids": [doc.pk for doc in fragment.documents.all()],
-            "old_shelfmarks": fragment.old_shelfmarks,
+            "shelfmarks_historic": fragment.old_shelfmarks,
             "url": fragment.url,
             "iiif_url": fragment.iiif_url,
             "is_multifragment": fragment.is_multifragment,

--- a/geniza/corpus/tests/test_metadata_export.py
+++ b/geniza/corpus/tests/test_metadata_export.py
@@ -231,7 +231,7 @@ def test_fragment_export_data(multifragment):
     data = FragmentExporter().get_export_data_dict(multifragment)
     assert data["shelfmark"] == multifragment.shelfmark
     assert data["pgpids"] == []
-    assert data["old_shelfmarks"] == ""
+    assert data["shelfmarks_historic"] == ""
     # fixture is not in a collection
     assert "collection" not in data
 


### PR DESCRIPTION
**Associated Issue(s):** #1810

### Changes in this PR

- Use the column name `shelfmarks_historic` in Fragment exports, in order to match Document exports' column name
