### PR TITLE
Upgrade djiffy to 0.9.2 for interim jsonfield migration

### DIFF
--- a/geniza/corpus/fixtures/ui_ux_test_documents.json
+++ b/geniza/corpus/fixtures/ui_ux_test_documents.json
@@ -1,50 +1,44 @@
 [
   {
     "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/4069f1b9-d29d-43e7-ac57-a39ff2d073a4.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/4069f1b9-d29d-43e7-ac57-a39ff2d073a4\",\"identifier\":[\"ark:/88435/dc7m01bw84k\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-12-01T22:47:32Z\",\"system_updated_at\":\"2022-01-06T19:20:01Z\",\"title\":[{\"@value\":\"ENA 2727.15d\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 2727.15d",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/dc7m01bw84k\"],\"Title\":[\"ENA 2727.15d\"],\"Local Identifier\":[\"ENA 2727.15d\"]}",
-      "short_id": "4069f1b9-d29d-43e7-ac57-a39ff2d073a4",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/4069f1b9-d29d-43e7-ac57-a39ff2d073a4/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 11842
-  },
-  {
-    "fields": {
       "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00008-J-00005-00001/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Legal document (T-S 8J5.1)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"torn\"],\"Origin Place\":[\"Cairo; Fus\\u1e6d\\u0101\\u1e6d\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"2 leaves (bifolium). Leaf height: 17.6 cm, width: 26 (1 leaf: 13.3) cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Legal document from Cairo and Fus\\u1e6d\\u0101\\u1e6d. The rich goldsmith Ab\\u016b Ya\\u02bfq\\u016bb Joseph b. Samuel\\u2019s (known as Ibn Na\\u1e25um) estate is recorded after his death for his minor children. Mentions Ab\\u016b Sahl, Ab\\u016b Sulaym\\u0101n, Ab\\u016b l-\\u1e24usayn al-\\u1e24alab\\u012b, Ab\\u016b l-Faraj b. Qas\\u0101ma, Ab\\u016b l-\\u1e6c\\u0101hir, Ab\\u016b l-\\u1e24asan b. Ayy\\u016bb, M\\u016bs\\u0101 b. Musallam al-Qazz\\u0101z (the silk trader), M\\u016bs\\u0101 b. Faraj the Christian, \\u1e62\\u0101f\\u012b b. Na\\u1e25r\\u012br, Ma\\u1e63lia\\u1e25 the Sicilian, Ab\\u016b l-\\u1e24asan al-\\u1e62an\\u0101n\\u012br\\u012b, and Ab\\u016b Is\\u1e25\\u0101q b. \\u1e62ul\\u1e25\\u0101n. Signed by Abraham b. Nathan Av Bet Din, Abraham b. \\u0160ema\\u02bfya he-\\u1e24aver (descendant of \\u0160ema\\u02bfya Ga\\u02beon), Isaac b. Samuel ha-Sefardi, Mevasser ha-Levi b. Ye\\u0161u\\u02bfa and S[...]l b. Sa\\u02bfadya. Dated 1425 of the Seleucid Era (= 1114 CE). In the hand of \\u1e24alfon b. Manasseh (who also signed the document). </p>\"],\"Date of Creation\":[\"1114 CE\"],\"Title\":[\"Legal document\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 8J5.1\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Associated Name(s)\":[\"Ab\\u016b Ya\\u02bfq\\u016bb Joseph b. Samuel (known as Ibn Na\\u1e25um the goldsmith); Ab\\u016b Sahl; Ab\\u016b Sulaym\\u0101n; Ab\\u016b l-\\u1e24usayn al-\\u1e24alab\\u012b; Ab\\u016b l-Faraj b. Qas\\u0101ma; Ab\\u016b l-\\u1e6c\\u0101hir; Ab\\u016b l-\\u1e24asan b. Ayy\\u016bb; M\\u016bs\\u0101 b. Musallam al-Qazz\\u0101z; M\\u016bs\\u0101 b. Faraj the Christian; \\u1e62\\u0101f\\u012b b. Na\\u1e25r\\u012br; Ma\\u1e63lia\\u1e25 the Sicilian; Ab\\u016b l-\\u1e24asan al-\\u1e62an\\u0101n\\u012br\\u012b; Ab\\u016b Is\\u1e25\\u0101q b. \\u1e62ul\\u1e25\\u0101n; Abraham b. Nathan Av; Abraham b. \\u0160ema\\u02bfya he-\\u1e24aver; Isaac b. Samuel ha-Sefardi; Mevasser ha-Levi b. Ye\\u0161u\\u02bfa; S[...]l b. Sa\\u02bfadya\"],\"Language(s)\":[\"Judaeo-Arabic; Hebrew; Aramaic\"],\"Layout\":[\"12-19 lines\"],\"Scribe(s)\":[\"\\u1e24alfon b. Manasseh\"]}",
-      "short_id": "MS-TS-00008-J-00005-00001",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00008-J-00005-00001"
-    },
-    "model": "djiffy.manifest",
-    "pk": 5695
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00018-J-00001-00017/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Legal document (T-S 18J1.17)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"torn, holes\"],\"Origin Place\":[\"Cairo\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf. Leaf height: 32.5 cm, width: 21.2 cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Deed of sale, written by Abraham b. Nathan b. Abraham, dated Tuesday, 5th Kislev 1420 (= 1108 CE), in Cairo, in which Sitt al-Aqr\\u0101n b. Joseph ha-Kohen, wife of Judah b. \\u02bfAll\\u0101n, sells her female slave Na\\u02bf\\u012bm to Sitt al-Muna b. Nathan, widow of Nahray b. Nissim, for the sum of 20 dinars. Witnessed by Mena\\u1e25em b. Samuel, Ya\\u02bfir ha-Kohen b. Sa\\u02bfadya, and \\u1e62ema\\u1e25 ha-Levi b. Jacob. Verso: Arabic text, perhaps related to the legal text on verso. </p>\"],\"Date of Creation\":[\"1108 CE\"],\"Title\":[\"Legal document\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 18J1.17\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Associated Name(s)\":[\"Sitt al-Aqr\\u0101n b. Joseph ha-Kohen, wife of Judah b. \\u02bfAll\\u0101n; Na\\u02bf\\u012bm, the female slave; Sitt al-Muna b. Nathan, widow of Nahray b. Nissim; Mena\\u1e25em b. Samuel; Ya\\u02bfir ha-Kohen b. Sa\\u02bfadya; \\u1e62ema\\u1e25 ha-Levi b. Jacob\"],\"Language(s)\":[\"Aramaic; Hebrew; Judaeo-Arabic; Arabic\"],\"Layout\":[\"37 lines (recto), 9 lines (verso)\"],\"Scribe(s)\":[\"Abraham b. Nathan b. Abraham\"]}",
-      "short_id": "MS-TS-00018-J-00001-00017",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00018-J-00001-00017"
-    },
-    "model": "djiffy.manifest",
-    "pk": 2972
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00013-J-00035-00003/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00013-J-00035-00003/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
       "label": "Letter (T-S 13J35.3)",
       "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"torn, holes, rubbed\"],\"Origin Place\":[\"Fus\\u1e6d\\u0101\\u1e6d\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf. Leaf height: 25 cm, width: 17.6 cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Letter from the community of Fus\\u1e6d\\u0101\\u1e6d concerning the imposition of a ban on Abraham. </p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Letter\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 13J35.3\"],\"Note(s)\":[\"Belongs together with AIU VII A 23.; Associated manuscripts: AIU VII A 23\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Associated Name(s)\":[\"Abraham\"],\"Language(s)\":[\"Judaeo-Arabic; Hebrew\"],\"Layout\":[\"20 lines (recto); 4 lines (verso)\"]}",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Letter from the community of Fusṭāṭ concerning the imposition of a ban on Abraham. </p>"
+        ],
+        "Associated Name(s)": ["Abraham"],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 13J35.3"],
+        "Condition": ["torn, holes, rubbed"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf. Leaf height: 25 cm, width: 17.6 cm."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Judaeo-Arabic; Hebrew"],
+        "Layout": ["20 lines (recto); 4 lines (verso)"],
+        "Material": ["Paper"],
+        "Note(s)": [
+          "Belongs together with AIU VII A 23.; Associated manuscripts: AIU VII A 23"
+        ],
+        "Origin Place": ["Fusṭāṭ"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Letter"]
+      },
       "short_id": "MS-TS-00013-J-00035-00003",
       "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00013-J-00035-00003"
     },
@@ -53,76 +47,43 @@
   },
   {
     "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2\",\"identifier\":[\"ark:/88435/dcxs55mp093\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-12-02T03:17:03Z\",\"system_updated_at\":\"2022-01-06T21:11:02Z\",\"title\":[{\"@value\":\"ENA 3751.5\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 3751.5",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/dcxs55mp093\"],\"Title\":[\"ENA 3751.5\"],\"Local Identifier\":[\"ENA 3751.5\"]}",
-      "short_id": "fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 14035
-  },
-  {
-    "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/40be59a7-e77c-4534-8e87-c0137c7789c8.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/40be59a7-e77c-4534-8e87-c0137c7789c8\",\"identifier\":[\"ark:/88435/dc2514nw495\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-12-02T05:16:27Z\",\"system_updated_at\":\"2022-01-06T19:56:11Z\",\"title\":[{\"@value\":\"ENA 4045.2\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 4045.2",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/dc2514nw495\"],\"Title\":[\"ENA 4045.2\"],\"Local Identifier\":[\"ENA 4045.2\"]}",
-      "short_id": "40be59a7-e77c-4534-8e87-c0137c7789c8",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/40be59a7-e77c-4534-8e87-c0137c7789c8/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 12331
-  },
-  {
-    "fields": {
       "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AS-00135-00053/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Letter; unidentified (T-S AS 135.53)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"badly torn, holes, badly stained\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf. Leaf height: 6.1 cm, width: 5.1 cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Recto: part of a letter in Arabic. Verso: unidentified text in Hebrew characters. </p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Letter; unidentified\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S AS 135.53\"],\"Note(s)\":[\"Verso is written transversely in relation to recto.\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Language(s)\":[\"Arabic; Hebrew (?)\"],\"Layout\":[\"4 lines (recto); 1 line (verso)\"]}",
-      "short_id": "MS-TS-AS-00135-00053",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AS-00135-00053"
-    },
-    "model": "djiffy.manifest",
-    "pk": 5903
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AR-00030-00129/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Genizah Fragment (T-S Ar.30.129)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Genizah Fragment\"],\"Author(s) of the Record\":[\"CUL\"],\"Classmark\":[\"T-S Ar.30.129\"]}",
-      "short_id": "MS-TS-AR-00030-00129",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AR-00030-00129"
-    },
-    "model": "djiffy.manifest",
-    "pk": 78
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00018-J-00001-00001/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Letter; document (T-S 18J1.1)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"torn, holes, rubbed, faded\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf. Leaf height: 29.5 cm, width: 19.6 cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Recto: letter in which 15 signatories ask a community in another country to bring to court a merchant against whom a widow has financial claims. Verso: document in Arabic script. </p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Letter; document\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 18J1.1\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Language(s)\":[\"Judaeo-Arabic; Arabic\"],\"Layout\":[\"26 lines (recto); 5 lines + marginalia (verso)\"]}",
-      "short_id": "MS-TS-00018-J-00001-00001",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00018-J-00001-00001"
-    },
-    "model": "djiffy.manifest",
-    "pk": 6885
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00010-J-00022-00006/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00010-J-00022-00006/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
       "label": "Poetry; panegyric; magical (T-S 10J22.6)",
       "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"holes, rubbed, faded\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"2 leaves (bifolium). Leaf height: 18.1 cm, width: 26 (1 leaf: 13.1) cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>F. 1r: jottings. F. 1v: magical; divination. Ff. 2r-v: Hebrew poetry: panegyric. </p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Poetry; panegyric; magical\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 10J22.6\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Language(s)\":[\"Hebrew; Judaeo-Arabic (sporadic Tiberian vocalisation)\"],\"Layout\":[\"17-21 lines (2r is blank)\"]}",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>F. 1r: jottings. F. 1v: magical; divination. Ff. 2r-v: Hebrew poetry: panegyric. </p>"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 10J22.6"],
