### PR TITLE
Allow transcription/translation editor image popout container to have width >640px (#1885)

### DIFF
--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -424,7 +424,7 @@
             /* enlarge button and enlarge functionality */
             @include breakpoints.for-tablet-landscape-up {
                 transition: max-width 0.3s ease-in-out;
-                & > div {
+                & > div:not(.popout-container) {
                     max-width: 640px;
                     margin: 0 auto;
                     transition: max-width 0.3s ease-in-out;


### PR DESCRIPTION
**Associated Issue(s):** #1885

### Changes in this PR

- Allow transcription/translation editor image popout container to have width >640px