### PR TITLE
Apply mark.underline style to content pages (#1314)

### DIFF
--- a/sitemedia/scss/pages/_content.scss
+++ b/sitemedia/scss/pages/_content.scss
@@ -175,11 +175,6 @@ main.homepage {
         // Paragraph spacing unique to content pages
         margin-bottom: spacing.$spacing-md;
         // Mark for underilne
-        mark.underline {
-            // Prevent user agent stylesheet from treating all marks like highlights
-            background-color: transparent;
-            text-decoration: underline;
-        }
         // Wagtail rich text editor uses b tag for bold
         b {
             @include typography.body-bold;
@@ -188,6 +183,12 @@ main.homepage {
         i {
             @include typography.body-italic;
         }
+    }
+
+    mark.underline {
+        // Prevent user agent stylesheet from treating all marks like highlights
+        background-color: transparent;
+        text-decoration: underline;
     }
 
     // Image handling unique to content pages


### PR DESCRIPTION
**Associated Issue(s):** #1314

### Changes in this PR

- Apply `mark.underline` styles to all Wagtail content pages, not just the homepage, to avoid unintentional highlighting when an underline was intended