+        "Condition": ["holes, rubbed, faded"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": [
+          "2 leaves (bifolium). Leaf height: 18.1 cm, width: 26 (1 leaf: 13.1) cm."
+        ],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": [
+          "Hebrew; Judaeo-Arabic (sporadic Tiberian vocalisation)"
+        ],
+        "Layout": ["17-21 lines (2r is blank)"],
+        "Material": ["Paper"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Poetry; panegyric; magical"]
+      },
       "short_id": "MS-TS-00010-J-00022-00006",
       "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00010-J-00022-00006"
     },
@@ -132,15 +93,658 @@
   {
     "fields": {
       "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00010-J-00012-00016/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AR-00030-00245/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Grammar; legal document (T-S Ar.30.245)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Recto: response to the endorsement of a petition to the imām Al-Muṣtansir bi-Allāh. Ca. 427-487 AH (= 1036-1094 CE). Verso and continuing on recto: Judaeo-Arabic treatise on the Arabic language.</p>"
+        ],
+        "Associated Name(s)": ["Al-Muṣtansir bi-Allāh"],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S Ar.30.245"],
+        "Condition": ["Torn, rubbed, faded, stained"],
+        "Date of Creation": ["1036-1094 CE"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Judaeo-Arabic; Arabic"],
+        "Layout": ["32 lines + marginalia (recto); 32 lines (verso)"],
+        "Material": ["Paper"],
+        "Note(s)": [
+          "Recto and verso have been inverted during conservation. The Arabic text is written perpendicular in relation to the Judaeo-Arabic text on verso."
+        ],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Grammar; legal document"]
+      },
+      "short_id": "MS-TS-AR-00030-00245",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AR-00030-00245"
+    },
+    "model": "djiffy.manifest",
+    "pk": 6750
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/12a80dcc-1433-4230-9677-e3a83c4880cd.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/12a80dcc-1433-4230-9677-e3a83c4880cd",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/j6731c28x"],
+          "system_created_at": "2021-01-08T06:47:56Z",
+          "system_updated_at": "2022-04-20T21:20:32Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 2697.9"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 2697.9",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/j6731c28x"],
+        "Local Identifier": ["ENA 2697.9"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 2697.9"]
+      },
+      "short_id": "12a80dcc-1433-4230-9677-e3a83c4880cd",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/12a80dcc-1433-4230-9677-e3a83c4880cd/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 10608
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/50a29467-9298-4e4e-994d-9064dd7de49e.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/50a29467-9298-4e4e-994d-9064dd7de49e",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/zg64tv44j"],
+          "system_created_at": "2021-01-08T06:48:01Z",
+          "system_updated_at": "2022-04-20T21:20:31Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 2697.8"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 2697.8",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/zg64tv44j"],
+        "Local Identifier": ["ENA 2697.8"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 2697.8"]
+      },
+      "short_id": "50a29467-9298-4e4e-994d-9064dd7de49e",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/50a29467-9298-4e4e-994d-9064dd7de49e/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 10607
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00018-J-00001-00017/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Legal document (T-S 18J1.17)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Deed of sale, written by Abraham b. Nathan b. Abraham, dated Tuesday, 5th Kislev 1420 (= 1108 CE), in Cairo, in which Sitt al-Aqrān b. Joseph ha-Kohen, wife of Judah b. ʿAllān, sells her female slave Naʿīm to Sitt al-Muna b. Nathan, widow of Nahray b. Nissim, for the sum of 20 dinars. Witnessed by Menaḥem b. Samuel, Yaʿir ha-Kohen b. Saʿadya, and Ṣemaḥ ha-Levi b. Jacob. Verso: Arabic text, perhaps related to the legal text on verso. </p>"
+        ],
+        "Associated Name(s)": [
+          "Sitt al-Aqrān b. Joseph ha-Kohen, wife of Judah b. ʿAllān; Naʿīm, the female slave; Sitt al-Muna b. Nathan, widow of Nahray b. Nissim; Menaḥem b. Samuel; Yaʿir ha-Kohen b. Saʿadya; Ṣemaḥ ha-Levi b. Jacob"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 18J1.17"],
+        "Condition": ["torn, holes"],
+        "Date of Creation": ["1108 CE"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf. Leaf height: 32.5 cm, width: 21.2 cm."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Aramaic; Hebrew; Judaeo-Arabic; Arabic"],
+        "Layout": ["37 lines (recto), 9 lines (verso)"],
+        "Material": ["Paper"],
+        "Origin Place": ["Cairo"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Scribe(s)": ["Abraham b. Nathan b. Abraham"],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Legal document"]
+      },
+      "short_id": "MS-TS-00018-J-00001-00017",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00018-J-00001-00017"
+    },
+    "model": "djiffy.manifest",
+    "pk": 2972
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AR-00030-00129/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Genizah Fragment (T-S Ar.30.129)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S Ar.30.129"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Genizah Fragment"]
+      },
+      "short_id": "MS-TS-AR-00030-00129",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AR-00030-00129"
+    },
+    "model": "djiffy.manifest",
+    "pk": 78
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/4069f1b9-d29d-43e7-ac57-a39ff2d073a4.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/4069f1b9-d29d-43e7-ac57-a39ff2d073a4",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/dc7m01bw84k"],
+          "system_created_at": "2021-12-01T22:47:32Z",
+          "system_updated_at": "2022-04-21T00:38:10Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 2727.15d"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 2727.15d",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/dc7m01bw84k"],
+        "Local Identifier": ["ENA 2727.15d"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 2727.15d"]
+      },
+      "short_id": "4069f1b9-d29d-43e7-ac57-a39ff2d073a4",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/4069f1b9-d29d-43e7-ac57-a39ff2d073a4/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 11842
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00008-J-00005-00001/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Legal document (T-S 8J5.1)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Legal document from Cairo and Fusṭāṭ. The rich goldsmith Abū Yaʿqūb Joseph b. Samuel’s (known as Ibn Naḥum) estate is recorded after his death for his minor children. Mentions Abū Sahl, Abū Sulaymān, Abū l-Ḥusayn al-Ḥalabī, Abū l-Faraj b. Qasāma, Abū l-Ṭāhir, Abū l-Ḥasan b. Ayyūb, Mūsā b. Musallam al-Qazzāz (the silk trader), Mūsā b. Faraj the Christian, Ṣāfī b. Naḥrīr, Maṣliaḥ the Sicilian, Abū l-Ḥasan al-Ṣanānīrī, and Abū Isḥāq b. Ṣulḥān. Signed by Abraham b. Nathan Av Bet Din, Abraham b. Šemaʿya he-Ḥaver (descendant of Šemaʿya Gaʾon), Isaac b. Samuel ha-Sefardi, Mevasser ha-Levi b. Yešuʿa and S[...]l b. Saʿadya. Dated 1425 of the Seleucid Era (= 1114 CE). In the hand of Ḥalfon b. Manasseh (who also signed the document). </p>"
+        ],
+        "Associated Name(s)": [
+          "Abū Yaʿqūb Joseph b. Samuel (known as Ibn Naḥum the goldsmith); Abū Sahl; Abū Sulaymān; Abū l-Ḥusayn al-Ḥalabī; Abū l-Faraj b. Qasāma; Abū l-Ṭāhir; Abū l-Ḥasan b. Ayyūb; Mūsā b. Musallam al-Qazzāz; Mūsā b. Faraj the Christian; Ṣāfī b. Naḥrīr; Maṣliaḥ the Sicilian; Abū l-Ḥasan al-Ṣanānīrī; Abū Isḥāq b. Ṣulḥān; Abraham b. Nathan Av; Abraham b. Šemaʿya he-Ḥaver; Isaac b. Samuel ha-Sefardi; Mevasser ha-Levi b. Yešuʿa; S[...]l b. Saʿadya"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 8J5.1"],
+        "Condition": ["torn"],
+        "Date of Creation": ["1114 CE"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": [
+          "2 leaves (bifolium). Leaf height: 17.6 cm, width: 26 (1 leaf: 13.3) cm."
+        ],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Judaeo-Arabic; Hebrew; Aramaic"],
+        "Layout": ["12-19 lines"],
+        "Material": ["Paper"],
+        "Origin Place": ["Cairo; Fusṭāṭ"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Scribe(s)": ["Ḥalfon b. Manasseh"],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Legal document"]
+      },
+      "short_id": "MS-TS-00008-J-00005-00001",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00008-J-00005-00001"
+    },
+    "model": "djiffy.manifest",
+    "pk": 5695
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/dcxs55mp093"],
+          "system_created_at": "2021-12-02T03:17:03Z",
+          "system_updated_at": "2022-04-21T02:03:31Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 3751.5"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 3751.5",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/dcxs55mp093"],
+        "Local Identifier": ["ENA 3751.5"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 3751.5"]
+      },
+      "short_id": "fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/fd1a6b4c-c7e6-4920-bda5-2306cbb3f6e2/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 14035
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/40be59a7-e77c-4534-8e87-c0137c7789c8.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/40be59a7-e77c-4534-8e87-c0137c7789c8",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/dc2514nw495"],
+          "system_created_at": "2021-12-02T05:16:27Z",
+          "system_updated_at": "2022-04-21T00:53:20Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 4045.2"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 4045.2",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/dc2514nw495"],
+        "Local Identifier": ["ENA 4045.2"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 4045.2"]
+      },
+      "short_id": "40be59a7-e77c-4534-8e87-c0137c7789c8",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/40be59a7-e77c-4534-8e87-c0137c7789c8/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 12331
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AS-00135-00053/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Letter; unidentified (T-S AS 135.53)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Recto: part of a letter in Arabic. Verso: unidentified text in Hebrew characters. </p>"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S AS 135.53"],
+        "Condition": ["badly torn, holes, badly stained"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf. Leaf height: 6.1 cm, width: 5.1 cm."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Arabic; Hebrew (?)"],
+        "Layout": ["4 lines (recto); 1 line (verso)"],
+        "Material": ["Paper"],
+        "Note(s)": ["Verso is written transversely in relation to recto."],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Letter; unidentified"]
+      },
+      "short_id": "MS-TS-AS-00135-00053",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AS-00135-00053"
+    },
+    "model": "djiffy.manifest",
+    "pk": 5903
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00010-J-00012-00016/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
       "label": "Letter (T-S 10J12.16)",
       "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"holes, rubbed\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf. Leaf height: 21 cm, width: 16.7 cm.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Letter from a mother to her son Ab\\u016b l-Ma\\u1e25\\u0101sin in a hostel in the Alexandrian quarter al-Qamra. Written by Ab\\u016b Man\\u1e63\\u016br and mentioning people including Ab\\u016b l-Wa\\u1e25\\u0161, the shop of al-Kohen al-Siqill\\u012b and Ab\\u016b l-Faraj al-\\u0160ar\\u0101b\\u012b. </p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Letter\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S 10J12.16\"],\"Note(s)\":[\"Two lines on verso are inverted in relation to recto.\"],\"Recipient(s)\":[\"Ab\\u016b l-Ma\\u1e25\\u0101sin\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Associated Name(s)\":[\"Ab\\u016b Man\\u1e63\\u016br; Ab\\u016b l-Wa\\u1e25\\u0161; al-Kohen al-Siqill\\u012b; Ab\\u016b l-Faraj al-\\u0160ar\\u0101b\\u012b\"],\"Language(s)\":[\"Judaeo-Arabic; Hebrew; Arabic\"],\"Layout\":[\"21 lines + marginalia (recto); 4 lines (verso)\"],\"Author(s)\":[\"Ab\\u016b l-Ma\\u1e25\\u0101sin, mother of\"],\"Scribe(s)\":[\"Ab\\u016b Man\\u1e63\\u016br\"]}",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Letter from a mother to her son Abū l-Maḥāsin in a hostel in the Alexandrian quarter al-Qamra. Written by Abū Manṣūr and mentioning people including Abū l-Waḥš, the shop of al-Kohen al-Siqillī and Abū l-Faraj al-Šarābī. </p>"
