### PR TITLE
Style improvements for related document sections in Person and Place admin (#1883)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -348,6 +348,9 @@ class PersonAdmin(
     )
     own_pk = None
 
+    class Media:
+        css = {"all": ("css/admin-local.css",)}
+
     def save_related(self, request, form, formsets, change):
         """Override save to ensure slug is generated if empty. Adapted from mep-django"""
         super().save_related(request, form, formsets, change)
@@ -650,6 +653,9 @@ class PlaceAdmin(SortableAdminBase, admin.ModelAdmin):
         "i",  # PlaceEventInline
         "i",  # FootnoteInline
     )
+
+    class Media:
+        css = {"all": ("css/admin-local.css",)}
 
     def save_related(self, request, form, formsets, change):
         """Override save to ensure slug is generated if empty. Adapted from mep-django"""

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -417,3 +417,17 @@ div.form-row.field-doc_date_original .inline-group {
 .object-tools a.addlink.needs-transcription {
     background-image: url("/static/img/icons/arrow-square-out.svg");
 }
+
+/* related documents: vertical alignment */
+.inline-group .tabular tr[id^="persondocumentrelation_set"] td,
+.inline-group .tabular tr[id^="documentplacerelation_set"] td {
+    vertical-align: top;
+}
+/* related documents: document description section */
+td.field-document_description {
+    min-width: 200px;
+}
+td.field-document_description p {
+    max-height: 200px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
**Associated Issue(s):** #1883

### Changes in this PR

In Person and Place admin:
- Give document description a minimum width and a max height to improve UX
- Vertically align content to the top of each cell in the table so that it is easier to read alongside descriptions