### PR TITLE
Relevance scores for Person multiple social roles (#1839)

### DIFF
--- a/geniza/entities/conftest.py
+++ b/geniza/entities/conftest.py
@@ -17,8 +17,10 @@ def make_person():
 
 def make_person_diacritic():
     (official, _) = PersonRole.objects.get_or_create(name_en="State official")
+    (other, _) = PersonRole.objects.get_or_create(name_en="Other")
     person = Person.objects.create(gender=Person.MALE)
     person.roles.add(official)
+    person.roles.add(other)
     Name.objects.create(
         name="Ḥalfon ha-Levi b. Netanʾel", content_object=person, primary=True
     )

--- a/geniza/entities/templates/entities/person_list.html
+++ b/geniza/entities/templates/entities/person_list.html
@@ -77,9 +77,9 @@
                     </label>
                 </fieldset>
             </div>
-            <label for="{{ form.social_role.auto_id }}">
+            <label for="{{ form.social_role.auto_id }}" data-search-target="socialRoles">
                 <span class="fieldname">{{ form.social_role.label }}</span>
-                {% render_field form.social_role data-action="search#update" %}
+                {% render_field form.social_role data-action="input->search#autoUpdateRadioSort search#update" %}
             </label>
             <label for="{{ form.document_relation.auto_id }}">
                 <span class="fieldname">{{ form.document_relation.label }}</span>
@@ -152,6 +152,12 @@
                     {% for person in people %}
                         <tr>
                             <td class="name">
+                                {% if "SHOW_RELEVANCE_SCORES" in FEATURE_FLAGS %}
+                                    {# show relevance score if enabled #}
+                                    <span class="score">
+                                        Relevance: {{ person.score|default:0 }}
+                                    </span>
+                                {% endif %}
                                 {% if person.url %}
                                     <a href="{{ person.url }}">{{ person.name }}</a>
                                 {% else %}

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -559,13 +559,78 @@ class TestPersonListView:
                     "sort_dir": "desc",
                 }
                 personlist_view.get_queryset()
-                mock_order_by.assert_called_with("-end_dating_i")
+                mock_order_by.assert_called_with("-end_dating_i", "slug_s")
                 mock_get_form.return_value.cleaned_data = {
                     "sort": "date",
                     "sort_dir": "asc",
                 }
                 personlist_view.get_queryset()
-                mock_order_by.assert_called_with("start_dating_i")
+                mock_order_by.assert_called_with("start_dating_i", "slug_s")
+
+    def test_multiple_social_roles_filter(
+        self, person, person_diacritic, person_multiname, empty_solr
+    ):
+        # add person's name to person_diacritic so we can check both in a
+        # keyword query
+        Name.objects.create(name=str(person), content_object=person_diacritic)
+        SolrClient().update.index(
+            [
+                person.index_data(),
+                person_diacritic.index_data(),
+                person_multiname.index_data(),
+            ],
+            commit=True,
+        )
+        personlist_view = PersonListView()
+        with patch.object(personlist_view, "get_form") as mock_get_form:
+            # filter by multiple social roles
+            roles = person_diacritic.roles.all()
+            mock_get_form.return_value.cleaned_data = {
+                "social_role": f"['{roles[0].name}', '{roles[1].name}']",
+                "sort": "relevance",
+                "sort_dir": "desc",
+            }
+            # should include people with either role
+            qs = personlist_view.get_queryset()
+            assert qs.count() == 2
+            # person with both roles should be first by relevance
+            assert qs[0].get("slug") == person_diacritic.slug
+
+            # filter by 3 social roles
+            role_3 = person_multiname.roles.first().name
+            mock_get_form.return_value.cleaned_data = {
+                "social_role": f"['{roles[0].name}', '{roles[1].name}', '{role_3}']",
+                "sort": "relevance",
+                "sort_dir": "desc",
+            }
+            qs = personlist_view.get_queryset()
+            # should include everyone
+            assert qs.count() == 3
+            # person with both roles should still be first
+            assert qs[0].get("slug") == person_diacritic.slug
+
+            # filter by 3 social roles AND keyword query
+            role_3 = person_multiname.roles.first().name
+            mock_get_form.return_value.cleaned_data = {
+                "q": str(person),
+                "social_role": f"['{roles[0].name}', '{roles[1].name}', '{role_3}']",
+            }
+            qs = personlist_view.get_queryset()
+            # should include just the two matching the keyword query
+            assert qs.count() == 2
+
+            # person with both roles should be boosted
+            score_with_roles = next(
+                p.get("score") for p in qs if p.get("slug") == person_diacritic.slug
+            )
+            mock_get_form.return_value.cleaned_data = {
+                "q": str(person),
+            }
+            qs = personlist_view.get_queryset()
+            score_without_roles = next(
+                p.get("score") for p in qs if p.get("slug") == person_diacritic.slug
+            )
+            assert score_with_roles > score_without_roles
 
     def test_get_queryset__keyword_query(
         self, person, person_diacritic, person_multiname, empty_solr

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -884,8 +884,24 @@ class PersonListView(ListView, FormMixin, SolrDateRangeMixin):
             ]
         if search_opts.get("social_role"):
             roles = literal_eval(search_opts["social_role"])
-            roles = [re.sub(self.qs_regex, r"\\\1", r) for r in roles]
-            people = people.filter(roles__in=roles)
+            roles_escaped = [re.sub(self.qs_regex, r"\\\1", r) for r in roles]
+            people = people.filter(roles__in=roles_escaped)
+            # boost multiple selected values
+            if len(roles) > 1:
+                roles_field = people.field_aliases.get("roles")
+                # if no keyword query entered, need to use the filter values
+                # as an OR query, in order to get any relevance score
+                if not search_opts.get("q"):
+                    roles_q = " OR ".join(roles_escaped)
+                    people = people.search(f"{roles_field}:({roles_q})")
+                # use edismax boost, sum(termfreq) filter query to boost score
+                # when more than one of the selected terms appears
+                term_freq_boosts = ",".join(
+                    [f'termfreq({roles_field},"{role}")' for role in roles]
+                )
+                people = people.raw_query_parameters(
+                    boost=f"sum({term_freq_boosts})"
+                ).also("score")
             self.applied_filter_labels += self.get_applied_filter_labels(
                 form, "social_role", roles
             )
@@ -916,7 +932,8 @@ class PersonListView(ListView, FormMixin, SolrDateRangeMixin):
                 and "date" not in sort_field
             ):
                 order_by = f"-{order_by}"