+        ],
+        "Associated Name(s)": [
+          "Abū Manṣūr; Abū l-Waḥš; al-Kohen al-Siqillī; Abū l-Faraj al-Šarābī"
+        ],
+        "Author(s)": ["Abū l-Maḥāsin, mother of"],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 10J12.16"],
+        "Condition": ["holes, rubbed"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf. Leaf height: 21 cm, width: 16.7 cm."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Judaeo-Arabic; Hebrew; Arabic"],
+        "Layout": ["21 lines + marginalia (recto); 4 lines (verso)"],
+        "Material": ["Paper"],
+        "Note(s)": ["Two lines on verso are inverted in relation to recto."],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Recipient(s)": ["Abū l-Maḥāsin"],
+        "Scribe(s)": ["Abū Manṣūr"],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Letter"]
+      },
       "short_id": "MS-TS-00010-J-00012-00016",
       "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00010-J-00012-00016"
     },
     "model": "djiffy.manifest",
     "pk": 2409
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact <a href='mailto:genizah@lib.cam.ac.uk'>genizah@lib.cam.ac.uk</a>.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-00018-J-00001-00001/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Letter; document (T-S 18J1.1)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Recto: letter in which 15 signatories ask a community in another country to bring to court a merchant against whom a widow has financial claims. Verso: document in Arabic script. </p>"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["T-S 18J1.1"],
+        "Condition": ["torn, holes, rubbed, faded"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf. Leaf height: 29.5 cm, width: 19.6 cm."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Judaeo-Arabic; Arabic"],
+        "Layout": ["26 lines (recto); 5 lines + marginalia (verso)"],
+        "Material": ["Paper"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Letter; document"]
+      },
+      "short_id": "MS-TS-00018-J-00001-00001",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-00018-J-00001-00001"
+    },
+    "model": "djiffy.manifest",
+    "pk": 6885
+  },
+  {
+    "fields": {
+      "created": "2021-12-20",
+      "extra_data": {
+        "attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.",
+        "https://services.prod.env.cudl.link/v1/metadata/tei/MS-OR-01080-00001-00064/": {},
+        "logo": "https://cudl.lib.cam.ac.uk/img/cu_logo.png"
+      },
+      "label": "Responsa (Or.1080 1.64)",
+      "last_modified": "2022-02-17",
+      "metadata": {
+        "Abstract": [
+          "<p style='text-align: justify;'>Various Geonic responsa.</p>"
+        ],
+        "Author(s) of the Record": ["CUL"],
+        "Classmark": ["Or.1080 1.64"],
+        "Condition": ["Holes, faded"],
+        "Date of Creation": ["6th-19th century"],
+        "Donor(s)": [
+          "Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908"
+        ],
+        "Extent": ["1 leaf."],
+        "Funding": [
+          "The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>."
+        ],
+        "Language(s)": ["Hebrew; Aramaic (isolated Babylonian vocalisation)"],
+        "Layout": ["28 lines"],
+        "Material": ["Vellum"],
+        "Physical Location": ["Cambridge University Library"],
+        "Provenance": [
+          "Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection"
+        ],
+        "Subject(s)": ["Cairo Genizah"],
+        "Title": ["Responsa"]
+      },
+      "short_id": "MS-OR-01080-00001-00064",
+      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-OR-01080-00001-00064"
+    },
+    "model": "djiffy.manifest",
+    "pk": 5809
+  },
+  {
+    "fields": {
+      "created": "2022-01-20",
+      "extra_data": {
+        "https://figgy.princeton.edu/catalog/c3441638-b22f-46b7-b6a9-1301f6155c3e.jsonld": {
+          "@context": [
+            "https://bibdata.princeton.edu/context.json",
+            {
+              "latitude": {
+                "@id": "wgs84:lat"
+              },
+              "longitude": {
+                "@id": "wgs84:lon"
+              },
+              "wgs84": "http://www.w3.org/2003/01/geo/wgs84_pos#"
+            }
+          ],
+          "@id": "https://figgy.princeton.edu/catalog/c3441638-b22f-46b7-b6a9-1301f6155c3e",
+          "edm_rights": {
+            "@id": "https://creativecommons.org/publicdomain/zero/1.0/",
+            "@type": "dcterms:RightsStatement",
+            "pref_label": "CC-Zero / Public Domain"
+          },
+          "identifier": ["ark:/88435/4q77g0855"],
+          "system_created_at": "2021-01-08T06:19:59Z",
+          "system_updated_at": "2022-04-20T23:34:51Z",
+          "title": [
+            {
+              "@language": "eng",
+              "@value": "ENA 2209.12"
+            }
+          ]
+        },
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "logo": "https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png"
+      },
+      "label": "ENA 2209.12",
+      "last_modified": "2022-06-15",
+      "metadata": {
+        "Identifier": ["ark:/88435/4q77g0855"],
+        "Local Identifier": ["ENA 2209.12"],
+        "Provenance": [
+          "Images provided by the Jewish Theological Seminary Library (JTSL)"
+        ],
+        "Title": ["ENA 2209.12"]
+      },
+      "short_id": "c3441638-b22f-46b7-b6a9-1301f6155c3e",
+      "uri": "https://figgy.princeton.edu/concern/scanned_resources/c3441638-b22f-46b7-b6a9-1301f6155c3e/manifest"
+    },
+    "model": "djiffy.manifest",
+    "pk": 11360
   },
   {
     "fields": {
@@ -204,19 +808,6 @@
   },
   {
     "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-TS-AR-00030-00245/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Grammar; legal document (T-S Ar.30.245)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"Torn, rubbed, faded, stained\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Recto: response to the endorsement of a petition to the im\\u0101m Al-Mu\\u1e63tansir bi-All\\u0101h. Ca. 427-487 AH (= 1036-1094 CE). Verso and continuing on recto: Judaeo-Arabic treatise on the Arabic language.</p>\"],\"Date of Creation\":[\"1036-1094 CE\"],\"Title\":[\"Grammar; legal document\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Paper\"],\"Classmark\":[\"T-S Ar.30.245\"],\"Note(s)\":[\"Recto and verso have been inverted during conservation. The Arabic text is written perpendicular in relation to the Judaeo-Arabic text on verso.\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Associated Name(s)\":[\"Al-Mu\\u1e63tansir bi-All\\u0101h\"],\"Language(s)\":[\"Judaeo-Arabic; Arabic\"],\"Layout\":[\"32 lines + marginalia (recto); 32 lines (verso)\"]}",
-      "short_id": "MS-TS-AR-00030-00245",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-TS-AR-00030-00245"
-    },
-    "model": "djiffy.manifest",
-    "pk": 6750
-  },
-  {
-    "fields": {
       "abbrev": "T-S",
       "lib_abbrev": "CUL",
       "library": "Cambridge University Library",
@@ -224,32 +815,6 @@
       "name": "Taylor-Schechter"
     },
     "model": "corpus.collection"
-  },
-  {
-    "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/12a80dcc-1433-4230-9677-e3a83c4880cd.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/12a80dcc-1433-4230-9677-e3a83c4880cd\",\"identifier\":[\"ark:/88435/j6731c28x\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-01-08T06:47:56Z\",\"system_updated_at\":\"2021-03-23T19:37:53Z\",\"title\":[{\"@value\":\"ENA 2697.9\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 2697.9",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/j6731c28x\"],\"Title\":[\"ENA 2697.9\"],\"Local Identifier\":[\"ENA 2697.9\"]}",
-      "short_id": "12a80dcc-1433-4230-9677-e3a83c4880cd",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/12a80dcc-1433-4230-9677-e3a83c4880cd/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 10608
-  },
-  {
-    "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/50a29467-9298-4e4e-994d-9064dd7de49e.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/50a29467-9298-4e4e-994d-9064dd7de49e\",\"identifier\":[\"ark:/88435/zg64tv44j\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-01-08T06:48:01Z\",\"system_updated_at\":\"2021-03-23T19:37:52Z\",\"title\":[{\"@value\":\"ENA 2697.8\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 2697.8",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/zg64tv44j\"],\"Title\":[\"ENA 2697.8\"],\"Local Identifier\":[\"ENA 2697.8\"]}",
-      "short_id": "50a29467-9298-4e4e-994d-9064dd7de49e",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/50a29467-9298-4e4e-994d-9064dd7de49e/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 10607
   },
   {
     "fields": {
@@ -263,19 +828,6 @@
   },
   {
     "fields": {
-      "created": "2022-01-20",
-      "extra_data": "{\"https://figgy.princeton.edu/catalog/c3441638-b22f-46b7-b6a9-1301f6155c3e.jsonld\":{\"@context\":[\"https://bibdata.princeton.edu/context.json\",{\"wgs84\":\"http://www.w3.org/2003/01/geo/wgs84_pos#\",\"latitude\":{\"@id\":\"wgs84:lat\"},\"longitude\":{\"@id\":\"wgs84:lon\"}}],\"@id\":\"https://figgy.princeton.edu/catalog/c3441638-b22f-46b7-b6a9-1301f6155c3e\",\"identifier\":[\"ark:/88435/4q77g0855\"],\"edm_rights\":{\"@id\":\"http://rightsstatements.org/vocab/NKC/1.0/\",\"@type\":\"dcterms:RightsStatement\",\"pref_label\":\"No Known Copyright\"},\"system_created_at\":\"2021-01-08T06:19:59Z\",\"system_updated_at\":\"2021-03-23T19:22:47Z\",\"title\":[{\"@value\":\"ENA 2209.12\",\"@language\":\"eng\"}]},\"logo\":\"https://figgy.princeton.edu/assets/pul_logo_icon-7b5f9384dfa5ca04f4851c6ee9e44e2d6953e55f893472a3e205e1591d3b2ca6.png\",\"license\":\"http://rightsstatements.org/vocab/NKC/1.0/\"}",
-      "label": "ENA 2209.12",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Identifier\":[\"ark:/88435/4q77g0855\"],\"Title\":[\"ENA 2209.12\"],\"Local Identifier\":[\"ENA 2209.12\"]}",
-      "short_id": "c3441638-b22f-46b7-b6a9-1301f6155c3e",
-      "uri": "https://figgy.princeton.edu/concern/scanned_resources/c3441638-b22f-46b7-b6a9-1301f6155c3e/manifest"
-    },
-    "model": "djiffy.manifest",
-    "pk": 11360
-  },
-  {
-    "fields": {
       "abbrev": "",
       "lib_abbrev": "JTS",
       "library": "Jewish Theological Seminary Library",
@@ -283,19 +835,6 @@
       "name": ""
     },
     "model": "corpus.collection"
-  },
-  {
-    "fields": {
-      "created": "2021-12-20",
-      "extra_data": "{\"https://services.prod.env.cudl.link/v1/metadata/tei/MS-OR-01080-00001-00064/\":{},\"logo\":\"https://cudl.lib.cam.ac.uk/img/cu_logo.png\",\"attribution\":\"Provided by Cambridge University Library. Zooming image \\u00a9 Cambridge University Library, All rights reserved.  This image may be used in accord with fair use and fair dealing provisions, including teaching and research. If you wish to reproduce it within publications or on the public web, please contact genizah@lib.cam.ac.uk.   This metadata is published free of restrictions, under the terms of the Creative Commons CC0 1.0 Universal Public Domain Dedication.\"}",
-      "label": "Responsa (Or.1080 1.64)",
-      "last_modified": "2022-02-17",
-      "metadata": "{\"Condition\":[\"Holes, faded\"],\"Provenance\":[\"Donated by Dr Solomon Schechter and his patron Dr Charles Taylor in 1898 as part of the Taylor-Schechter Genizah Collection\"],\"Physical Location\":[\"Cambridge University Library\"],\"Extent\":[\"1 leaf.\"],\"Funding\":[\"The digitisation of the Taylor-Schechter Cairo Genizah Collection has been sponsored by the <a target='_blank' class='externalLink' href='http://www.jewishmanuscripts.org/'>Jewish Manuscript Preservation Society</a>, the <a target='_blank' class='externalLink' href='http://www.genizah.org/'>Friedberg Genizah Project Inc.</a>, and the <a target='_blank' class='externalLink' href='http://www.ahrc.ac.uk/Pages/default.aspx'>Arts and Humanities Research Council, UK</a>.\"],\"Abstract\":[\"<p style='text-align: justify;'>Various Geonic responsa.</p>\"],\"Date of Creation\":[\"6th-19th century\"],\"Title\":[\"Responsa\"],\"Author(s) of the Record\":[\"CUL\"],\"Material\":[\"Vellum\"],\"Classmark\":[\"Or.1080 1.64\"],\"Donor(s)\":[\"Schechter, S. (Solomon), 1847-1915; Taylor, Charles, 1840-1908\"],\"Subject(s)\":[\"Cairo Genizah\"],\"Language(s)\":[\"Hebrew; Aramaic (isolated Babylonian vocalisation)\"],\"Layout\":[\"28 lines\"]}",
-      "short_id": "MS-OR-01080-00001-00064",
-      "uri": "https://cudl.lib.cam.ac.uk/iiif/MS-OR-01080-00001-00064"
-    },
-    "model": "djiffy.manifest",
-    "pk": 5809
   },
   {
     "fields": {
@@ -321,7 +860,7 @@
     "fields": {
       "abbrev": "",
       "lib_abbrev": "AIU",
-      "library": "Alliance Isra\u00e9lite Universelle",
+      "library": "Alliance Israélite Universelle",
       "location": "Paris",
       "name": ""
     },
@@ -1219,7 +1758,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:35.929Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1721,7 +2260,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:51.379Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1737,7 +2276,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:51.355Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1769,7 +2308,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:38.644Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1785,7 +2324,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:34.961Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1801,7 +2340,7 @@
   },
   {
     "fields": {
-      "collection": ["", "Alliance Isra\u00e9lite Universelle"],
+      "collection": ["", "Alliance Israélite Universelle"],
       "created": "2021-05-26T20:22:33.785Z",
       "iiif_url": "",
       "is_multifragment": false,
@@ -1818,9 +2357,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:24:17.570Z",
-      "description": "Fragments from a copy of a letter. The writer is a person from Pumbedita (which belongs to a family of several Gaons) to a person in Spain, might be Hisdai b. Shafrut. The copy from the 11th century. Original letter from March/April 953. The letter contains important details about the connections with Spain, as well as about main figures in the Iraqi yeshiva. Mentions the head of the Gola \u2013 Shlomo b. Yisha\u2019ayahu. (Gil, Kingdom, vol. 2, Doc. #13) VMR",
+      "description": "Fragments from a copy of a letter. The writer is a person from Pumbedita (which belongs to a family of several Gaons) to a person in Spain, might be Hisdai b. Shafrut. The copy from the 11th century. Original letter from March/April 953. The letter contains important details about the connections with Spain, as well as about main figures in the Iraqi yeshiva. Mentions the head of the Gola – Shlomo b. Yisha’ayahu. (Gil, Kingdom, vol. 2, Doc. #13) VMR",
       "description_ar": null,
-      "description_en": "Fragments from a copy of a letter. The writer is a person from Pumbedita (which belongs to a family of several Gaons) to a person in Spain, might be Hisdai b. Shafrut. The copy from the 11th century. Original letter from March/April 953. The letter contains important details about the connections with Spain, as well as about main figures in the Iraqi yeshiva. Mentions the head of the Gola \u2013 Shlomo b. Yisha\u2019ayahu. (Gil, Kingdom, vol. 2, Doc. #13) VMR",
+      "description_en": "Fragments from a copy of a letter. The writer is a person from Pumbedita (which belongs to a family of several Gaons) to a person in Spain, might be Hisdai b. Shafrut. The copy from the 11th century. Original letter from March/April 953. The letter contains important details about the connections with Spain, as well as about main figures in the Iraqi yeshiva. Mentions the head of the Gola – Shlomo b. Yisha’ayahu. (Gil, Kingdom, vol. 2, Doc. #13) VMR",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -1842,9 +2381,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:36:31.954Z",
-      "description": "Letter in the hand of Yehuda b. \u1e6coviyyahu (muqaddam of Bilbays, active 1170s\u20131219). In Judaeo-Arabic. Containing a complaint about illness. The purpose seems to be that the writer is unable to support a \u1e24aver who came to stay with him. \u201c[I was] constrained by my great expenses for medicines and chickens\u2026 An illness came upon me, on top of my chronic illness: shortness of breath and fever...\u201d Mentions the boy Abu l-Bayan and al-Shaykh al-Muhadhdhab. Cites Berakhot 3b: \u201cA handful cannot satisfy a lion, nor can a pit be filled up with its own clods.\u201d Information from Goitein\u2019s note cards. Goitein read the word farr\u016bj as sur\u016bj (meaning lamps -\"perhaps he stayed up at night\"), but see, for instance, Halper 410 and DK 238.3 for the formula \"the medicine and the chicken.\" Regards to \"our rabbi Avraham (Maimonides)\" in the margin. AA. ASE.",
+      "description": "Letter in the hand of Yehuda b. Ṭoviyyahu (muqaddam of Bilbays, active 1170s–1219). In Judaeo-Arabic. Containing a complaint about illness. The purpose seems to be that the writer is unable to support a Ḥaver who came to stay with him. “[I was] constrained by my great expenses for medicines and chickens… An illness came upon me, on top of my chronic illness: shortness of breath and fever...” Mentions the boy Abu l-Bayan and al-Shaykh al-Muhadhdhab. Cites Berakhot 3b: “A handful cannot satisfy a lion, nor can a pit be filled up with its own clods.” Information from Goitein’s note cards. Goitein read the word farrūj as surūj (meaning lamps -\"perhaps he stayed up at night\"), but see, for instance, Halper 410 and DK 238.3 for the formula \"the medicine and the chicken.\" Regards to \"our rabbi Avraham (Maimonides)\" in the margin. AA. ASE.",
       "description_ar": null,
-      "description_en": "Letter in the hand of Yehuda b. \u1e6coviyyahu (muqaddam of Bilbays, active 1170s\u20131219). In Judaeo-Arabic. Containing a complaint about illness. The purpose seems to be that the writer is unable to support a \u1e24aver who came to stay with him. \u201c[I was] constrained by my great expenses for medicines and chickens\u2026 An illness came upon me, on top of my chronic illness: shortness of breath and fever...\u201d Mentions the boy Abu l-Bayan and al-Shaykh al-Muhadhdhab. Cites Berakhot 3b: \u201cA handful cannot satisfy a lion, nor can a pit be filled up with its own clods.\u201d Information from Goitein\u2019s note cards. Goitein read the word farr\u016bj as sur\u016bj (meaning lamps -\"perhaps he stayed up at night\"), but see, for instance, Halper 410 and DK 238.3 for the formula \"the medicine and the chicken.\" Regards to \"our rabbi Avraham (Maimonides)\" in the margin. AA. ASE.",
+      "description_en": "Letter in the hand of Yehuda b. Ṭoviyyahu (muqaddam of Bilbays, active 1170s–1219). In Judaeo-Arabic. Containing a complaint about illness. The purpose seems to be that the writer is unable to support a Ḥaver who came to stay with him. “[I was] constrained by my great expenses for medicines and chickens… An illness came upon me, on top of my chronic illness: shortness of breath and fever...” Mentions the boy Abu l-Bayan and al-Shaykh al-Muhadhdhab. Cites Berakhot 3b: “A handful cannot satisfy a lion, nor can a pit be filled up with its own clods.” Information from Goitein’s note cards. Goitein read the word farrūj as surūj (meaning lamps -\"perhaps he stayed up at night\"), but see, for instance, Halper 410 and DK 238.3 for the formula \"the medicine and the chicken.\" Regards to \"our rabbi Avraham (Maimonides)\" in the margin. AA. ASE.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -1869,9 +2408,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:35:19.784Z",
-      "description": "Inventory of the estate of a wealthy goldsmith, Abu Ya\u02bfqub, dated Elul 1425 (=August, 1114 CE) and consisting of dinars in bankers\u2019 notes, gold cash, and in bars of precious metals; various vessels, two female slaves, and promissory notes are also referenced. The document was written by \u1e24alfon b. Manasse and sealed by the rabbinic court on the day of Abu Ya\u02bfqub\u2019s death. Before any shares were distributed to the heirs, the widow received the \u201cdeferred installment\u201d due to her according to her marriage contract, in this case 75 dinars. (S. D. Goitein, Mediterranean Society 5:168-70, 549, 533; and Goitein\u2019s index cards) EMS",
+      "description": "Inventory of the estate of a wealthy goldsmith, Abu Yaʿqub, dated Elul 1425 (=August, 1114 CE) and consisting of dinars in bankers’ notes, gold cash, and in bars of precious metals; various vessels, two female slaves, and promissory notes are also referenced. The document was written by Ḥalfon b. Manasse and sealed by the rabbinic court on the day of Abu Yaʿqub’s death. Before any shares were distributed to the heirs, the widow received the “deferred installment” due to her according to her marriage contract, in this case 75 dinars. (S. D. Goitein, Mediterranean Society 5:168-70, 549, 533; and Goitein’s index cards) EMS",
       "description_ar": null,
-      "description_en": "Inventory of the estate of a wealthy goldsmith, Abu Ya\u02bfqub, dated Elul 1425 (=August, 1114 CE) and consisting of dinars in bankers\u2019 notes, gold cash, and in bars of precious metals; various vessels, two female slaves, and promissory notes are also referenced. The document was written by \u1e24alfon b. Manasse and sealed by the rabbinic court on the day of Abu Ya\u02bfqub\u2019s death. Before any shares were distributed to the heirs, the widow received the \u201cdeferred installment\u201d due to her according to her marriage contract, in this case 75 dinars. (S. D. Goitein, Mediterranean Society 5:168-70, 549, 533; and Goitein\u2019s index cards) EMS",
+      "description_en": "Inventory of the estate of a wealthy goldsmith, Abu Yaʿqub, dated Elul 1425 (=August, 1114 CE) and consisting of dinars in bankers’ notes, gold cash, and in bars of precious metals; various vessels, two female slaves, and promissory notes are also referenced. The document was written by Ḥalfon b. Manasse and sealed by the rabbinic court on the day of Abu Yaʿqub’s death. Before any shares were distributed to the heirs, the widow received the “deferred installment” due to her according to her marriage contract, in this case 75 dinars. (S. D. Goitein, Mediterranean Society 5:168-70, 549, 533; and Goitein’s index cards) EMS",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -1941,9 +2480,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:33:59.835Z",
-      "description": "Deed of sale in Arabic script, written by Avraham b. Natan b. Avraham. Sitt al-Aqran sells her female slave Na\u02bf\u012bm to Sitt al-Mun\u0101, the widow of Nahray b. Nissim, for 20 dinars. Dated Kislev 1420/ November 1107. (Gil, Kingdom, Vol. 2, 918)",
+      "description": "Deed of sale in Arabic script, written by Avraham b. Natan b. Avraham. Sitt al-Aqran sells her female slave Naʿīm to Sitt al-Munā, the widow of Nahray b. Nissim, for 20 dinars. Dated Kislev 1420/ November 1107. (Gil, Kingdom, Vol. 2, 918)",
       "description_ar": null,
-      "description_en": "Deed of sale in Arabic script, written by Avraham b. Natan b. Avraham. Sitt al-Aqran sells her female slave Na\u02bf\u012bm to Sitt al-Mun\u0101, the widow of Nahray b. Nissim, for 20 dinars. Dated Kislev 1420/ November 1107. (Gil, Kingdom, Vol. 2, 918)",
+      "description_en": "Deed of sale in Arabic script, written by Avraham b. Natan b. Avraham. Sitt al-Aqran sells her female slave Naʿīm to Sitt al-Munā, the widow of Nahray b. Nissim, for 20 dinars. Dated Kislev 1420/ November 1107. (Gil, Kingdom, Vol. 2, 918)",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -1965,9 +2504,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:32:52.123Z",
-      "description": "Bill of divorce, Qaraite. In Hebrew. T-S 12.54 and T-S 12.70 are two very rare examples of Qaraite bills of divorce. Husband: \u02bfAmm\u0101r al-Kh\u0101\u1e6dir\u012b. Witnesses: Yefet Kohen b. \u02bfEli; Mevorakh b. Yehuda ha-Levi.",
+      "description": "Bill of divorce, Qaraite. In Hebrew. T-S 12.54 and T-S 12.70 are two very rare examples of Qaraite bills of divorce. Husband: ʿAmmār al-Khāṭirī. Witnesses: Yefet Kohen b. ʿEli; Mevorakh b. Yehuda ha-Levi.",
       "description_ar": null,
-      "description_en": "Bill of divorce, Qaraite. In Hebrew. T-S 12.54 and T-S 12.70 are two very rare examples of Qaraite bills of divorce. Husband: \u02bfAmm\u0101r al-Kh\u0101\u1e6dir\u012b. Witnesses: Yefet Kohen b. \u02bfEli; Mevorakh b. Yehuda ha-Levi.",
+      "description_en": "Bill of divorce, Qaraite. In Hebrew. T-S 12.54 and T-S 12.70 are two very rare examples of Qaraite bills of divorce. Husband: ʿAmmār al-Khāṭirī. Witnesses: Yefet Kohen b. ʿEli; Mevorakh b. Yehuda ha-Levi.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2013,9 +2552,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:39:38.626Z",
-      "description": "Letter fragment in Judaeo-Arabic. Quite faded. Mentions that all slaughtering in Dams\u012bs has been put on hold; asks the addressee to obtain a fatw\u0101 in response to some query; mentions Ibn al-Munajjim; mentions an illness. ",
+      "description": "Letter fragment in Judaeo-Arabic. Quite faded. Mentions that all slaughtering in Damsīs has been put on hold; asks the addressee to obtain a fatwā in response to some query; mentions Ibn al-Munajjim; mentions an illness. ",
       "description_ar": null,
-      "description_en": "Letter fragment in Judaeo-Arabic. Quite faded. Mentions that all slaughtering in Dams\u012bs has been put on hold; asks the addressee to obtain a fatw\u0101 in response to some query; mentions Ibn al-Munajjim; mentions an illness. ",
+      "description_en": "Letter fragment in Judaeo-Arabic. Quite faded. Mentions that all slaughtering in Damsīs has been put on hold; asks the addressee to obtain a fatwā in response to some query; mentions Ibn al-Munajjim; mentions an illness. ",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2037,9 +2576,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:39:06.101Z",
-      "description": "Fatimid decree from the chancery  of al-\u1e24\u0101kim, al-\u1e92\u0101hir or al-Mustan\u1e63ir to an official in Egypt regarding a dispute over irrigation canals and access to water \u2014\u00a0insofar as one can judge. Left half of lines only, about 1.3 meters of what was once a much longer decree. Verso: Efrayim b. Shemarya uses and reworks passages from the She\u02beiltot for a sermon. Top of rotulus is headed Shabbat Bereishit. Join: Roni Shweka (bottom six fragments) and Rebecca Sebbagh (top fragment). Before 1055. See also Mosseri VI.17.12, which may belong to the left side of this decree. (MR)",
+      "description": "Fatimid decree from the chancery  of al-Ḥākim, al-Ẓāhir or al-Mustanṣir to an official in Egypt regarding a dispute over irrigation canals and access to water — insofar as one can judge. Left half of lines only, about 1.3 meters of what was once a much longer decree. Verso: Efrayim b. Shemarya uses and reworks passages from the Sheʾiltot for a sermon. Top of rotulus is headed Shabbat Bereishit. Join: Roni Shweka (bottom six fragments) and Rebecca Sebbagh (top fragment). Before 1055. See also Mosseri VI.17.12, which may belong to the left side of this decree. (MR)",
       "description_ar": null,
-      "description_en": "Fatimid decree from the chancery  of al-\u1e24\u0101kim, al-\u1e92\u0101hir or al-Mustan\u1e63ir to an official in Egypt regarding a dispute over irrigation canals and access to water \u2014\u00a0insofar as one can judge. Left half of lines only, about 1.3 meters of what was once a much longer decree. Verso: Efrayim b. Shemarya uses and reworks passages from the She\u02beiltot for a sermon. Top of rotulus is headed Shabbat Bereishit. Join: Roni Shweka (bottom six fragments) and Rebecca Sebbagh (top fragment). Before 1055. See also Mosseri VI.17.12, which may belong to the left side of this decree. (MR)",
+      "description_en": "Fatimid decree from the chancery  of al-Ḥākim, al-Ẓāhir or al-Mustanṣir to an official in Egypt regarding a dispute over irrigation canals and access to water — insofar as one can judge. Left half of lines only, about 1.3 meters of what was once a much longer decree. Verso: Efrayim b. Shemarya uses and reworks passages from the Sheʾiltot for a sermon. Top of rotulus is headed Shabbat Bereishit. Join: Roni Shweka (bottom six fragments) and Rebecca Sebbagh (top fragment). Before 1055. See also Mosseri VI.17.12, which may belong to the left side of this decree. (MR)",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2085,9 +2624,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:35:42.506Z",
-      "description": "State document: end of report with \u1e25asbala, but then another line with name and title of al-Mustan\u1e63ir. See separate record (PGPID 30818).",
+      "description": "State document: end of report with ḥasbala, but then another line with name and title of al-Mustanṣir. See separate record (PGPID 30818).",
       "description_ar": null,
-      "description_en": "State document: end of report with \u1e25asbala, but then another line with name and title of al-Mustan\u1e63ir. See separate record (PGPID 30818).",
+      "description_en": "State document: end of report with ḥasbala, but then another line with name and title of al-Mustanṣir. See separate record (PGPID 30818).",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2205,9 +2744,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:31:49.823Z",
-      "description": "Letter from a woman, in Fustat, to her son Ab\u016b l-Ma\u1e25\u0101sin, in Funduq al-Qamra, Alexandria. Dictated to Ab\u016b Man\u1e63\u016br. Likely belongs with T-S 10J19.26, in which case the writer of this letter is Sitt Ghaz\u0101l bt. Ab\u016b \u02bfUmar. She expresses the anxiety (n\u0101r) that afflicts her heart on his behalf ever since his departure on Friday. She has been having nightmares and insomnia, and fears that if he does not return quickly, she will be completely blind by the time he returns. (It is also possible that the phrase \"yatlaf ba\u1e63ar\u012b\" refers to death instead of going blind; compare \"waf\u0101t \u02bfaynak\" in T-S 10J12.14.) She urges him not to drink wine \"on account of your illness. . . May God protect us from illness while separated (al-mara\u1e0d f\u012b l-ghurba). . . If my night visions are distressing to me, how [much the worse] if I should see them while awake.\" The last sentence is ambiguous: either she fears that nightmares can afflict a blind person at all hours, or she fears that her visions of terrible things happening to her son will become realities. She requests that he bring various goods back with him: a large bowl (qa\u1e63\u02bfa), a linen cloth (? sh\u012bta), a good comb (mush\u1e6d), and two spoons (mil\u02bfaqatayn), and possibly red ink (? mid\u0101dun yak\u016bn\u016b \u1e25umr) for Umm Ab\u016b l-Bah\u0101'. The scribe Ab\u016b Man\u1e63\u016br interjects here (line 13), and the remainder of the letter is in his voice. He apologizes for troubling the addressee with news of illness, but the fever is still with him. He asks for news of Ab\u016b l-Wa\u1e25sh Sib\u0101\u02bf, and the bible, and the book of Rabbenu Ba\u1e25ye. He is very anxious to learn what his instructions are\u2014it seems he is to copy one or both of these books for Ab\u016b l-Wa\u1e25sh\u2014so that he is not accused of tardiness. The instructions should be delivered either to S\u016bq al-\u02bfA\u1e6d\u1e6d\u0101r\u012bn to the shop of al-Kohen al-Siqill\u012b, or to al-S\u016bq al-Kabir, to the shop of Ab\u016b l-Faraj al-Shar\u0101b\u012b. See Mediterranean Society, IV, pp. 224\u201325, 260. VMR. ASE.",
+      "description": "Letter from a woman, in Fustat, to her son Abū l-Maḥāsin, in Funduq al-Qamra, Alexandria. Dictated to Abū Manṣūr. Likely belongs with T-S 10J19.26, in which case the writer of this letter is Sitt Ghazāl bt. Abū ʿUmar. She expresses the anxiety (nār) that afflicts her heart on his behalf ever since his departure on Friday. She has been having nightmares and insomnia, and fears that if he does not return quickly, she will be completely blind by the time he returns. (It is also possible that the phrase \"yatlaf baṣarī\" refers to death instead of going blind; compare \"wafāt ʿaynak\" in T-S 10J12.14.) She urges him not to drink wine \"on account of your illness. . . May God protect us from illness while separated (al-maraḍ fī l-ghurba). . . If my night visions are distressing to me, how [much the worse] if I should see them while awake.\" The last sentence is ambiguous: either she fears that nightmares can afflict a blind person at all hours, or she fears that her visions of terrible things happening to her son will become realities. She requests that he bring various goods back with him: a large bowl (qaṣʿa), a linen cloth (? shīta), a good comb (mushṭ), and two spoons (milʿaqatayn), and possibly red ink (? midādun yakūnū ḥumr) for Umm Abū l-Bahā'. The scribe Abū Manṣūr interjects here (line 13), and the remainder of the letter is in his voice. He apologizes for troubling the addressee with news of illness, but the fever is still with him. He asks for news of Abū l-Waḥsh Sibāʿ, and the bible, and the book of Rabbenu Baḥye. He is very anxious to learn what his instructions are—it seems he is to copy one or both of these books for Abū l-Waḥsh—so that he is not accused of tardiness. The instructions should be delivered either to Sūq al-ʿAṭṭārīn to the shop of al-Kohen al-Siqillī, or to al-Sūq al-Kabir, to the shop of Abū l-Faraj al-Sharābī. See Mediterranean Society, IV, pp. 224–25, 260. VMR. ASE.",
       "description_ar": null,
-      "description_en": "Letter from a woman, in Fustat, to her son Ab\u016b l-Ma\u1e25\u0101sin, in Funduq al-Qamra, Alexandria. Dictated to Ab\u016b Man\u1e63\u016br. Likely belongs with T-S 10J19.26, in which case the writer of this letter is Sitt Ghaz\u0101l bt. Ab\u016b \u02bfUmar. She expresses the anxiety (n\u0101r) that afflicts her heart on his behalf ever since his departure on Friday. She has been having nightmares and insomnia, and fears that if he does not return quickly, she will be completely blind by the time he returns. (It is also possible that the phrase \"yatlaf ba\u1e63ar\u012b\" refers to death instead of going blind; compare \"waf\u0101t \u02bfaynak\" in T-S 10J12.14.) She urges him not to drink wine \"on account of your illness. . . May God protect us from illness while separated (al-mara\u1e0d f\u012b l-ghurba). . . If my night visions are distressing to me, how [much the worse] if I should see them while awake.\" The last sentence is ambiguous: either she fears that nightmares can afflict a blind person at all hours, or she fears that her visions of terrible things happening to her son will become realities. She requests that he bring various goods back with him: a large bowl (qa\u1e63\u02bfa), a linen cloth (? sh\u012bta), a good comb (mush\u1e6d), and two spoons (mil\u02bfaqatayn), and possibly red ink (? mid\u0101dun yak\u016bn\u016b \u1e25umr) for Umm Ab\u016b l-Bah\u0101'. The scribe Ab\u016b Man\u1e63\u016br interjects here (line 13), and the remainder of the letter is in his voice. He apologizes for troubling the addressee with news of illness, but the fever is still with him. He asks for news of Ab\u016b l-Wa\u1e25sh Sib\u0101\u02bf, and the bible, and the book of Rabbenu Ba\u1e25ye. He is very anxious to learn what his instructions are\u2014it seems he is to copy one or both of these books for Ab\u016b l-Wa\u1e25sh\u2014so that he is not accused of tardiness. The instructions should be delivered either to S\u016bq al-\u02bfA\u1e6d\u1e6d\u0101r\u012bn to the shop of al-Kohen al-Siqill\u012b, or to al-S\u016bq al-Kabir, to the shop of Ab\u016b l-Faraj al-Shar\u0101b\u012b. See Mediterranean Society, IV, pp. 224\u201325, 260. VMR. ASE.",
+      "description_en": "Letter from a woman, in Fustat, to her son Abū l-Maḥāsin, in Funduq al-Qamra, Alexandria. Dictated to Abū Manṣūr. Likely belongs with T-S 10J19.26, in which case the writer of this letter is Sitt Ghazāl bt. Abū ʿUmar. She expresses the anxiety (nār) that afflicts her heart on his behalf ever since his departure on Friday. She has been having nightmares and insomnia, and fears that if he does not return quickly, she will be completely blind by the time he returns. (It is also possible that the phrase \"yatlaf baṣarī\" refers to death instead of going blind; compare \"wafāt ʿaynak\" in T-S 10J12.14.) She urges him not to drink wine \"on account of your illness. . . May God protect us from illness while separated (al-maraḍ fī l-ghurba). . . If my night visions are distressing to me, how [much the worse] if I should see them while awake.\" The last sentence is ambiguous: either she fears that nightmares can afflict a blind person at all hours, or she fears that her visions of terrible things happening to her son will become realities. She requests that he bring various goods back with him: a large bowl (qaṣʿa), a linen cloth (? shīta), a good comb (mushṭ), and two spoons (milʿaqatayn), and possibly red ink (? midādun yakūnū ḥumr) for Umm Abū l-Bahā'. The scribe Abū Manṣūr interjects here (line 13), and the remainder of the letter is in his voice. He apologizes for troubling the addressee with news of illness, but the fever is still with him. He asks for news of Abū l-Waḥsh Sibāʿ, and the bible, and the book of Rabbenu Baḥye. He is very anxious to learn what his instructions are—it seems he is to copy one or both of these books for Abū l-Waḥsh—so that he is not accused of tardiness. The instructions should be delivered either to Sūq al-ʿAṭṭārīn to the shop of al-Kohen al-Siqillī, or to al-Sūq al-Kabir, to the shop of Abū l-Faraj al-Sharābī. See Mediterranean Society, IV, pp. 224–25, 260. VMR. ASE.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2229,9 +2768,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:31:43.348Z",
-      "description": "Document that is a continuation of Sassoon 1055A. Aharon al-Araki, who received a part of a house in Sana'a, sells his part to his brother Salam and his niece Badra for 150 Rial (75 for each); 1667.\u00a0(Goitein, The Yemenites, 157-158) VMR",
+      "description": "Document that is a continuation of Sassoon 1055A. Aharon al-Araki, who received a part of a house in Sana'a, sells his part to his brother Salam and his niece Badra for 150 Rial (75 for each); 1667. (Goitein, The Yemenites, 157-158) VMR",
       "description_ar": null,
-      "description_en": "Document that is a continuation of Sassoon 1055A. Aharon al-Araki, who received a part of a house in Sana'a, sells his part to his brother Salam and his niece Badra for 150 Rial (75 for each); 1667.\u00a0(Goitein, The Yemenites, 157-158) VMR",
+      "description_en": "Document that is a continuation of Sassoon 1055A. Aharon al-Araki, who received a part of a house in Sana'a, sells his part to his brother Salam and his niece Badra for 150 Rial (75 for each); 1667. (Goitein, The Yemenites, 157-158) VMR",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2277,9 +2816,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:31:42.722Z",
-      "description": "Bill of divorce. Dated: Monday, 18 Adar 1365 Seleucid, which is 1054 CE. Location: Fustat. Husband: Yosef b. David. Wife: Khib\u0101 bt. Yosef. No witness signatures. Verso was not photographed.",
+      "description": "Bill of divorce. Dated: Monday, 18 Adar 1365 Seleucid, which is 1054 CE. Location: Fustat. Husband: Yosef b. David. Wife: Khibā bt. Yosef. No witness signatures. Verso was not photographed.",
       "description_ar": null,
-      "description_en": "Bill of divorce. Dated: Monday, 18 Adar 1365 Seleucid, which is 1054 CE. Location: Fustat. Husband: Yosef b. David. Wife: Khib\u0101 bt. Yosef. No witness signatures. Verso was not photographed.",
+      "description_en": "Bill of divorce. Dated: Monday, 18 Adar 1365 Seleucid, which is 1054 CE. Location: Fustat. Husband: Yosef b. David. Wife: Khibā bt. Yosef. No witness signatures. Verso was not photographed.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2301,9 +2840,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:31:42.052Z",
-      "description": "Possibly a tax receipt or an order of payment? Two endorsements, end of Dh\u016b l-Qa\u02bfda of the year 403 (?) 6x8 cm, verso blank",
+      "description": "Possibly a tax receipt or an order of payment? Two endorsements, end of Dhū l-Qaʿda of the year 403 (?) 6x8 cm, verso blank",
       "description_ar": null,
-      "description_en": "Possibly a tax receipt or an order of payment? Two endorsements, end of Dh\u016b l-Qa\u02bfda of the year 403 (?) 6x8 cm, verso blank",
+      "description_en": "Possibly a tax receipt or an order of payment? Two endorsements, end of Dhū l-Qaʿda of the year 403 (?) 6x8 cm, verso blank",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2325,9 +2864,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:30:58.848Z",
-      "description": "Letter fragment in Arabic script in the margin of a Coptic New Testament. \"\u0627\u0639\u0645\u0644\u0648\u0627/\u062a\u0639\u0645\u0644\u0648\u0627 \u0645\u0639\u0631\u0648\u0641\u0643\u0645 \u0627\u0644\u0649 \u0627\u0648\u0631\u0634\u0644\u064a\u0645 \u0648\u0627\u0646 \u0643\u0627\u0646 \u064a\u0646\u0628\u063a\u064a \u0627\u0646 \u0627\u0645\u0636\u064a \u0627\u0646\u0627 \u0627\u064a\u0636\u0627 \u0627\u0644\u0649 \u0647\u0627 \u0647\u0646\u0627\u0643 \u0627\u0630\u0647\u0628\u0648\u0627 \u0645\u0639\u064a \u0641\u0627\u0646\u064a . . . \u0639\u0644\u064a\u0643\u0645.\" Planning a trip to Jerusalem? Needs further examination.",
+      "description": "Letter fragment in Arabic script in the margin of a Coptic New Testament. \"اعملوا/تعملوا معروفكم الى اورشليم وان كان ينبغي ان امضي انا ايضا الى ها هناك اذهبوا معي فاني . . . عليكم.\" Planning a trip to Jerusalem? Needs further examination.",
       "description_ar": null,
-      "description_en": "Letter fragment in Arabic script in the margin of a Coptic New Testament. \"\u0627\u0639\u0645\u0644\u0648\u0627/\u062a\u0639\u0645\u0644\u0648\u0627 \u0645\u0639\u0631\u0648\u0641\u0643\u0645 \u0627\u0644\u0649 \u0627\u0648\u0631\u0634\u0644\u064a\u0645 \u0648\u0627\u0646 \u0643\u0627\u0646 \u064a\u0646\u0628\u063a\u064a \u0627\u0646 \u0627\u0645\u0636\u064a \u0627\u0646\u0627 \u0627\u064a\u0636\u0627 \u0627\u0644\u0649 \u0647\u0627 \u0647\u0646\u0627\u0643 \u0627\u0630\u0647\u0628\u0648\u0627 \u0645\u0639\u064a \u0641\u0627\u0646\u064a . . . \u0639\u0644\u064a\u0643\u0645.\" Planning a trip to Jerusalem? Needs further examination.",
+      "description_en": "Letter fragment in Arabic script in the margin of a Coptic New Testament. \"اعملوا/تعملوا معروفكم الى اورشليم وان كان ينبغي ان امضي انا ايضا الى ها هناك اذهبوا معي فاني . . . عليكم.\" Planning a trip to Jerusalem? Needs further examination.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2349,9 +2888,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:30:28.475Z",
-      "description": "Accounts in Judaeo-Arabic of funds regarding weeks of the Jewish liturgical calendar that differ in structure but are related to nearby shelfmarks such as JRL C 161 and JRL C 159. From the paleography the dating can be estimated as 18th/19th-century. On the recto there is also a list of books in the Bible and the corresponding totals of their respective chapters (i.e. Joshua 24, Judges 21, etc.). On the verso, the Judaeo-Arabic word \"\u05d7\u05e1\u05d0\u05d1 / \u062d\u0633\u0627\u0628\" is used repeatedly in labeling the headings of various entries/calculations. Date: 18th c or 19th c. MCD.",
+      "description": "Accounts in Judaeo-Arabic of funds regarding weeks of the Jewish liturgical calendar that differ in structure but are related to nearby shelfmarks such as JRL C 161 and JRL C 159. From the paleography the dating can be estimated as 18th/19th-century. On the recto there is also a list of books in the Bible and the corresponding totals of their respective chapters (i.e. Joshua 24, Judges 21, etc.). On the verso, the Judaeo-Arabic word \"חסאב / حساب\" is used repeatedly in labeling the headings of various entries/calculations. Date: 18th c or 19th c. MCD.",
       "description_ar": null,
-      "description_en": "Accounts in Judaeo-Arabic of funds regarding weeks of the Jewish liturgical calendar that differ in structure but are related to nearby shelfmarks such as JRL C 161 and JRL C 159. From the paleography the dating can be estimated as 18th/19th-century. On the recto there is also a list of books in the Bible and the corresponding totals of their respective chapters (i.e. Joshua 24, Judges 21, etc.). On the verso, the Judaeo-Arabic word \"\u05d7\u05e1\u05d0\u05d1 / \u062d\u0633\u0627\u0628\" is used repeatedly in labeling the headings of various entries/calculations. Date: 18th c or 19th c. MCD.",
+      "description_en": "Accounts in Judaeo-Arabic of funds regarding weeks of the Jewish liturgical calendar that differ in structure but are related to nearby shelfmarks such as JRL C 161 and JRL C 159. From the paleography the dating can be estimated as 18th/19th-century. On the recto there is also a list of books in the Bible and the corresponding totals of their respective chapters (i.e. Joshua 24, Judges 21, etc.). On the verso, the Judaeo-Arabic word \"חסאב / حساب\" is used repeatedly in labeling the headings of various entries/calculations. Date: 18th c or 19th c. MCD.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2397,9 +2936,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:29:23.006Z",
-      "description": "Report to an Ayyubid official mentioning al-Malik al-\u02bf\u0100dil and a deceased official named Shams al-D\u012bn. The Mainz shelfmark is how it's listed in FGP, but it's not actually in Mainz. The image in FGP is from a microfilm at the National Library of Israel; the original was at a paper museum in Mainz that has since closed, now presumed lost. Join: Marina Rustow.",
+      "description": "Report to an Ayyubid official mentioning al-Malik al-ʿĀdil and a deceased official named Shams al-Dīn. The Mainz shelfmark is how it's listed in FGP, but it's not actually in Mainz. The image in FGP is from a microfilm at the National Library of Israel; the original was at a paper museum in Mainz that has since closed, now presumed lost. Join: Marina Rustow.",
       "description_ar": null,
-      "description_en": "Report to an Ayyubid official mentioning al-Malik al-\u02bf\u0100dil and a deceased official named Shams al-D\u012bn. The Mainz shelfmark is how it's listed in FGP, but it's not actually in Mainz. The image in FGP is from a microfilm at the National Library of Israel; the original was at a paper museum in Mainz that has since closed, now presumed lost. Join: Marina Rustow.",
+      "description_en": "Report to an Ayyubid official mentioning al-Malik al-ʿĀdil and a deceased official named Shams al-Dīn. The Mainz shelfmark is how it's listed in FGP, but it's not actually in Mainz. The image in FGP is from a microfilm at the National Library of Israel; the original was at a paper museum in Mainz that has since closed, now presumed lost. Join: Marina Rustow.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2421,9 +2960,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:25:27.997Z",
-      "description": "State document: A set of responses to petitions (?) from the administration of al-Mustan\u1e63ir (427\u201387). Join: Marina Rustow. Cf. BL OR 5553.1 + BL OR 5553.2 + T-S Ar.51.49 + BL OR 5553A.1 + BL OR 5553A.2. ",
+      "description": "State document: A set of responses to petitions (?) from the administration of al-Mustanṣir (427–87). Join: Marina Rustow. Cf. BL OR 5553.1 + BL OR 5553.2 + T-S Ar.51.49 + BL OR 5553A.1 + BL OR 5553A.2. ",
       "description_ar": null,
-      "description_en": "State document: A set of responses to petitions (?) from the administration of al-Mustan\u1e63ir (427\u201387). Join: Marina Rustow. Cf. BL OR 5553.1 + BL OR 5553.2 + T-S Ar.51.49 + BL OR 5553A.1 + BL OR 5553A.2. ",
+      "description_en": "State document: A set of responses to petitions (?) from the administration of al-Mustanṣir (427–87). Join: Marina Rustow. Cf. BL OR 5553.1 + BL OR 5553.2 + T-S Ar.51.49 + BL OR 5553A.1 + BL OR 5553A.2. ",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2445,9 +2984,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:25:13.960Z",
-      "description": "State document: fragment of a decree (sijill mansh\u016br)",
+      "description": "State document: fragment of a decree (sijill manshūr)",
       "description_ar": null,
-      "description_en": "State document: fragment of a decree (sijill mansh\u016br)",
+      "description_en": "State document: fragment of a decree (sijill manshūr)",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2457,7 +2996,7 @@
       "languages": [],
       "last_modified": "2021-05-26T20:25:13.960Z",
       "needs_review": "",
-      "notes": "Rustow, PGP NEED TO DO : [h\u0101dha a]l-sijill al-mansh\u016br f\u012b al-a\u02bfm\u0101[l]",
+      "notes": "Rustow, PGP NEED TO DO : [hādha a]l-sijill al-manshūr fī al-aʿmā[l]",
       "old_pgpids": null,
       "secondary_languages": [],
       "shelfmark_override": "",
@@ -2496,9 +3035,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:23:54.775Z",
-      "description": "Business letter sent from Qayrawan by Efrayim b. Ismail, probably to Ya\u02bfaqov b. Yosef b. Awkal in Fustat (Gil) or from Ifr\u012bqiya by 'Alush b. Yeshua to Ismail b. Avraham in Egypt (Ben-Sasson). The letter deals mainly with merchandise and shipments of goods. Dated to the beginning of the 11th century (Gil) or the first third of the 11th century (Ben-Sasson). (Information from Gil, Vol. 2, p. 312 and from Ben-Sasson, p. 219)",
+      "description": "Business letter sent from Qayrawan by Efrayim b. Ismail, probably to Yaʿaqov b. Yosef b. Awkal in Fustat (Gil) or from Ifrīqiya by 'Alush b. Yeshua to Ismail b. Avraham in Egypt (Ben-Sasson). The letter deals mainly with merchandise and shipments of goods. Dated to the beginning of the 11th century (Gil) or the first third of the 11th century (Ben-Sasson). (Information from Gil, Vol. 2, p. 312 and from Ben-Sasson, p. 219)",
       "description_ar": null,
-      "description_en": "Business letter sent from Qayrawan by Efrayim b. Ismail, probably to Ya\u02bfaqov b. Yosef b. Awkal in Fustat (Gil) or from Ifr\u012bqiya by 'Alush b. Yeshua to Ismail b. Avraham in Egypt (Ben-Sasson). The letter deals mainly with merchandise and shipments of goods. Dated to the beginning of the 11th century (Gil) or the first third of the 11th century (Ben-Sasson). (Information from Gil, Vol. 2, p. 312 and from Ben-Sasson, p. 219)",
+      "description_en": "Business letter sent from Qayrawan by Efrayim b. Ismail, probably to Yaʿaqov b. Yosef b. Awkal in Fustat (Gil) or from Ifrīqiya by 'Alush b. Yeshua to Ismail b. Avraham in Egypt (Ben-Sasson). The letter deals mainly with merchandise and shipments of goods. Dated to the beginning of the 11th century (Gil) or the first third of the 11th century (Ben-Sasson). (Information from Gil, Vol. 2, p. 312 and from Ben-Sasson, p. 219)",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2544,9 +3083,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:22:51.359Z",
-      "description": "Late accounts for the year \"sham tzivah\"; unclear how to translate this into a number. There are headings for \"duy\u016bn,\" \"qarqa\u02bfot,\" and \"se\u1e25orot.\" There is a third join somewhere in the first 50 shelfmarks of this folder if memory serves.",
+      "description": "Late accounts for the year \"sham tzivah\"; unclear how to translate this into a number. There are headings for \"duyūn,\" \"qarqaʿot,\" and \"seḥorot.\" There is a third join somewhere in the first 50 shelfmarks of this folder if memory serves.",
       "description_ar": null,
-      "description_en": "Late accounts for the year \"sham tzivah\"; unclear how to translate this into a number. There are headings for \"duy\u016bn,\" \"qarqa\u02bfot,\" and \"se\u1e25orot.\" There is a third join somewhere in the first 50 shelfmarks of this folder if memory serves.",
+      "description_en": "Late accounts for the year \"sham tzivah\"; unclear how to translate this into a number. There are headings for \"duyūn,\" \"qarqaʿot,\" and \"seḥorot.\" There is a third join somewhere in the first 50 shelfmarks of this folder if memory serves.",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -2568,9 +3107,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:23:41.348Z",
-      "description": "A deed of acquittance, in which Sedid b. Sa\u02bfadya releases Fakhr bat \u02bfAlam. Signed in Cairo near Fustat, at the time of the Nagid \u02bfAmram, on Friday, 9 Nissan 1688(?) Seleucid (1377CE). (Information from Goitein notes and index card linked below and Assaf, Toledot ha-Yehudim, p. 22.). In the edition from his dissertation (p.366) Dotan Arad confirms the dating as 1377CE. MCD.",
+      "description": "A deed of acquittance, in which Sedid b. Saʿadya releases Fakhr bat ʿAlam. Signed in Cairo near Fustat, at the time of the Nagid ʿAmram, on Friday, 9 Nissan 1688(?) Seleucid (1377CE). (Information from Goitein notes and index card linked below and Assaf, Toledot ha-Yehudim, p. 22.). In the edition from his dissertation (p.366) Dotan Arad confirms the dating as 1377CE. MCD.",
       "description_ar": null,
-      "description_en": "A deed of acquittance, in which Sedid b. Sa\u02bfadya releases Fakhr bat \u02bfAlam. Signed in Cairo near Fustat, at the time of the Nagid \u02bfAmram, on Friday, 9 Nissan 1688(?) Seleucid (1377CE). (Information from Goitein notes and index card linked below and Assaf, Toledot ha-Yehudim, p. 22.). In the edition from his dissertation (p.366) Dotan Arad confirms the dating as 1377CE. MCD.",
+      "description_en": "A deed of acquittance, in which Sedid b. Saʿadya releases Fakhr bat ʿAlam. Signed in Cairo near Fustat, at the time of the Nagid ʿAmram, on Friday, 9 Nissan 1688(?) Seleucid (1377CE). (Information from Goitein notes and index card linked below and Assaf, Toledot ha-Yehudim, p. 22.). In the edition from his dissertation (p.366) Dotan Arad confirms the dating as 1377CE. MCD.",
       "description_he": null,
       "doc_date_calendar": "s",
       "doc_date_original": "1688",
@@ -2616,9 +3155,9 @@
   {
     "fields": {
       "created": "2021-05-26T20:22:34.964Z",
-      "description": "Two different fragments. First fragment: An abridgement of some of the dietary and lifestyle advice from Chapter 4 of the Hebrew plague treatise \"Moshia\u02bf \u1e24osim\" (Venice, 1587) by Avraham Yagel (a.k.a. Gallico). This page dates from after 1623, since \u05d6\u05dc\u05d4\u05d4 is written after Galiko's name. The advice includes: boiling all water before drinking it or mixing it with wine; cooking all produce to \"remove the disease from it\"; or to pick wild herbs growing in desolate locations; to dwell in spacious, airy, and beautifully decorated houses; and not to eat too much, not to sleep too much, not to eat excessively warming foods, not to wear excessively warming clothes. On Yagel/Gallico, see Ruderman, Kabbalah, Magic and Science The Cultural Universe of a Sixteenth-Century Jewish Physician, HUP 1988. Second fragment: This is labeled as \"Image 2\" and contains one line of Arabic script. However, the shape of the paper and the location of holes do not correspond to Image 1, suggesting that we are missing two images (verso of both Image 1 and Image 2). ",
+      "description": "Two different fragments. First fragment: An abridgement of some of the dietary and lifestyle advice from Chapter 4 of the Hebrew plague treatise \"Moshiaʿ Ḥosim\" (Venice, 1587) by Avraham Yagel (a.k.a. Gallico). This page dates from after 1623, since זלהה is written after Galiko's name. The advice includes: boiling all water before drinking it or mixing it with wine; cooking all produce to \"remove the disease from it\"; or to pick wild herbs growing in desolate locations; to dwell in spacious, airy, and beautifully decorated houses; and not to eat too much, not to sleep too much, not to eat excessively warming foods, not to wear excessively warming clothes. On Yagel/Gallico, see Ruderman, Kabbalah, Magic and Science The Cultural Universe of a Sixteenth-Century Jewish Physician, HUP 1988. Second fragment: This is labeled as \"Image 2\" and contains one line of Arabic script. However, the shape of the paper and the location of holes do not correspond to Image 1, suggesting that we are missing two images (verso of both Image 1 and Image 2). ",
       "description_ar": null,
-      "description_en": "Two different fragments. First fragment: An abridgement of some of the dietary and lifestyle advice from Chapter 4 of the Hebrew plague treatise \"Moshia\u02bf \u1e24osim\" (Venice, 1587) by Avraham Yagel (a.k.a. Gallico). This page dates from after 1623, since \u05d6\u05dc\u05d4\u05d4 is written after Galiko's name. The advice includes: boiling all water before drinking it or mixing it with wine; cooking all produce to \"remove the disease from it\"; or to pick wild herbs growing in desolate locations; to dwell in spacious, airy, and beautifully decorated houses; and not to eat too much, not to sleep too much, not to eat excessively warming foods, not to wear excessively warming clothes. On Yagel/Gallico, see Ruderman, Kabbalah, Magic and Science The Cultural Universe of a Sixteenth-Century Jewish Physician, HUP 1988. Second fragment: This is labeled as \"Image 2\" and contains one line of Arabic script. However, the shape of the paper and the location of holes do not correspond to Image 1, suggesting that we are missing two images (verso of both Image 1 and Image 2). ",
+      "description_en": "Two different fragments. First fragment: An abridgement of some of the dietary and lifestyle advice from Chapter 4 of the Hebrew plague treatise \"Moshiaʿ Ḥosim\" (Venice, 1587) by Avraham Yagel (a.k.a. Gallico). This page dates from after 1623, since זלהה is written after Galiko's name. The advice includes: boiling all water before drinking it or mixing it with wine; cooking all produce to \"remove the disease from it\"; or to pick wild herbs growing in desolate locations; to dwell in spacious, airy, and beautifully decorated houses; and not to eat too much, not to sleep too much, not to eat excessively warming foods, not to wear excessively warming clothes. On Yagel/Gallico, see Ruderman, Kabbalah, Magic and Science The Cultural Universe of a Sixteenth-Century Jewish Physician, HUP 1988. Second fragment: This is labeled as \"Image 2\" and contains one line of Arabic script. However, the shape of the paper and the location of holes do not correspond to Image 1, suggesting that we are missing two images (verso of both Image 1 and Image 2). ",
       "description_he": null,
       "doc_date_calendar": "",
       "doc_date_original": "",
@@ -3409,9 +3948,9 @@
   },
   {
     "fields": {
-      "first_name": "Na\u00efm",
+      "first_name": "Naïm",
       "first_name_ar": null,
-      "first_name_en": "Na\u00efm",
+      "first_name_en": "Naïm",
       "first_name_he": null,
       "last_name": "Vanthieghem",
       "last_name_ar": null,
@@ -3639,10 +4178,10 @@
       "place_published": "Jerusalem",
       "publisher": "Ben-Zvi Institute",
       "source_type": 1,
-      "title": "The Jews of Sicily, 825\u20131068: Documents and Sources",
+      "title": "The Jews of Sicily, 825–1068: Documents and Sources",
       "title_ar": null,
-      "title_en": "The Jews of Sicily, 825\u20131068: Documents and Sources",
-      "title_he": "\u05d9\u05d4\u05d5\u05d3\u05d9 \u05e1\u05d9\u05e6\u05d9\u05dc\u05d9\u05d4 1068-825",
+      "title_en": "The Jews of Sicily, 825–1068: Documents and Sources",
+      "title_he": "יהודי סיציליה 1068-825",
       "url": "",
       "volume": "",
       "year": 1991
@@ -3675,9 +4214,9 @@
       "place_published": "",
       "publisher": "PhD Dissertation. The Hebrew University of Jerusalem.",
       "source_type": 4,
-      "title": "The Musta\u02bfrib Jews in Syria, Palestine and Egypt: 1330-1700",
+      "title": "The Mustaʿrib Jews in Syria, Palestine and Egypt: 1330-1700",
       "title_ar": null,
-      "title_en": "The Musta\u02bfrib Jews in Syria, Palestine and Egypt: 1330-1700",
+      "title_en": "The Mustaʿrib Jews in Syria, Palestine and Egypt: 1330-1700",
       "title_he": null,
       "url": "",
       "volume": "",
@@ -3711,9 +4250,9 @@
       "place_published": "",
       "publisher": "",
       "source_type": 1,
-      "title": "Palestine During the First Muslim Period (634\u20131099)",
+      "title": "Palestine During the First Muslim Period (634–1099)",
       "title_ar": null,
-      "title_en": "Palestine During the First Muslim Period (634\u20131099)",
+      "title_en": "Palestine During the First Muslim Period (634–1099)",
       "title_he": null,
       "url": "",
       "volume": "2",
@@ -3734,12 +4273,12 @@
       "place_published": "",
       "publisher": "",
       "source_type": 2,
-      "title": "La lettre de divorce cara\u00efte et sa place dans les relations entre Cara\u00eftes et Rabbanites au Moyen Age (Une \u00e9tude de manuscrits de la Geniza du Caire)",
+      "title": "La lettre de divorce caraïte et sa place dans les relations entre Caraïtes et Rabbanites au Moyen Age (Une étude de manuscrits de la Geniza du Caire)",
       "title_ar": null,
-      "title_en": "La lettre de divorce cara\u00efte et sa place dans les relations entre Cara\u00eftes et Rabbanites au Moyen Age (Une \u00e9tude de manuscrits de la Geniza du Caire)",
+      "title_en": "La lettre de divorce caraïte et sa place dans les relations entre Caraïtes et Rabbanites au Moyen Age (Une étude de manuscrits de la Geniza du Caire)",
       "title_he": null,
       "url": "",
-      "volume": "155:3\u20134",
+      "volume": "155:3–4",
       "year": 1996
     },
     "model": "footnotes.source",
@@ -3773,7 +4312,7 @@
       "title": "Engagement and Betrothal Documents from the Cairo Geniza",
       "title_ar": null,
       "title_en": "Engagement and Betrothal Documents from the Cairo Geniza",
-      "title_he": "\u05e9\u05d9\u05d3\u05d5\u05db\u05d9\u05df \u05d5\u05d0\u05d9\u05e8\u05d5\u05e1\u05d9\u05df \u05e2\u05dc-\u05e4\u05d9 \u05ea\u05e2\u05d5\u05d3\u05d5\u05ea \u05de\u05df \u05d4\u05d2\u05e0\u05d9\u05d6\u05d4 \u05d4\u05e7\u05d4\u05d9\u05e8\u05d9\u05ea",
+      "title_he": "שידוכין ואירוסין על-פי תעודות מן הגניזה הקהירית",
       "url": "",
       "volume": "",
       "year": 2006
@@ -3822,11 +4361,11 @@
       "first_name": "Moshe",
       "first_name_ar": null,
       "first_name_en": "Moshe",
-      "first_name_he": "\u05de\u05e9\u05d4",
+      "first_name_he": "משה",
       "last_name": "Gil",
       "last_name_ar": null,
       "last_name_en": "Gil",
-      "last_name_he": "\u05d2\u05d9\u05dc"
+      "last_name_he": "גיל"
     },
     "model": "footnotes.creator"
   },
@@ -3891,13 +4430,13 @@
   },
   {
     "fields": {
-      "first_name": "\u1e62ab\u012b\u1e25",
+      "first_name": "Ṣabīḥ",
       "first_name_ar": null,
-      "first_name_en": "\u1e62ab\u012b\u1e25",
+      "first_name_en": "Ṣabīḥ",
       "first_name_he": null,
-      "last_name": "\u02bfAodeh",
+      "last_name": "ʿAodeh",
       "last_name_ar": null,
-      "last_name_en": "\u02bfAodeh",
+      "last_name_en": "ʿAodeh",
       "last_name_he": null
     },
     "model": "footnotes.creator"
@@ -4153,7 +4692,7 @@
   },
   {
     "fields": {
-      "creator": ["Vanthieghem", "Na\u00efm"],
+      "creator": ["Vanthieghem", "Naïm"],
       "sort_order": 2,
       "source": 263
     },
@@ -4306,7 +4845,7 @@
   },
   {
     "fields": {
-      "creator": ["\u02bfAodeh", "\u1e62ab\u012b\u1e25"],
+      "creator": ["ʿAodeh", "Ṣabīḥ"],
       "sort_order": 1,
       "source": 21
     },
@@ -4909,7 +5448,7 @@
       "doc_relation": "E",
       "location": "",
       "location_sort": "",
-      "notes": "12/2019 (incorporating partial transcription on Goitein\u2019s note card)",
+      "notes": "12/2019 (incorporating partial transcription on Goitein’s note card)",
       "object_id": 8151,
       "source": 35,
       "url": ""
@@ -4951,7 +5490,7 @@
       "doc_relation": "E",
       "location": "",
       "location_sort": "",
-      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk \u1e24alfon Ben Manasse, Ph.D. Dissertation, 1970",
+      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk Ḥalfon Ben Manasse, Ph.D. Dissertation, 1970",
       "object_id": 2142,
       "source": 737,
       "url": ""
@@ -4965,7 +5504,7 @@
       "doc_relation": "E",
       "location": "",
       "location_sort": "",
-      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk \u1e24alfon Ben Manasse, Ph.D. Dissertation, 1970",
+      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk Ḥalfon Ben Manasse, Ph.D. Dissertation, 1970",
       "object_id": 2142,
       "source": 737,
       "url": ""
@@ -4979,7 +5518,7 @@
       "doc_relation": "E",
       "location": "",
       "location_sort": "",
-      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk \u1e24alfon Ben Manasse, Ph.D. Dissertation, 1970",
+      "notes": "compared with G. Weiss, Legal Documents Written by the Court Clerk Ḥalfon Ben Manasse, Ph.D. Dissertation, 1970",
       "object_id": 2142,
       "source": 737,
       "url": ""
@@ -5075,8 +5614,8 @@
     "fields": {
       "content_type": ["corpus", "document"],
       "doc_relation": "E,T",
-      "location": "pp. 348\u201350",
-      "location_sort": "pp. 000348\u2013000050",
+      "location": "pp. 348–50",
+      "location_sort": "pp. 000348–000050",
       "notes": "Translation to French",
       "object_id": 9469,
       "source": 768,
@@ -6545,7 +7084,7 @@
       "change_message": "merged with 5627, 5628, 5629, 5630, 5631: all descriptions match",
       "content_type": ["corpus", "document"],
       "object_id": "5626",
-      "object_repr": "Bodl. MS heb. f 34/39 + \u2026 (PGPID 5626)",
+      "object_repr": "Bodl. MS heb. f 34/39 + … (PGPID 5626)",
       "user": ["script"]
     },
     "model": "admin.logentry",
@@ -6558,7 +7097,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "5626",
-      "object_repr": "Bodl. MS heb. f 34/39 + \u2026 (PGPID 5626)",
+      "object_repr": "Bodl. MS heb. f 34/39 + … (PGPID 5626)",
       "user": ["mrustow"]
     },
     "model": "admin.logentry",
@@ -6571,7 +7110,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\", \"Needs review\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "5626",
-      "object_repr": "Bodl. MS heb. f 34/39 + \u2026 (PGPID 5626)",
+      "object_repr": "Bodl. MS heb. f 34/39 + … (PGPID 5626)",
       "user": ["alg4"]
     },
     "model": "admin.logentry",
@@ -6650,7 +7189,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\"]}}, {\"added\": {\"name\": \"Related Fragment\", \"object\": \"ENA 2727.15d\"}}]",
       "content_type": ["corpus", "document"],
       "object_id": "8151",
-      "object_repr": "ENA 2727.15d + \u2026 (PGPID 8151)",
+      "object_repr": "ENA 2727.15d + … (PGPID 8151)",
       "user": ["ae5677"]
     },
     "model": "admin.logentry",
@@ -6663,7 +7202,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "8151",
-      "object_repr": "ENA 2727.15d + \u2026 (PGPID 8151)",
+      "object_repr": "ENA 2727.15d + … (PGPID 8151)",
       "user": ["ae5677"]
     },
     "model": "admin.logentry",
