### PR TITLE
Prevent deleting display name; fix no-slug admin search bug (#1803)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -72,7 +72,11 @@ class NameInlineFormSet(BaseGenericInlineFormSet):
         cleaned_data = [form.cleaned_data for form in self.forms if form.is_valid()]
         if cleaned_data:
             primary_names_count = len(
-                [name for name in cleaned_data if name.get("primary") == True]
+                [
+                    name
+                    for name in cleaned_data
+                    if name.get("primary") == True and not name.get("DELETE")
+                ]
             )
             if primary_names_count == 0 or primary_names_count > 1:
                 raise ValidationError(self.DISPLAY_NAME_ERROR, code="invalid")
@@ -362,7 +366,7 @@ class PersonAdmin(TabbedTranslationAdmin, SortableAdminBase, admin.ModelAdmin):
                 .only("slug")
                 .get_results(rows=10000)
             )
-            slugs = [r["slug"] for r in sqs]
+            slugs = [r.get("slug") for r in sqs if r.get("slug")]
             # filter queryset by slug if there are results
             if sqs:
                 queryset = queryset.filter(slug__in=slugs)

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -339,6 +339,25 @@ class TestNameInlineFormSet:
         )
         assertNotContains(response, NameInlineFormSet.DISPLAY_NAME_ERROR)
 
+        # should raise validation error if exactly one primary name and DELETE is checked
+        response = admin_client.post(
+            reverse("admin:entities_person_add"),
+            data={
+                "entities-name-content_type-object_id-INITIAL_FORMS": ["0"],
+                "entities-name-content_type-object_id-TOTAL_FORMS": ["2"],
+                "entities-name-content_type-object_id-MAX_NUM_FORMS": ["1000"],
+                "entities-name-content_type-object_id-0-name": "Marina Rustow",
+                "entities-name-content_type-object_id-0-primary": "on",
+                "entities-name-content_type-object_id-0-language": str(english.pk),
+                "entities-name-content_type-object_id-0-transliteration_style": Name.NONE,
+                "entities-name-content_type-object_id-0-DELETE": "on",
+                "entities-name-content_type-object_id-1-name": "S.D. Goitein",
+                "entities-name-content_type-object_id-1-language": str(english.pk),
+                "entities-name-content_type-object_id-1-transliteration_style": Name.NONE,
+            },
+        )
+        assertContains(response, NameInlineFormSet.DISPLAY_NAME_ERROR)
+
 
 @pytest.mark.django_db
 class TestPersonPersonRelationTypeChoiceIterator:


### PR DESCRIPTION
**Associated Issue(s):** #1803

### Changes in this PR

- Prevent deleting a Person record's only display name
- Fix a bug that crashed person admin search when a record was accidentally indexed with no slug