### PR TITLE
Pin Wagtail by minor version (>=7.1, <7.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "gitpython",
     "neuxml",
     "rich",
-    "wagtail>=7.0,<8",
+    "wagtail>=7.1,<7.2",
     "wagtail-localize>=1.12,<1.13",
     "djiffy>=1.0.1,<1.1",
     "natsort",


### PR DESCRIPTION
**Associated Issue(s):** N/A

### Changes in this PR

- Pin Wagtail by minor version (>=7.1, <7.2) to avoid accidental upgrades, as Wagtail can introduce [breaking changes](https://docs.wagtail.org/en/latest/releases/7.1.html#upgrade-considerations-changes-affecting-all-projects) in minor versions.