### PR TITLE
Validate nested regex quantifiers (#1845) and update error message (#1871)

### DIFF
--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -404,11 +404,7 @@ class DocumentSearchView(
             context_data["form"].set_choices_from_facets(facet_dict.facet_fields)
             if self.request.GET.get("mode") == "regex":
                 context_data["form"].add_error(
-                    "q",
-                    # Translators: General error text for regular expression errors
-                    _(
-                        "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
-                    ),
+                    "q", DocumentSearchForm.GENERIC_REGEX_ERROR
                 )
         context_data.update(
             {


### PR DESCRIPTION
**Associated Issue(s):** #1845, #1871 

### Changes in this PR

Per #1845:
- Add validation to prevent nested regex quantifiers, such as `*{0,12}` or `+*`, using python regex's built in error handling

Per #1871:
- Update generic regex error message to indicate that complexity errors (such as large numeric ranges) may be the culprit