### PR TITLE
Fix selected_images queryselector (#1857)

### DIFF
--- a/sitemedia/js/admin.js
+++ b/sitemedia/js/admin.js
@@ -27,7 +27,7 @@ window.addEventListener("DOMContentLoaded", () => {
             "td.field-thumbnail div.admin-thumbnail"
         );
         const selectedImagesField = row.querySelector(
-            "td.original input[name$='selected_images']"
+            "td.field-selected_images input[name$='selected_images']"
         );
         thumbnails.forEach((thumbnailDiv, i) => {
             thumbnailDiv.addEventListener(


### PR DESCRIPTION
**Associated Issue(s):** #1857

### Changes in this PR

- Update a querySelector in admin JS to fix a bug caused by an [undocumented change](https://github.com/django/django/commit/de95c826673be9ea519acc86fd898631d1a11356) to `TabularInline` HTML, introduced in Django 4.0, where hidden fields that would formerly appear under `<td class="original">` now appear under their own field column `<td class="field-[fieldname]">`

### Reviewer Checklist

- [ ] Code review
- [ ] `collectstatic` and relaunch server/npm, follow the steps to reproduce listed in https://github.com/Princeton-CDH/geniza/issues/1857 and there should be no error / changes should persist on save