### PR TITLE
Prevent empty doc relation from displaying (#1800)

### DIFF
--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -176,7 +176,7 @@ def all_doc_relations(footnotes):
     relations = set()
     for fn in footnotes:
         relations.update(
-            set([n.strip() for n in fn.get_doc_relation_display().split(",")])
+            set([n.strip() for n in fn.get_doc_relation_display().split(",") if n])
         )
 
     return sorted(relations)

--- a/geniza/corpus/templatetags/corpus_extras.py
+++ b/geniza/corpus/templatetags/corpus_extras.py
@@ -176,7 +176,13 @@ def all_doc_relations(footnotes):
     relations = set()
     for fn in footnotes:
         relations.update(
-            set([n.strip() for n in fn.get_doc_relation_display().split(",") if n])
+            set(
+                [
+                    doc_relation.strip()
+                    for doc_relation in fn.get_doc_relation_display().split(",")
+                    if doc_relation
+                ]
+            )
         )
 
     return sorted(relations)

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -73,6 +73,13 @@ class TestCorpusExtrasTemplateTags:
             doc_relation=Footnote.EDITION,
             location="other place",
         )
+        # should not include empty doc relation in list
+        Footnote.objects.create(
+            object_id=document.pk,
+            content_type=footnote.content_type,
+            source=footnote.source,
+            doc_relation=[],
+        )
         assert corpus_extras.all_doc_relations(list(document.footnotes.all())) == [
             "Digital Edition",
             "Edition",

--- a/geniza/footnotes/models.py
+++ b/geniza/footnotes/models.py
@@ -679,10 +679,17 @@ class Footnote(TrackChangesModel):
                             fn.get_doc_relation_display(),
                         )
                         for fn in footnotes
+                        if fn.doc_relation
                     ]
                 )
             else:
-                relation_set = set([fn.get_doc_relation_display() for fn in footnotes])
+                relation_set = set(
+                    [
+                        fn.get_doc_relation_display()
+                        for fn in footnotes
+                        if fn.doc_relation
+                    ]
+                )
             relation_display = list_to_string(sorted(list(relation_set)))
             if relation_display:
                 citation += f"'s {relation_display.lower()}"


### PR DESCRIPTION
**Associated Issue(s):** #1800

### Changes in this PR

Per #1800:
- Prevent empty `doc_relation` on Footnotes from being displayed in and below citations