-            people = people.order_by(order_by)
+            # use name (slug_s ascending) as tiebreaker
+            people = people.order_by(order_by, "slug_s")
 
         self.queryset = people
 

--- a/sitemedia/js/controllers/search_controller.js
+++ b/sitemedia/js/controllers/search_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
         "placesMode",
         "peopleMode",
         "radioSort",
+        "socialRoles",
     ];
     static debounces = ["update"];
 
@@ -269,8 +270,16 @@ export default class extends Controller {
     }
 
     autoUpdateRadioSort(event) {
+        // special case: people search, multiple role filtering: allow and switch to relevance
+        let relevanceOverride = false;
+        if (this.hasSocialRolesTarget) {
+            const checkedRoles = this.socialRolesTarget.querySelectorAll(
+                "input[type='checkbox']:checked"
+            );
+            relevanceOverride = checkedRoles.length > 1;
+        }
         // when query is empty, disable sort by relevance
-        if (this.queryTarget.value.trim() == "") {
+        if (this.queryTarget.value.trim() == "" && !relevanceOverride) {
             this.disableRelevanceSort(true);
         } else if (event && this.defaultSortElement.checked) {
             // if this was triggered by an event and not in sortTargetConnected,

--- a/sitemedia/scss/pages/_people.scss
+++ b/sitemedia/scss/pages/_people.scss
@@ -147,6 +147,7 @@ main.people {
                 border-radius: 5px;
                 border: 1px solid var(--background-gray);
                 td.name {
+                    position: relative;
                     grid-area: name;
                     font-family: fonts.$primary-bold;
                     font-weight: bold;
@@ -156,6 +157,15 @@ main.people {
                     }
                     @include breakpoints.for-tablet-landscape-up {
                         font-size: typography.$text-size-xl;
+                    }
+                    .score {
+                        @include typography.meta-bold;
+                        display: block;
+                        position: absolute;
+                        right: -1rem;
+                        top: -1rem;
+                        padding: 0.25rem;
+                        font-size: 12px !important;
                     }
                 }
                 td.gender {


### PR DESCRIPTION
**Associated Issue(s):** #1839

### Changes in this PR

- Boost relevance scores for person search when a person has multiple social roles, and they match > 1 of the roles selected in the facet filters
- Default to relevance sort when selecting multiple roles