@@ -6676,7 +7215,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "8151",
-      "object_repr": "ENA 2727.15d + \u2026 (PGPID 8151)",
+      "object_repr": "ENA 2727.15d + … (PGPID 8151)",
       "user": ["ae5677"]
     },
     "model": "admin.logentry",
@@ -6689,7 +7228,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Description\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "8151",
-      "object_repr": "ENA 2727.15d + \u2026 (PGPID 8151)",
+      "object_repr": "ENA 2727.15d + … (PGPID 8151)",
       "user": ["ae5677"]
     },
     "model": "admin.logentry",
@@ -7132,7 +7671,7 @@
       "change_message": "[{\"changed\": {\"fields\": [\"Languages\"]}}]",
       "content_type": ["corpus", "document"],
       "object_id": "444",
-      "object_repr": "T-S 13J35.3 + \u2026 (PGPID 444)",
+      "object_repr": "T-S 13J35.3 + … (PGPID 444)",
       "user": ["micahn"]
     },
     "model": "admin.logentry",
@@ -7269,7 +7808,7 @@
       "change_message": "[{\"deleted\": {\"name\": \"footnote\", \"object\": \"Edition of ENA 3751.5 + \\u2026 (PGPID 30851)\"}}]",
       "content_type": ["corpus", "document"],
       "object_id": "30851",
