### PR TITLE
Fix people search filter overlap on mobile (#1844)

### DIFF
--- a/sitemedia/scss/pages/_people.scss
+++ b/sitemedia/scss/pages/_people.scss
@@ -15,17 +15,17 @@ main.people {
     // header row
     .topheader-row {
         display: flex;
-        flex-flow: row nowrap;
-        align-items: center;
-        justify-content: space-between;
+        flex-flow: column;
         width: 100%;
         gap: 0.75rem;
         @include breakpoints.for-tablet-landscape-up {
+            flex-flow: row nowrap;
+            justify-content: space-between;
+            align-items: center;
             gap: 2rem;
         }
         fieldset#query {
             flex-grow: 1;
-            margin-right: 5.75rem;
             @include breakpoints.for-tablet-landscape-up {
                 margin-left: 8rem;
                 margin-right: 0;


### PR DESCRIPTION
**Associated Issue(s):** #1844

### Changes in this PR

- Fix a CSS issue where the filter button would overlap the search query field in People keyword search