### PR TITLE
Various mobile CSS tweaks (#1844)

### DIFF
--- a/geniza/corpus/templates/corpus/document_list.html
+++ b/geniza/corpus/templates/corpus/document_list.html
@@ -101,7 +101,7 @@
                 <span class="sr-only">{{ close_button }}</span>
             </a>
             <div class="fieldset-left-column">
-                <label for="{{ form.docdate.auto_id }}" class="date-range-label">
+                <label for="{{ form.docdate.auto_id }}" class="docdate-range-label">
                     <span class="fieldname">{{ form.docdate.label }}</span>
                     {# NOTE: stimulus action is configured via django widget attrs #}
                     {{ form.docdate }}
@@ -128,7 +128,7 @@
                         </label>
                     </li>
                     <li>
-                        <label for="{{ form.has_translation.auto_id }}">
+                        <label for="{{ form.has_translation.auto_id }}" class="has-translation-label">
                             {% render_field form.has_translation data-action="search#update" %}
                             {{ form.has_translation.label }}
                         </label>

--- a/sitemedia/scss/components/_navigation.scss
+++ b/sitemedia/scss/components/_navigation.scss
@@ -146,6 +146,7 @@ nav#site-nav {
             visibility: visible;
             width: 100%;
             height: 100vh;
+            height: 100dvh;
             pointer-events: all;
             @include breakpoints.for-desktop-up {
                 flex: 1 0 auto;
@@ -369,6 +370,7 @@ nav#site-nav {
             visibility: visible;
             width: 100%;
             height: 100vh;
+            height: 100dvh;
             @include breakpoints.for-tablet-landscape-up {
                 width: 33%;
                 right: 0;

--- a/sitemedia/scss/components/_peopleform.scss
+++ b/sitemedia/scss/components/_peopleform.scss
@@ -28,6 +28,7 @@ main.search {
             max-width: none;
             width: min(20rem, 100vw);
             height: 100vh;
+            height: 100dvh;
             top: 0;
             right: 0;
             overflow-y: scroll;
@@ -55,11 +56,15 @@ main.search {
                 @include a11y.sr-only;
             }
             // on mobile, should look like header
+            display: contents;
             float: left;
             width: 100%;
             font-family: fonts.$primary-bold;
             font-size: 1.5rem;
             line-height: 1.4166;
+        }
+        .fieldset-left-column fieldset legend {
+            display: contents;
         }
         label,
         fieldset legend {
@@ -71,13 +76,16 @@ main.search {
                 line-height: 1.166;
                 margin-bottom: 0.25rem;
             }
-            &:not(last-of-type) {
-                border-bottom: 1px solid var(--background-gray);
-                padding-bottom: 1rem;
-                @include breakpoints.for-tablet-landscape-up {
-                    border: none;
-                    padding-bottom: 0;
-                }
+        }
+        .fieldset-left-column fieldset,
+        .fieldset-left-column:has(.docdate-range-label),
+        label:not(:last-of-type):not(.has-translation-label):not(.docdate-range-label),
+        .date-range-label {
+            border-bottom: 1px solid var(--background-gray);
+            padding-bottom: 1rem;
+            @include breakpoints.for-tablet-landscape-up {
+                border: none;
+                padding-bottom: 0;
             }
         }
         li label,

--- a/sitemedia/scss/pages/_places.scss
+++ b/sitemedia/scss/pages/_places.scss
@@ -131,6 +131,9 @@ main.places {
         bottom: -7px;
         height: calc(100vh - 10.5rem);
         max-height: calc(100vh - 10.5rem);
+        // use dvh where supported for mobile compatibility
+        height: calc(100dvh - 10.5rem);
+        max-height: calc(100dvh - 10.5rem);
         z-index: 2;
         @include breakpoints.for-tablet-landscape-up {
             position: relative;
@@ -255,6 +258,9 @@ main.places {
         // smaller map if filters open on mobile
         height: calc(100vh - 21.5rem);
         max-height: calc(100vh - 21.5rem);
+        // use dvh where supported for mobile compatibility
+        height: calc(100dvh - 21.5rem);
+        max-height: calc(100dvh - 21.5rem);
         @include breakpoints.for-tablet-landscape-up {
             height: auto;
             max-height: none;


### PR DESCRIPTION
**Associated Issue(s):** #1844, #1820, #1790

### Changes in this PR

- Various mobile CSS tweaks:
   - Use `dvh` units when available to make map height work on safari ios
   - Fix `legend` rendering in form filters
   - Fix borders applied to incorrect elements in form filters