-      "object_repr": "ENA 3751.5 + \u2026 (PGPID 30851)",
+      "object_repr": "ENA 3751.5 + … (PGPID 30851)",
       "user": ["alg4"]
     },
     "model": "admin.logentry",

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -6,7 +6,7 @@ from django.template.defaultfilters import pluralize
 from django.urls import reverse
 from django.urls import translate_url as django_translate_url
 from django.utils.safestring import mark_safe
-from piffle.iiif import IIIFImageClientException
+from piffle.image import IIIFImageClientException
 
 from geniza.common.utils import absolutize_url
 from geniza.footnotes.models import Footnote
@@ -78,7 +78,7 @@ def querystring_replace(context, **kwargs):
 @register.filter
 def iiif_image(img, args):
     """Add options to resize or otherwise change the display of an iiif
-    image; expects an instance of :class:`piffle.iiif.IIIFImageClient`.
+    image; expects an instance of :class:`piffle.image.IIIFImageClient`.
     Provide the method and arguments as filter string, i.e.::
 
         {{ myimg|iiif_image:"size:width=225,height=255" }}

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from django.http.request import HttpRequest, QueryDict
 from django.urls import reverse
-from piffle.iiif import IIIFImageClient
+from piffle.image import IIIFImageClient
 from pytest_django.asserts import assertContains
 
 from geniza.common.utils import absolutize_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
     "django-split-settings",
     "requests",
     "django-taggit>=1.5.1,<2.0",
-    # TODO: unpin piffle from 0.4 once breaking changes with piffle.iiif are handled
-    "piffle==0.4",
+    "piffle>=0.6",
     "taggit-selectize",
     # NOTE: as of 2024-07-91, django-multiselectfield 0.1.13 causes an error in unit"
     # tests and loaddata for loading fixtures"
@@ -30,7 +29,8 @@ dependencies = [
     "parasolr>=0.9.1",
     "django-gfklookupwidget",
     "django-adminlogentries",
-    "django-autocomplete-light>=3.11.0",
+    # TODO: Unpin from 3.9.7 when djiffy dependencies are updated
+    "django-autocomplete-light==3.9.7",
     "django-webpack-loader",
     "django-csp",
     "gitpython",
@@ -38,8 +38,7 @@ dependencies = [
     "rich",
     "wagtail>=2.15.3,<2.16",
     "wagtail-localize",
-    "rdflib<6.2",
-    "djiffy>=0.8",
+    "djiffy==0.9.2",
     "natsort",
     "django-widget-tweaks",
     "django-csp-helpers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "convertdate",
     "unidecode",
     "addict",
+    # TODO: replace with attrdict3 or addict before python 3.10 upgrade
+    "attrdict",
     "beautifulsoup4",
     "bleach",
     "python-slugify"


### PR DESCRIPTION
**Associated Issue(s):** #1822

Requesting review from @rlskoeser on this one to make sure the additional required changes make sense; and from @mabdellatif88 to keep him informed and give him the opportunity to ask questions, and get a sense of how I typically structure these upgrade PRs.

### Changes in this PR

- Upgrade djiffy to 0.9.2 so that we can complete the jsonfield migration before the 1.0 upgrade
   - Bump piffle to required 0.6, resolve `piffle.iiif`
   - Remove rdflib dependency, which was conflicting (we don't use it directly)
   - Pin `django-autocomplete-light` until it is unpinned in djiffy
   - Regenerate fixtures (`ui_ux_test_documents.json`): the old fixtures were using the old `jsonfield` djiffy model which stored json as strings, so they have now been converted to proper django JSONFields where the json is stored as actual json
- Add `attrdict` to dependencies as it's no longer a sub-dependency of one of the upgraded packages. We will need to replace it in #1821
- Fix a broken unit test `test_iiif_images_iiifexception`

### Notes

- @mabdellatif88 I think the unit test `test_iiif_images_iiifexception` that we'd deleted on the call yesterday actually was written incorrectly, and I'm not sure how it passed before. We `except` the `IIIFException` in the tested function, so it shouldn't be raised, and `assertRaises` should be false. I think it is useful to keep after all, since what we're actually testing is the "log at level WARN" when an exception _is_ raised.
- Fixture generation isn't currently working due to some foreign key conflicts between generated fixture data and data introduced in migrations. If fixtures ever need to be regenerated, this code will likely need to be updated. (in this PR I replaced the old entries manually)