### PR TITLE
Use GET instead of HEAD to check iiif (#1824)

### DIFF
--- a/sitemedia/js/controllers/iiif_controller.js
+++ b/sitemedia/js/controllers/iiif_controller.js
@@ -116,9 +116,9 @@ export default class extends Controller {
     }
 
     checkTileSource(url) {
-        // use HEAD request to check that a tilesource doesn't 404 or cause other errors
+        // use GET request to check that a tilesource doesn't 404 or cause other errors
         return new Promise((resolve, reject) => {
-            fetch(url, { method: "HEAD" })
+            fetch(url, { method: "GET" })
                 .then((response) => {
                     if (response.ok) {
                         resolve(url);


### PR DESCRIPTION
**Associated Issue(s):** #1824

### Changes in this PR

- Use `GET` instead of `HEAD` to check for broken IIIF images in transcription/translation editor

### Notes

- This fixes a bug where `HEAD` requests to puliiif would return 403 errors, while `GET` requests would succeed. Thus, the image would appear to be broken and use a placeholder, when in fact it was working fine.