### PR TITLE
Handle LTR line numbers cut off in Safari (#1408)

### DIFF
--- a/sitemedia/scss/components/_searchform.scss
+++ b/sitemedia/scss/components/_searchform.scss
@@ -186,6 +186,7 @@ main.search form {
             height: 2.5rem;
             width: 16.25rem;
             cursor: pointer;
+            color: var(--on-background-light);
             background-color: var(--background-light);
             border: 1px solid var(--background-gray);
             font-family: fonts.$primary;

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1549,6 +1549,13 @@
                 line-height: 17px;
             }
         }
+        // handle LTR line numbers cut off horizontally
+        &[dir="ltr"] ol {
+            margin-left: 5px;
+            @include breakpoints.for-tablet-landscape-up {
+                margin-left: 10px;
+            }
+        }
     }
     #toggles:has(#transcription-on:not(:checked) ~ #translation-on:checked)
         ~ .panel-container


### PR DESCRIPTION
**Associated Issue(s):** https://github.com/Princeton-CDH/geniza/issues/1408#issuecomment-3271243730

### Changes in this PR

Per https://github.com/Princeton-CDH/geniza/issues/1408#issuecomment-3271243730:
- Add left margin to `ol` in Safari mobile and desktop to ensure line numbers do not get cut off

### Notes

Due to [webkit bug 204163](https://bugs.webkit.org/show_bug.cgi?id=204163) it's not currently possible to style the `ol` marker pseudo-element, but it may become possible some day.