### PR TITLE
Fix positioning issue with "exclude uncertain" toggle (#1836)

### DIFF
--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -561,6 +561,7 @@ main.people {
     form fieldset#filters {
         div.fieldset-left-column label[for="id_exclude_inferred"],
         label[for="id_exclude_uncertain"] {
+            display: block;
             position: relative;
             cursor: pointer;
             input[type="checkbox"] + span::before {


### PR DESCRIPTION
**Associated Issue(s):** #1836

### Changes in this PR

- Fix positioning issue with the People search page "Exclude Uncertain" toggle present in Firefox and Safari