### PR TITLE
Moving (and refactoring) format_attribution

### DIFF
--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -121,18 +121,6 @@ def iiif_info_json(images):
 
 
 @register.filter
-def format_attribution(attribution):
-    """format attribution for local manifests (deprecated)"""
-    (attribution, additional_restrictions, extra_attrs_set) = attribution
-    extra_attrs = "\n".join("<p>%s</p>" % attr for attr in extra_attrs_set)
-    return '<div class="attribution"><p>%s</p><p>%s</p>%s</div>' % (
-        attribution,
-        additional_restrictions,
-        extra_attrs,
-    )
-
-
-@register.filter
 def pgp_urlize(text):
     """Find all instances of \"PGPID #\" in the passed text, and convert
     each to a link to the referenced document."""

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -642,6 +642,16 @@ class DocumentManifestView(DocumentDetailView):
 
     viewname = "corpus-uris:document-manifest"
 
+    def format_attribution(self, attribution):
+        """format attribution for local manifests (deprecated)"""
+        (attribution, additional_restrictions, extra_attrs_set) = attribution
+        extra_attrs = "\n".join("<p>%s</p>" % attr for attr in extra_attrs_set)
+        return '<div class="attribution"><p>%s</p><p>%s</p>%s</div>' % (
+            attribution,
+            additional_restrictions,
+            extra_attrs,
+        )
+
     def get(self, request, *args, **kwargs):
         document = self.get_object()
         # should 404 if no images or no transcription
@@ -724,7 +734,7 @@ class DocumentManifestView(DocumentDetailView):
         # (or at least, do not display in Mirador)
         # in 3.0 we can use multiple provider blocks, but no viewer supports it yet
 
-        manifest.attribution = corpus_extras.format_attribution(document.attribution())
+        manifest.attribution = self.format_attribution(document.attribution())
 
         # if transcription is available, add an annotation list to first canvas
         if document.has_transcription():


### PR DESCRIPTION
**Associated Issue(s):** [#808](https://github.com/Princeton-CDH/geniza/issues/808) 

### Changes in this PR

- Rm format_attribution from templatetags
- Adding format_attribution (refactored) to views' DocumentManifestView


### Reviewer Checklist

- [x] Tests pass
- [x] Compatible with the most recent develop
