### PR TITLE
Ensure all related records merged in document and person merges (#1854)

### DIFF
--- a/geniza/corpus/forms.py
+++ b/geniza/corpus/forms.py
@@ -512,7 +512,7 @@ class DocumentMergeForm(forms.Form):
         help_text=(
             "Select the primary document, which will be used as the merged document PGPID. "
             "All other PGPIDs will be added to the list of old PGPIDs. "
-            "All metadata, tags, footnotes, and log entries will be combined on the merged document."
+            "All metadata, authors, tags, footnotes, related entities, and log entries will be combined on the merged document."
         ),
         empty_label=None,
         widget=forms.RadioSelect,

--- a/geniza/corpus/templates/corpus/snippets/document_option_label.html
+++ b/geniza/corpus/templates/corpus/snippets/document_option_label.html
@@ -13,6 +13,11 @@
             <label>Description</label><div>{{ document.description }}</div>
         </div>
     {% endif %}
+    {% if document.authors.count %}
+        <div class="form-row">
+            <label>Description Authors</label><div>{{ document.authors.all|join:", " }}</div>
+        </div>
+    {% endif %}
     {% if document.all_languages %}
         <div class="form-row">
             <label>Languages</label><div>{{ document.all_languages }}</div>
@@ -68,16 +73,95 @@
                                 <label>Footnote relation</label>
                                 <div>{{ fn.get_doc_relation_display }}</div>
                             </div>
-                            {% if fn.has_transcription %}
+                            {% if fn.content_html_str %}
                                 <div class="form-row">
-                                    <label>Transcription(s)</label>
+                                    <label>Content</label>
                                     <div class="transcription-container">
-                                        {{ fn.content_html }}
+                                        {{ fn.content_html_str|safe }}
                                     </div>
                                 </div>
                             {% endif %}
                         {% endfor %}
                     </li>
+                {% endfor %}
+            </ol>
+        </div>
+    {% endif %}
+    {% if document.persondocumentrelation_set.count %}
+        <div class="form-row">
+            <label>Related People</label>
+            <ol>
+                {% for person_rel in document.persondocumentrelation_set.all %}
+                    <li>
+                        <div class="form-row">
+                            <label>Person</label>
+                            <div>
+                                {{ person_rel.person }}
+                                <a href="{% url 'admin:entities_person_change' person_rel.person.id %}" title="Go to this person's admin edit page">
+                                    <img src="/static/admin/img/icon-changelink.svg" alt="Change">
+                                </a>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <label>Relationship</label>
+                            <div>{{ person_rel.type }}</div>
+                        </div>
+                        <div class="form-row">
+                            <label>Uncertain</label>
+                            <div>{{ person_rel.uncertain }}</div>
+                        </div>
+                        {% if person_rel.notes %}
+                            <div class="form-row">
+                                <label>Notes</label>
+                                <div>{{ person_rel.notes }}</div>
+                            </div>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ol>
+        </div>
+    {% endif %}
+    {% if document.documentplacerelation_set.count %}
+        <div class="form-row">
+            <label>Related Places</label>
+            <ol>
+                {% for place_rel in document.documentplacerelation_set.all %}
+                    <li>
+                        <div class="form-row">
+                            <label>Place</label>
+                            <div>
+                                {{ place_rel.place }}
+                                <a href="{% url 'admin:entities_place_change' place_rel.place.id %}" title="Go to this place's admin edit page">
+                                    <img src="/static/admin/img/icon-changelink.svg" alt="Change">
+                                </a>
+                            </div>
+                        </div>
+                        <div class="form-row">
+                            <label>Relationship</label>
+                            <div>{{ place_rel.type }}</div>
+                        </div>
+                        {% if place_rel.notes %}
+                            <div class="form-row">
+                                <label>Notes</label>
+                                <div>{{ place_rel.notes }}</div>
+                            </div>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ol>
+        </div>
+    {% endif %}
+    {% if document.events.count %}
+        <div class="form-row">
+            <label>Related Events</label>
+            <ol>
+                {% for event_rel in document.documenteventrelation_set.all %}
+                    <li>
+                        {{ event_rel.event }}
+                        <a href="{% url 'admin:entities_event_change' event_rel.event.id %}" title="Go to this event's admin edit page">
+                            <img src="/static/admin/img/icon-changelink.svg" alt="Change">
+                        </a>
+                        {% if event_rel.notes %}(notes: {{ event_rel.notes }}){% endif %}</li>
                 {% endfor %}
             </ol>
         </div>

--- a/geniza/entities/templates/entities/snippets/person_option_label.html
+++ b/geniza/entities/templates/entities/snippets/person_option_label.html
@@ -29,10 +29,6 @@
                 <a target="_blank" href="{% url 'admin:corpus_document_change' rel.document.pk %}">
                     {{ rel.document }}</a> ({{ rel.type }})</div>
         </div>
-    {% empty %}
-        <div class="form-row">
-            <label>Related document</label><div>[no related documents]</div>
-        </div>
     {% endfor %}
     {% for rel in person.to_person.all %}
         <div class="form-row">
@@ -53,38 +49,21 @@
             </div>
         </div>
     {% endfor %}
-    {% if not person.from_person.exists and not person.to_person.exists %}
-        <div class="form-row">
-            <label>Related person</label><div>[no related persons]</div>
-        </div>
-    {% endif %}
     {% for rel in person.personplacerelation_set.all %}
         <div class="form-row">
             <label>Related place</label><div>
                 <a target="_blank" href="{% url 'admin:entities_place_change' rel.place.pk %}">
                     {{ rel.place }}</a> ({{ rel.type }})</div>
         </div>
-    {% empty %}
-        <div class="form-row">
-            <label>Related place</label><div>[no related places]</div>
-        </div>
     {% endfor %}
     {% for event in person.events.all %}
         <div class="form-row">
             <label>Related event</label><div><a target="_blank" href="{% url 'admin:entities_event_change' event.pk %}"> {{ event }}</a></div>
         </div>
-    {% empty %}
-        <div class="form-row">
-            <label>Related event</label><div>[no related events]</div>
-        </div>
     {% endfor %}
     {% for footnote in person.footnotes.all %}
         <div class="form-row">
             <label>Data source (footnote)</label><div>{{ footnote.source.formatted_display|safe }}</div>
-        </div>
-    {% empty %}
-        <div class="form-row">
-            <label>Data source (footnote)</label><div>[no footnotes]</div>
         </div>
     {% endfor %}
 </div>

--- a/geniza/entities/templates/entities/snippets/person_option_label.html
+++ b/geniza/entities/templates/entities/snippets/person_option_label.html
@@ -12,9 +12,11 @@
             <label>{% if name.primary %}Display n{% else %}N{% endif %}ame ({{ name.language }})</label><div>{{ name }}</div>
         </div>
     {% endfor %}
-    <div class="form-row">
-        <label>Social role</label><div>{{ person.role|default:"[no role]" }}</div>
-    </div>
+    {% for role in person.roles.all %}
+        <div class="form-row">
+            <label>Social role</label><div>{{ role }}</div>
+        </div>
+    {% endfor %}
     <div class="form-row">
         <label>Gender</label><div>{{ person.gender }}</div>
     </div>
@@ -65,6 +67,15 @@
     {% empty %}
         <div class="form-row">
             <label>Related place</label><div>[no related places]</div>
+        </div>
+    {% endfor %}
+    {% for event in person.events.all %}
+        <div class="form-row">
+            <label>Related event</label><div><a target="_blank" href="{% url 'admin:entities_event_change' event.pk %}"> {{ event }}</a></div>
+        </div>
+    {% empty %}
+        <div class="form-row">
+            <label>Related event</label><div>[no related events]</div>
         </div>
     {% endfor %}
     {% for footnote in person.footnotes.all %}

--- a/geniza/entities/tests/test_entities_models.py
+++ b/geniza/entities/tests/test_entities_models.py
@@ -180,9 +180,30 @@ class TestPerson:
         PersonPersonRelation.objects.create(
             from_person=grandchild, to_person=parent_dupe, type=grandchild_type
         )
+        # business partnership on both records
+        business_partner = Person.objects.create()
+        partner_type, _ = PersonPersonRelationType.objects.get_or_create(
+            name_en="partner"
+        )
+        partner_parent_notes = "Found by evidence."
+        partner_dupe_notes = "Seen on documents."
+        partner_parent = PersonPersonRelation.objects.create(
+            from_person=parent,
+            to_person=business_partner,
+            type=partner_type,
+            notes=partner_parent_notes,
+        )
+        PersonPersonRelation.objects.create(
+            from_person=parent_dupe,
+            to_person=business_partner,
+            type=partner_type,
+            notes=partner_dupe_notes,
+        )
+        parent_dupe_str = str(parent_dupe)
         parent.merge_with([parent_dupe])
 
-        # ambiguity relationship should no longer be present
+        # ambiguity relationship should no longer be present; i.e. avoided
+        # self-self relationship
         assert not parent.to_person.filter(type=ambiguity_type).exists()
         assert not parent.from_person.filter(type=ambiguity_type).exists()
 
@@ -195,6 +216,32 @@ class TestPerson:
         assert PersonPersonRelation.objects.filter(
             from_person=grandchild, to_person=parent, type=grandchild_type
         ).exists()
+
+        # only one business partner relationship should exist still
+        partner_relations = PersonPersonRelation.objects.filter(
+            from_person=parent,
+            to_person=business_partner,
+            type=partner_type,
+        )
+        assert partner_relations.count() == 1
+        # its notes should be combined
+        partner_parent.refresh_from_db()
+        assert partner_parent.notes == "\n".join(
+            [
+                partner_parent_notes,
+                "Notes from merged record %s: %s"
+                % (parent_dupe_str, partner_dupe_notes),
+            ]
+        )
+
+    def test_merge_with_related_events(self):
+        person = Person.objects.create()
+        person_dupe = Person.objects.create()
+        event = Event.objects.create()
+        person_dupe.events.add(event)
+        person.merge_with([person_dupe])
+        # event relation should be reassigned to merged result
+        assert person.events.filter(pk=event.pk).exists()
 
     def test_merge_with_related_places(self):
         person = Person.objects.create()

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -252,9 +252,13 @@ fieldset.transcriptions-field
     max-height: 350px;
     overflow-y: scroll;
 }
