### PR TITLE
Show descriptions in user's preferred language in search results (#843)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,10 @@
 # Deploy Notes
 
+## 4.25
+
+-   Solr configuration has changed. Ensure Solr configset has been updated
+    and then reindex all content: `python manage.py index`
+
 ## 4.24
 
 -   Solr configuration has changed. Ensure Solr configset has been updated

--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,6 +1,6 @@
 # Deploy Notes
 
-## 4.25
+## 4.26
 
 -   Solr configuration has changed. Ensure Solr configset has been updated
     and then reindex all content: `python manage.py index`

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -1356,8 +1356,9 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                     if self.doctype
                     else "Unknown type"
                 ),
-                # use english description for now
                 "description_en_bigram": strip_tags(self.description_en),
+                "description_he_bigram": strip_tags(self.description_he),
+                "description_ar_bigram": strip_tags(self.description_ar),
                 "notes_t": self.notes or None,
                 "needs_review_t": self.needs_review or None,
                 # index shelfmark label as a string (combined shelfmark OR shelfmark override)

--- a/geniza/corpus/templates/corpus/snippets/document_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_result.html
@@ -51,22 +51,22 @@
                 {% endif %}
             </dl>
 
-                {# description #}
-                {# TODO: Adjust lang attribute logic for non-English descriptions #}
-            <p class="description" lang="en">
-                    {# display keywords in context if any #}
-                {% with document_highlights=highlighting|dict_item:document.id %}
-                    {% if document_highlights.description %}
-                        {% for snippet in document_highlights.description %}
-                            {{ snippet|safe }}
-                            {% if not forloop.last %}[…]{% endif %}
+            {# description #}
+            {% with highlight=highlighting|dict_item:document.id|translate_highlight %}
+                {% if highlight and highlight.snippets %}
+                    <p class="description" lang="{{ highlight.lang }}" dir="{{ highlight.dir }}">
+                        {% for snippet in highlight.snippets %}
+                            {{ snippet|safe }}{% if not forloop.last %}[…]{% endif %}
                         {% endfor %}
-                    {% else %}
-                            {# otherwise, display truncated description #}
-                        {{ document.description|truncatewords:25 }}
-                    {% endif %}
-                {% endwith %}
-            </p>
+                    </p>
+                {% else %}
+                    {% with description=document|translate_description %}
+                        <p class="description" lang="{{ description.lang }}" dir="{{ description.dir }}">
+                            {{ description.text|truncatewords:25 }}
+                        </p>
+                    {% endwith %}
+                {% endif %}
+            {% endwith %}
 
                 {# transcription: keywords in context if any, or excerpt #}
             {% with document_highlights=highlighting|dict_item:document.id lang=document.language_code lang_script=document.language_script %}

--- a/geniza/corpus/tests/test_corpus_templatetags.py
+++ b/geniza/corpus/tests/test_corpus_templatetags.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from django.http.request import HttpRequest, QueryDict
 from django.urls import reverse
+from django.utils.translation import activate, get_language
 from piffle.image import IIIFImageClient
 from pytest_django.asserts import assertContains
 
@@ -288,6 +289,78 @@ def test_translate_url(document):
     # if a Hebrew version cannot be determined, should return the original URL
     ctx["request"].path = "https://example.com"
     assert corpus_extras.translate_url(ctx, "he") == "https://example.com"
+
+
+def test_translate_highlight():
+    current_lang = get_language()
+
+    # no highlights: return None
+    assert corpus_extras.translate_highlight({}) is None
+
+    # language is english, highlight is in english
+    activate("en")
+    en_highlights = ["example highlight"]
+    highlights = {"description": en_highlights}
+    assert corpus_extras.translate_highlight(highlights)["snippets"] == en_highlights
+    assert corpus_extras.translate_highlight(highlights)["lang"] == "en"
+    assert corpus_extras.translate_highlight(highlights)["dir"] == "ltr"
+
+    # language is hebrew, highlight is in english
+    activate("he")
+    assert corpus_extras.translate_highlight(highlights)["snippets"] == en_highlights
+    assert corpus_extras.translate_highlight(highlights)["lang"] == "en"
+    assert corpus_extras.translate_highlight(highlights)["dir"] == "ltr"
+
+    # language is hebrew, highlight is in english and hebrew: should prefer hebrew
+    he_highlights = ["דוגמאות עיקריות"]
+    highlights = {"description": en_highlights, "description_he": he_highlights}
+    assert corpus_extras.translate_highlight(highlights)["lang"] == "he"
+    assert corpus_extras.translate_highlight(highlights)["dir"] == "rtl"
+
+    # language is arabic, highlight is in english and hebrew: should prefer english
+    activate("ar")
+    assert corpus_extras.translate_highlight(highlights)["lang"] == "en"
+    assert corpus_extras.translate_highlight(highlights)["dir"] == "ltr"
+
+    # reactivate previous default (in case it matters for other tests)
+    activate(current_lang)
+
+
+def test_translate_description():
+    current_lang = get_language()
+
+    # no highlights: empty description
+    assert corpus_extras.translate_description({})["text"] is None
+
+    # language is english, description is in english
+    activate("en")
+    en_desc = "An example document description"
+    document = {"description": en_desc}
+    assert corpus_extras.translate_description(document)["text"] == en_desc
+    assert corpus_extras.translate_description(document)["lang"] == "en"
+    assert corpus_extras.translate_description(document)["dir"] == "ltr"
+
+    # language is hebrew, description is in english
+    activate("he")
+    assert corpus_extras.translate_description(document)["text"] == en_desc
+    assert corpus_extras.translate_description(document)["lang"] == "en"
+    assert corpus_extras.translate_description(document)["dir"] == "ltr"
+
+    # language is hebrew, description is in english and hebrew: should prefer hebrew
+    he_desc = "תיאור מסמך לדוגמה"
+    document = {"description": en_desc, "description_he": he_desc}
+    assert corpus_extras.translate_description(document)["text"] == he_desc
+    assert corpus_extras.translate_description(document)["lang"] == "he"
+    assert corpus_extras.translate_description(document)["dir"] == "rtl"
+
+    # language is arabic, description is in english and hebrew: should prefer english
+    activate("ar")
+    assert corpus_extras.translate_description(document)["text"] == en_desc
+    assert corpus_extras.translate_description(document)["lang"] == "en"
+    assert corpus_extras.translate_description(document)["dir"] == "ltr"
+
+    # reactivate previous default (in case it matters for other tests)
+    activate(current_lang)
 
 
 class TestAdminExtrasTemplateTags:

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -257,6 +257,38 @@ class DocumentSearchView(
                         requireFieldMatch=False,
                         **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
                     )
+                    .highlight(
+                        "description_he",
+                        snippets=3,
+                        method="unified",
+                        fragsize=150,
+                        requireFieldMatch=True,
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
+                    )
+                    .highlight(
+                        "description_he_nostem",
+                        snippets=3,
+                        method="unified",
+                        fragsize=150,
+                        requireFieldMatch=True,
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
+                    )
+                    .highlight(
+                        "description_ar",
+                        snippets=3,
+                        method="unified",
+                        fragsize=150,
+                        requireFieldMatch=True,
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
+                    )
+                    .highlight(
+                        "description_ar_nostem",
+                        snippets=3,
+                        method="unified",
+                        fragsize=150,
+                        requireFieldMatch=True,
+                        **{"bs.type": "SEPARATOR", "bs.separator": "\n"},
+                    )
                     # highlight old shelfmark so we can show match in results
                     .highlight("old_shelfmark", requireFieldMatch=True)
                     .highlight("old_shelfmark_t", requireFieldMatch=True)

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -1111,7 +1111,7 @@ class PersonSolrQuerySet(EntitySolrQuerySet):
         "name": "name_s",
         # need access to these other_names fields for highlighting
         "other_names_nostem": "other_names_nostem",
-        "other_names_bigram": "other_names_bigram",
+        "other_names_bigram": "other_names_bigrams",
         "description": "description_txt",
         "gender": "gender_s",
         "roles": "role_ss",
@@ -1724,7 +1724,7 @@ class PlaceSolrQuerySet(EntitySolrQuerySet):
         "other_names": "other_names_ss",
         # copies of other_names for improved search
         "other_names_nostem": "other_names_nostem",
-        "other_names_bigram": "other_names_bigram",
+        "other_names_bigram": "other_names_bigrams",
         "url": "url_s",
         "documents": "documents_i",
         "people": "people_i",

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -165,6 +165,17 @@ section#document-list {
             }
         }
 
+        .description {
+            &[dir="ltr"] {
+                direction: ltr;
+                text-align: left;
+            }
+            &[dir="rtl"] {
+                direction: rtl;
+                text-align: right;
+            }
+        }
+
         .transcription {
             @include typography.transcription-search;
         }

--- a/solr_conf/conf/managed-schema
+++ b/solr_conf/conf/managed-schema
@@ -334,19 +334,19 @@
   <!-- local fields -->
   <field name="last_modified" type="pdate" multiValued="false" indexed="true" required="true" stored="true" default="NOW"/>
 
-  <copyField source="shelfmark_s" dest="shelfmark_bigram" maxChars="30000" />
+  <copyField source="shelfmark_s" dest="shelfmark_bigrams" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_textnum" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_natsort" maxChars="30000" />
   <copyField source="shelfmark_s" dest="shelfmark_regex" maxChars="30000" />
   <!-- individual shelfmarks -->
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_t" maxChars="30000" />
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_textnum" maxChars="30000" />
-  <copyField source="fragment_shelfmark_ss" dest="shelfmark_bigram" maxChars="30000" />  
+  <copyField source="fragment_shelfmark_ss" dest="shelfmark_bigrams" maxChars="30000" />  
   <copyField source="fragment_shelfmark_ss" dest="shelfmark_regex" maxChars="30000" />
   <!-- old / historic shelfmarks -->
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_t" maxChars="30000" />
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_textnum" maxChars="30000" />
-  <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_bigram" maxChars="30000" />
+  <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_bigrams" maxChars="30000" />
   <copyField source="fragment_old_shelfmark_ss" dest="old_shelfmark_regex" maxChars="30000" />
   
   <copyField source="tags_ss_lower" dest="tags_t" maxChars="30000" />
@@ -354,15 +354,19 @@
 
   <!-- copy description and transcription to nostem fields for exact matches -->
   <copyField source="description_en_bigram" dest="description_nostem" maxChars="30000" />
+  <copyField source="description_he_bigram" dest="description_he_nostem" maxChars="30000" />
+  <copyField source="description_ar_bigram" dest="description_ar_nostem" maxChars="30000" />
   <copyField source="text_transcription" dest="transcription_nostem" maxChars="30000" />
 
   <!-- copy description and translation to regex fields -->
   <copyField source="description_en_bigram" dest="description_regex" maxChars="30000" />
+  <copyField source="description_he_bigram" dest="description_he_regex" maxChars="30000" />
+  <copyField source="description_ar_bigram" dest="description_ar_regex" maxChars="30000" />
 
   <!-- copy entity name fields to text fields -->
-  <copyField source="name_s" dest="name_bigram" maxChars="30000" />
+  <copyField source="name_s" dest="name_bigrams" maxChars="30000" />
   <copyField source="name_s" dest="name_nostem" maxChars="30000" />
-  <copyField source="other_names_ss" dest="other_names_bigram" maxChars="30000" />
+  <copyField source="other_names_ss" dest="other_names_bigrams" maxChars="30000" />
   <copyField source="other_names_ss" dest="other_names_nostem" maxChars="30000" />
 
   <dynamicField name="*_descendent_path" type="descendent_path" indexed="true" stored="true"/>
@@ -406,7 +410,8 @@
   <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
   <dynamicField name="*_ws" type="text_ws" indexed="true" stored="true"/>
   <dynamicField name="*_textnum" type="text_lettersnumbers" indexed="true" stored="true" multiValued="true"/>
-  <dynamicField name="*_bigram" type="text_bigram" indexed="true" stored="true" multiValued="true"/>
+  <dynamicField name="*_bigram" type="text_bigram" indexed="true" stored="true" />
+  <dynamicField name="*_bigrams" type="text_bigram" indexed="true" stored="true" multiValued="true"/>
 
   <dynamicField name="*_i" type="int" indexed="true" stored="true"/>
   <dynamicField name="*_s" type="string" indexed="true" stored="true"/>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -717,10 +717,14 @@
       <str name="keyword_qf">
         shelfmark_s^200
         description_nostem^190
+        description_he_nostem^190
+        description_ar_nostem^190
         transcription_nostem^190
-        shelfmark_bigram^180
+        shelfmark_bigrams^180
         shelfmark_textnum^140
         description_en_bigram^50
+        description_he_bigram^50
+        description_ar_bigram^50
         pgpid_i
         type_s
         type_t
@@ -729,7 +733,7 @@
         fragment_old_shelfmark_ss
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram
+        old_shelfmark_bigrams
         tags_t
         tags_ss_lower
         scholarship_t
@@ -739,14 +743,18 @@
         document_date_t
       </str>
       <str name="keyword_pf">
-        shelfmark_bigram^9500
+        shelfmark_bigrams^9500
         shelfmark_textnum^9500
         description_en_bigram^3500
+        description_he_bigram^3500
+        description_ar_bigram^3500
         description_nostem^3500
+        description_he_nostem^3500
+        description_ar_nostem^3500
         transcription_nostem^3500
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram^100
+        old_shelfmark_bigrams^100
         tags_t
         scholarship_t^80
         text_transcription^2500
@@ -757,13 +765,15 @@
        <!-- admin search field for Document model (no boosting because no relevance sort) -->
       <str name="admin_doc_qf">
         type_s
-        shelfmark_bigram
+        shelfmark_bigrams
         shelfmark_s
         fragment_shelfmark_ss
         shelfmark_textnum
         tags_t
         tags_ss_lower
         description_en_bigram
+        description_he_bigram
+        description_ar_bigram
         notes_t
         needs_review_t
         pgpid_i
@@ -774,15 +784,17 @@
         fragment_old_shelfmark_ss
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram
+        old_shelfmark_bigrams
         document_date_t
       </str>
       <str name="admin_doc_pf">
         type_s
-        shelfmark_bigram
+        shelfmark_bigrams
         shelfmark_textnum
         tags_t
         description_en_bigram
+        description_he_bigram
+        description_ar_bigram
         notes_t
         needs_review_t
         scholarship_t
@@ -790,7 +802,7 @@
         text_translation
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram
+        old_shelfmark_bigrams
         document_date_t
       </str>
 
@@ -798,25 +810,25 @@
       <str name="shelfmark_qf">
         shelfmark_s
         shelfmark_t
-        shelfmark_bigram
+        shelfmark_bigrams
         shelfmark_textnum
         old_shelfmark_t
         old_shelfmark_textnum
-        old_shelfmark_bigram
+        old_shelfmark_bigrams
       </str>
 
       <!-- search fields for entities -->
       <str name="entities_qf">
         name_nostem^30
-        name_bigram^20
+        name_bigrams^20
         other_names_nostem^10
-        other_names_bigram
+        other_names_bigrams
       </str>
       <str name="entities_pf">
         name_nostem^30
-        name_bigram^20
+        name_bigrams^20
         other_names_nostem^10
-        other_names_bigram
+        other_names_bigrams
       </str>
     </lst>
 


### PR DESCRIPTION
**Associated Issue(s):** #843

### Changes in this PR

Per #843:
- Hebrew and Arabic descriptions indexed in solr
   - Indexed as `_bigram` for general search, indexed as `_nostem` for exact match search with double quotes, and indexed as `_regex` for regex search
   - Had to create a new `*_bigram` single-valued dynamic solr field type in order to match `*_en_bigram`, as the existing `*_bigram` was multi-valued
      - Renamed `*_bigram` to `*_bigrams` to match existing multi-valued field name convention
- Added new template filters that pick the appropriate description to show in search results based on user's current language
   - One for descriptions when there is no highlighted match in descriptions, and one for when there is
   - Always prefers user's current language, then English

### Reviewer Checklist

- [x] Solr configset will need to be updated and the core reloaded in order for unit tests to pass: (replace `$SOLR_HOME` with your local solr home)
    ```sh
    rm -rf $SOLR_HOME/configsets/geniza/conf
    cp -r solr_conf/conf $SOLR_HOME/configsets/geniza
    curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=geniza"
    ```
- [x] Content will need to be reindexed in order to use search:
    ```sh
    python manage.py index
    ```
