### PR TITLE
Handle RTL line numbers cut off in Safari (#1408)

### DIFF
--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1539,6 +1539,12 @@
                 line-height: 24px;
             }
         }
+        // handle RTL line numbers cut off horizontally
+        &[dir="rtl"] ol {
+            @include breakpoints.for-tablet-landscape-up {
+                margin-right: 10px;
+            }
+        }
     }
     .translation {
         &[dir="ltr"] ol li:not([value])::before {


### PR DESCRIPTION
**Associated Issue(s):** https://github.com/Princeton-CDH/geniza/issues/1408#issuecomment-3275987683

### Changes in this PR

Per https://github.com/Princeton-CDH/geniza/issues/1408#issuecomment-3275987683:
- Minor CSS change to ensure RTL line numbers are fully visible in Safari desktop