-[class^="merge-"] li > label {
+[class^="merge-"] .form-row > div > div > label {
     display: flex;
     justify-content: flex-start;
+    width: 100%;
+}
+#id_primary_document > div > label > input {
+    margin: 0 144px 0 0;
 }
 
 [class^="merge-"] .submit-row {
@@ -273,7 +277,7 @@ fieldset.transcriptions-field
     margin-bottom: 10px;
 }
 
-.aligned ul .merge-document-label label {
+.aligned div .merge-document-label label {
     display: block;
     padding: 4px 10px 0 0;
     float: left;


### PR DESCRIPTION
**Associated Issue(s):** #1854

### Changes in this PR

- Ensure relationships to entities (person/place/event), and description authorships, aren't clobbered in Document merge
  - Show them in the table in the merge template
  - Create a reusable helper function to merge Document related records
  - Ensure no duplicate relationships are created (i.e. same Person + Type on Document, same Place + Type on Document, same Event on Document)
  - In the case of a duplicate being found, ensure all notes are combined on the primary document
- Refactor Person merge, ensure related events not clobbered by merge
   - Fix bug with Social Roles in the merge template
   - Create a reusable helper function to merge Person related records
   - Add some special handling for Person-Person relationships (asymmetrical self-referential M2M)
- Update some CSS for the admin merge views to fix issues caused by Django 4 changes

### Reviewer Checklist

- [ ] Leave comments on any parts of the code changes that you have questions about or don't understand
- [ ] Also note any possible mistakes, omissions, or bugs
- [ ] Try locally merging some Document records with related people, places, and events (Document admin list --> Select some with checkboxes --> Dropdown at the top of the list "Merge selected documents")
- [ ] Try locally merging some Person records with related documents, people, places, and events (Person admin list --> Select some with checkboxes --> Dropdown at the top of the list "Merge selected people")