### PR TITLE
Fallback for IIIF Image v2.0 images, such as JRL, to manually create square-cropped thumbnails (#1826)

### DIFF
--- a/geniza/entities/templates/entities/snippets/related_documents_table.html
+++ b/geniza/entities/templates/entities/snippets/related_documents_table.html
@@ -37,7 +37,7 @@
         <tbody>
             {% for document in relations %}
                 <tr>
-                    <td class="document-title">
+                    <td class="document-title" data-controller="thumbnail">
                         {% if document.thumbnail %}
                             {{ document.thumbnail }}
                         {% else %}

--- a/sitemedia/js/controllers/thumbnail_controller.js
+++ b/sitemedia/js/controllers/thumbnail_controller.js
@@ -1,0 +1,35 @@
+// controllers/thumbnail_controller.js
+
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    connect() {
+        // attach onerror event listener to every img element here
+        this.element.querySelectorAll("img").forEach((img) => {
+            img.addEventListener("error", this.handleError);
+        });
+    }
+    async handleError(evt) {
+        // if the image fails to load, try to manually create a square crop, in
+        // case this is IIIF v2.0 which doesn't support /square/ (e.g. JRL)
+        const iiifInfo = evt.target.src.replace(
+            /\/square\/60,60\/0\/default\.jpg$/,
+            "/info.json"
+        );
+        try {
+            // get width and height from IIIF info.json
+            const info = await fetch(iiifInfo);
+            const { width, height } = await info.json();
+            // manually create a centered, square crop of the image
+            const squareEdge = Math.min(width, height);
+            const xOffset = Math.floor((width - squareEdge) / 2);
+            const yOffset = Math.floor((height - squareEdge) / 2);
+            // update the img src with the new IIIF params for that crop
+            const newParams = `${xOffset},${yOffset},${squareEdge},${squareEdge}/60,60`;
+            evt.target.src = evt.target.src.replace(/square\/60,60/, newParams);
+        } catch (err) {
+            // if anything fails, image is probably just broken or service is down
+            console.error(err);
+        }
+    }
+}


### PR DESCRIPTION
**Associated Issue(s):** #1826

### Changes in this PR

- Attach a new Stimulus controller to document thumbnails in related documents pages, which use `/square/` in IIIF Image v2.1 to create square crops. If the image fails to load, assume it is IIIF v2.0 (like JRL) and attempt to manually create a centered square crop.