### PR TITLE
Add padding to handle Arabic (#1619)

### DIFF
--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1416,6 +1416,11 @@
         // color: yellow;
     }
 
+    // padding to handle Arabic characters that overflow container vertically
+    ol:last-of-type {
+        padding-bottom: 4px;
+    }
+
     // NOTE: Broken in stable Safari for now, but fixed in Safari preview release.
     li::marker {
         @include typography.transcription-numerals;


### PR DESCRIPTION
**Associated Issue(s):** #1619

### Changes in this PR

- Add padding to transcriptions/translations to handle Arabic characters that overflow the container vertically