### PR TITLE
#1801 Flattening nested lists while preserving all items and subitems when adding/editing transcription/translation

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -225,18 +225,25 @@ class Annotation(TrackChangesModel):
         """If the passed-in html string has nested lists, this method flattens it to a single list of one level of items.
         The method doesn't drop any item nor sub-item, instead it promotes the sub-items up as many levels as necessary to
         bring them all as the items of the single list"""
-        soup = BeautifulSoup(html_string, 'html.parser')
-        li_elem = soup.find(['li'])
+        soup = BeautifulSoup(html_string, "html.parser")
+        li_elem = soup.find(["li"])
         if not li_elem:
             return html_string
-        top_list = soup.find(['ul', 'ol'])
+        top_list = soup.find(["ul", "ol"])
         start, end = "", ""
         if str(top_list)[:4] == "<ol>":
             start, end = "<ol>", "</ol>"
         else:
             start, end = "<ul>", "</ul>"
-        needs_closing = html_string.replace("<ol>", "").replace("</ol>", "").replace("<ul>", "").replace("</ul>", "").replace("<li>", f"{start}<li>", 1)
-        return needs_closing[::-1].replace(">il/<", f"{end[::-1]}>il/<", 1)[::-1]
+        needs_closing = (
+            html_string.replace("<ol>", "")
+            .replace("</ol>", "")
+            .replace("<ul>", "")
+            .replace("</ul>", "")
+            .replace("<li>", f"{start}<li>", 1)
+        )
+        splitted = needs_closing.rsplit("</li>", 1)
+        return f"{splitted[0]}</li>{end}{splitted[1]}"
 
     @classmethod
     def sanitize_html(cls, html):

--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -222,6 +222,9 @@ class Annotation(TrackChangesModel):
 
     @classmethod
     def flatten_html_list(cls, html_string):
+        """If the passed-in html string has nested lists, this method flattens it to a single list of one level of items.
+        The method doesn't drop any item nor sub-item, instead it promotes the sub-items up as many levels as necessary to
+        bring them all as the items of the single list"""
         soup = BeautifulSoup(html_string, 'html.parser')
         li_elem = soup.find(['li'])
         if not li_elem:

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -150,10 +150,8 @@ class TestAnnotation:
         assert compiled["etag"] == line.etag
         assert "@context" not in compiled
 
-    @pytest.mark.mohamed
     def test_flatten_html_lists(self):
         html_nested_list = '<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>'
-        # assert Annotation.flatten_html_list(html_nested_list) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
         assert Annotation.flatten_html_list(
             html_nested_list) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
 

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -151,9 +151,12 @@ class TestAnnotation:
         assert "@context" not in compiled
 
     def test_flatten_html_lists(self):
-        html_nested_list = '<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>'
+        html_nested_ol = '<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>'
         assert Annotation.flatten_html_list(
-            html_nested_list) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
+            html_nested_ol) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
+        html_nested_ul = '<p></p><ul><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ul>'
+        assert Annotation.flatten_html_list(
+            html_nested_ul) == '<p></p><ul><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ul>'
 
     def test_sanitize_html(self):
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -150,6 +150,13 @@ class TestAnnotation:
         assert compiled["etag"] == line.etag
         assert "@context" not in compiled
 
+    @pytest.mark.mohamed
+    def test_flatten_html_lists(self):
+        html_nested_list = '<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>'
+        # assert Annotation.flatten_html_list(html_nested_list) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
+        assert Annotation.flatten_html_list(
+            html_nested_list) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
+
     def test_sanitize_html(self):
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'
         # should strip out all unwanted elements and attributes (table, div, style)


### PR DESCRIPTION
**Associated Issue(s):** #1801

### Changes in this PR

- Adding a method to flatten nested lists into a single list while preserving all items and sub-items
- Adding a test case


### Reviewer Checklist
- [x] Tests pass
- [x] Add a new transcription to an image by pasting in a list of lists from Google doc. Should flatten into a single list while preserving all the items and sub-items