### PR TITLE
Fix deletion issue with LogEntries (#1848)

### DIFF
--- a/geniza/common/signals.py
+++ b/geniza/common/signals.py
@@ -1,0 +1,11 @@
+"""Signal handlers shared across multiple apps"""
+
+
+def detach_logentries(sender, instance, **kwargs):
+    """Pre-delete signal handler required for models with generic
+    relations to log entries.
+
+    To avoid deleting log entries caused by the generic relation
+    to log entries, clear out object id for associated log entries
+    before deleting the instance."""
+    instance.log_entries.update(object_id=None)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -45,6 +45,7 @@ from geniza.common.models import (
     TrackChangesModel,
     cached_class_property,
 )
+from geniza.common.signals import detach_logentries
 from geniza.common.utils import absolutize_url
 from geniza.corpus.annotation_utils import document_id_from_manifest_uri
 from geniza.corpus.dates import DocumentDateMixin, PartialDate, standard_date_display
@@ -1793,14 +1794,8 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             log_entry.save()
 
 
-@receiver(pre_delete, sender=Document)
-def detach_document_logentries(sender, instance, **kwargs):
-    """:class:`~Document` pre-delete signal handler.
-
-    To avoid deleting log entries caused by the generic relation
-    from document to log entries, clear out object id
-    for associated log entries before deleting the document."""
-    instance.log_entries.update(object_id=None)
+# attach pre-delete for generic relation to log entries
+pre_delete.connect(detach_logentries, sender=Document)
 
 
 class TextBlock(models.Model):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1558,7 +1558,7 @@ class TestDocument:
         document.delete()
         # get fresh copy of the same log entry
         fresh_log_entry = LogEntry.objects.get(pk=log_entry.pk)
-        assert fresh_log_entry is None or fresh_log_entry.object_id is None
+        assert fresh_log_entry.object_id is None
 
     def test_save_set_standard_date(self, document):
         document.doc_date_original = "493"

--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -14,7 +14,7 @@ from django.http import HttpResponseRedirect
 from django.urls import path, reverse
 from modeltranslation.admin import TabbedTranslationAdmin
 
-from geniza.common.admin import TypedRelationInline
+from geniza.common.admin import PreventLogEntryDeleteMixin, TypedRelationInline
 from geniza.corpus.dates import standard_date_display
 from geniza.corpus.models import DocumentEventRelation
 from geniza.entities.forms import (
@@ -284,7 +284,12 @@ class PersonForm(ModelForm):
 
 
 @admin.register(Person)
-class PersonAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin):
+class PersonAdmin(
+    TabbedTranslationAdmin,
+    SortableAdminBase,
+    PreventLogEntryDeleteMixin,
+    admin.ModelAdmin,
+):
     """Admin for Person entities in the PGP"""
 
     form = PersonForm
@@ -485,7 +490,10 @@ class RelationTypeMergeAdminMixin:
 
 @admin.register(PersonDocumentRelationType)
 class PersonDocumentRelationTypeAdmin(
-    RelationTypeMergeAdminMixin, TabbedTranslationAdmin, admin.ModelAdmin
+    RelationTypeMergeAdminMixin,
+    TabbedTranslationAdmin,
+    PreventLogEntryDeleteMixin,
+    admin.ModelAdmin,
 ):
     """Admin for managing the controlled vocabulary of people's relationships to documents"""
 
@@ -498,7 +506,10 @@ class PersonDocumentRelationTypeAdmin(
 
 @admin.register(PersonPersonRelationType)
 class PersonPersonRelationTypeAdmin(
-    RelationTypeMergeAdminMixin, TabbedTranslationAdmin, admin.ModelAdmin
+    RelationTypeMergeAdminMixin,
+    TabbedTranslationAdmin,
+    PreventLogEntryDeleteMixin,
+    admin.ModelAdmin,
 ):
     """Admin for managing the controlled vocabulary of people's relationships to other people"""
 

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -595,6 +595,21 @@ class TestPerson:
         # should sort alphabetically last
         assert person.all_roles().endswith(pr.display_label)
 
+    def test_delete(self, person):
+        # create a log entry to confirm disassociation
+        log_entry = LogEntry.objects.create(
+            user_id=1,
+            content_type_id=ContentType.objects.get_for_model(person).pk,
+            object_id=person.pk,
+            object_repr="test",
+            action_flag=CHANGE,
+            change_message="test",
+        )
+        person.delete()
+        # get fresh copy of the same log entry
+        fresh_log_entry = LogEntry.objects.get(pk=log_entry.pk)
+        assert fresh_log_entry.object_id is None
+
 
 class TestPersonSolrQuerySet:
     def test_keyword_search(self):


### PR DESCRIPTION
**Associated Issue(s):** #1848

### Changes in this PR

- Pull `get_deleted_objects` out of `DocumentAdmin` and make it a generic admin mixin
   - Apply it also to `PersonAdmin`, `PersonDocumentRelationTypeAdmin`, and `PersonPersonRelationTypeAdmin`
   - This removes log entries from the list of permissions checked / objects listed for deletion, when deleting one of these objects that has a `GenericRelation` to log entries
- Pull `detach_document_logentries` signal handler out of `corpus` and into `common`
   - Attach it also to `Person`, `PersonDocumentRelationType`, and `PersonPersonRelationType`
   - This detaches log entries from their related objects so that when those objects are deleted, the log entries don't also get deleted