### PR TITLE
Use custom error message for solr outage (#1819)

### DIFF
--- a/geniza/common/views.py
+++ b/geniza/common/views.py
@@ -50,7 +50,8 @@ class SolrDownError(Exception):
 
 
 class SolrDownMixin:
-    """Mixin to use the solr_error template with a 503 status code when a view encounters a solr error"""
+    """Mixin to use the solr_error template with a 503 status code when a view
+    encounters a solr error"""
 
     def dispatch(self, request, *args, **kwargs):
         try:

--- a/geniza/common/views.py
+++ b/geniza/common/views.py
@@ -41,3 +41,19 @@ def language_switcher(request):
             "current_path": current_path,
         },
     )
+
+
+class SolrDownError(Exception):
+    """Custom exception to indicate Solr is unreachable"""
+
+    pass
+
+
+class SolrDownMixin:
+    """Mixin to use the solr_error template with a 503 status code when a view encounters a solr error"""
+
+    def dispatch(self, request, *args, **kwargs):
+        try:
+            return super().dispatch(request, *args, **kwargs)
+        except SolrDownError:
+            return render(request, "solr_error.html", {}, status=503)

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -15,10 +15,12 @@ from django.utils.text import Truncator, slugify
 from django.utils.timezone import get_current_timezone, make_aware
 from parasolr.django import SolrClient
 from pytest_django.asserts import assertContains, assertNotContains
+from requests.exceptions import ConnectionError
 from taggit.models import Tag
 
 from geniza.annotations.models import Annotation
 from geniza.common.utils import absolutize_url
+from geniza.common.views import SolrDownError
 from geniza.corpus.iiif_utils import EMPTY_CANVAS_ID, new_iiif_canvas
 from geniza.corpus.models import Document, DocumentType, Fragment, TextBlock
 from geniza.corpus.solr_queryset import DocumentSolrQuerySet, clean_html
@@ -30,6 +32,7 @@ from geniza.corpus.views import (
     DocumentScholarshipView,
     DocumentSearchView,
     DocumentTranscriptionText,
+    SolrDateRangeMixin,
     SourceAutocompleteView,
     TagMerge,
     old_pgp_edition,
@@ -45,6 +48,16 @@ from geniza.entities.models import (
 )
 from geniza.footnotes.forms import SourceChoiceForm
 from geniza.footnotes.models import Creator, Footnote, Source, SourceType
+
+
+class TestSolrDateRangeMixin:
+    def test_get_range_stats(self):
+        # simulate solr being down to test raising solr error
+        queryset_cls = Mock()
+        queryset_cls.side_effect = ConnectionError
+        mixin = SolrDateRangeMixin()
+        with pytest.raises(SolrDownError):
+            mixin.get_range_stats(queryset_cls, "test")
 
 
 class TestDocumentDetailView:
@@ -367,6 +380,10 @@ def test_pgp_metadata_for_old_site():
 
 
 class TestDocumentSearchView:
+    def test_solr_down_mixin(self):
+        docsearch_view = DocumentSearchView()
+        SolrDownError
+
     def test_ignore_suppressed_documents(self, document, empty_solr):
         suppressed_document = Document.objects.create(status=Document.SUPPRESSED)
         Document.index_items([document, suppressed_document])

--- a/geniza/entities/views.py
+++ b/geniza/entities/views.py
@@ -27,6 +27,7 @@ from django.views.generic import DetailView, FormView, ListView, View
 from django.views.generic.edit import FormMixin
 from natsort import natsort_key
 
+from geniza.common.views import SolrDownMixin
 from geniza.corpus.dates import DocumentDateMixin, standard_date_display
 from geniza.corpus.models import Dating, Document, DocumentType, TextBlock
 from geniza.corpus.solr_queryset import DocumentSolrQuerySet
@@ -789,7 +790,7 @@ class PlacePeopleView(RelatedPeopleMixin, PlaceDetailView):
     relation_field = "personplacerelation_set"
 
 
-class PersonListView(ListView, FormMixin, SolrDateRangeMixin):
+class PersonListView(ListView, SolrDownMixin, FormMixin, SolrDateRangeMixin):
     """A list view with faceted filtering and sorting using only the Django ORM/database."""
 
     model = Person
@@ -990,7 +991,7 @@ class PersonListView(ListView, FormMixin, SolrDateRangeMixin):
         return context_data
 
 
-class PlaceListView(ListView, FormMixin, SolrDateRangeMixin):
+class PlaceListView(ListView, SolrDownMixin, FormMixin, SolrDateRangeMixin):
     """A list view with faceted filtering and sorting using solr."""
 
     model = Place

--- a/geniza/locale/ar/LC_MESSAGES/django.po
+++ b/geniza/locale/ar/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-08-28 15:27-0400\n"
+"POT-Creation-Date: 2025-10-02 13:30-0400\n"
 "PO-Revision-Date: 2025-08-05 18:43\n"
 "Last-Translator: \n"
 "Language-Team: Arabic\n"
@@ -112,7 +112,7 @@ msgstr "الوصف"
 #. Translators: label for "has translation" search form filter
 #: corpus/forms.py:277 corpus/forms.py:323
 #: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:508
+#: footnotes/models.py:500
 msgid "Translation"
 msgstr "الترجمة"
 
@@ -152,7 +152,7 @@ msgid "Image"
 msgstr ""
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:327 footnotes/models.py:509
+#: corpus/forms.py:327 footnotes/models.py:501
 msgid "Discussion"
 msgstr "المناقشة"
 
@@ -180,80 +180,95 @@ msgstr ""
 msgid "RegEx search field"
 msgstr ""
 
-#: corpus/forms.py:386
+#: corpus/forms.py:367
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses. Regular expression may also "
+"be too complex to compute. If using numeric ranges such as {0,19}, consider "
+"using * (match 0 or more times) or + (match one or more times) instead."
+msgstr ""
+
+#: corpus/forms.py:394
 msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:394 corpus/models.py:1089 corpus/solr_queryset.py:342
+#: corpus/forms.py:402 corpus/models.py:1092 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
 #: corpus/templates/corpus/snippets/document_transcription.html:243
-#: entities/views.py:425
+#: entities/views.py:426
 msgid "Unknown type"
 msgstr "نوع غير معروف"
 
-#: corpus/forms.py:441
+#: corpus/forms.py:449
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "ترتيب الصلة غير متوفر بدون مصطلح البحث بواسطة كلمة مفتاحية."
 
-#: corpus/forms.py:457
+#: corpus/forms.py:464
 #, python-format
 msgid ""
 "Regular expression cannot contain { without a preceding character, without "
 "an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:466
+#: corpus/forms.py:473
 #, python-format
 msgid ""
 "Regular expression cannot contain * without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:475
+#: corpus/forms.py:482
 #, python-format
 msgid ""
 "Regular expression cannot contain + without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:484
+#: corpus/forms.py:491
 #, python-format
 msgid ""
 "Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:494
+#: corpus/forms.py:501
 #, python-format
 msgid ""
 "Regular expression cannot contain the escape character \\ followed by an "
 "alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
+#: corpus/forms.py:514
+#, python-format
+msgid ""
+"Regular expression cannot contain nested quantifiers, such as *{0,1} or +*. "
+"%s (or \\*, \\?, \\{, \\} for those characters)"
+msgstr ""
+
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/models.py:829 entities/templates/entities/person_detail.html:150
+#: corpus/models.py:832 entities/templates/entities/person_detail.html:150
 msgid "Permalink"
 msgstr "رابط دائم"
 
-#: corpus/models.py:1214 templates/base.html:21
+#: corpus/models.py:1217 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1216
+#: corpus/models.py:1219
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "تجميع بواسطة %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1219
+#: corpus/models.py:1222
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "التجميع والنسخ بواسطة %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1221
+#: corpus/models.py:1224
 msgid "Additional restrictions may apply."
 msgstr "قد تطبق قيود إضافية."
 
@@ -855,38 +870,32 @@ msgstr "التالي"
 
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
-#: corpus/views.py:82 templates/snippets/menu.html:11
+#: corpus/views.py:87 templates/snippets/menu.html:11
 msgid "Documents"
 msgstr "وثائق"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:84
+#: corpus/views.py:89
 msgid "Search and browse Geniza documents."
 msgstr "البحث في وثائق جنيزا وتصفحها."
 
-#: corpus/views.py:337 entities/views.py:874
+#: corpus/views.py:342 entities/views.py:875
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:339 entities/views.py:876
+#: corpus/views.py:344 entities/views.py:877
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:410
-msgid ""
-"Error retrieving search results. Check regular expression for errors such as "
-"unescaped or unclosed brackets or parentheses."
-msgstr ""
-
 #. Translators: title of document scholarship page
-#: corpus/views.py:545
+#: corpus/views.py:546
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "منحة في %(doc)s"
 
-#: corpus/views.py:552
+#: corpus/views.py:553
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -898,12 +907,12 @@ msgstr[4] "%(count)d سجلات منح دراسية"
 msgstr[5] "%(count)d سجلات منح دراسية"
 
 #. Translators: title of related documents page
-#: corpus/views.py:593
+#: corpus/views.py:594
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "المستندات ذات الصلة لـ %(doc)s"
 
-#: corpus/views.py:600 entities/views.py:347
+#: corpus/views.py:601 entities/views.py:348
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -932,7 +941,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:890
+#: entities/forms.py:206 entities/views.py:891
 msgid "Detail page available"
 msgstr ""
 
@@ -1241,18 +1250,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:341
+#: entities/views.py:342
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:547
+#: entities/views.py:548
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:555 entities/views.py:626
+#: entities/views.py:556 entities/views.py:627
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1264,12 +1273,12 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:685
+#: entities/views.py:686
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:693
+#: entities/views.py:694
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1282,28 +1291,28 @@ msgstr[5] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:799 templates/snippets/menu.html:19
+#: entities/views.py:800 templates/snippets/menu.html:19
 msgid "People"
 msgstr "اشخاص"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:801
+#: entities/views.py:802
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:1000 templates/snippets/menu.html:26
+#: entities/views.py:1001 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "أَماكِن"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:1002
+#: entities/views.py:1003
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
 #. Translators: number of results
-#: entities/views.py:1126
+#: entities/views.py:1127
 #, python-format
 msgid "%(count)d result"
 msgid_plural "%(count)d results"
@@ -1315,7 +1324,7 @@ msgstr[4] ""
 msgstr[5] ""
 
 #. Translators: number of places
-#: entities/views.py:1130
+#: entities/views.py:1131
 #, python-format
 msgid "%(count)d place"
 msgid_plural "%(count)d places"
@@ -1326,7 +1335,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: footnotes/models.py:507
+#: footnotes/models.py:499
 msgid "Edition"
 msgstr "الطبعة"
 
@@ -1461,7 +1470,7 @@ msgid "Princeton Center for Digital Humanities homepage"
 msgstr "الصفحة الرئيسية لـ Princeton Center for Digital Humanities"
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:9
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "قراءة هذه الصفحة في %(language_name)s (%(language_code)s)"
@@ -1475,3 +1484,15 @@ msgstr "العودة إلى القائمة الرئيسية"
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
 msgstr "تفعيل الوضع المظلم"
+
+#. Translators: title for solr Service Outage (503) error page
+#: templates/solr_error.html:5 templates/solr_error.html:19
+msgid "Service Outage"
+msgstr ""
+
+#. Translators: description for solr Service Outage (503) error page
+#: templates/solr_error.html:7 templates/solr_error.html:20
+msgid ""
+"The application server was unable to reach the Solr service. This is a "
+"temporary service disruption, and site administrators are working on a fix."
+msgstr ""

--- a/geniza/locale/en/LC_MESSAGES/django.po
+++ b/geniza/locale/en/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: geniza\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-08-28 15:27-0400\n"
+"POT-Creation-Date: 2025-10-02 13:30-0400\n"
 "PO-Revision-Date: 2022-08-01 14:25\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -111,7 +111,7 @@ msgstr ""
 #. Translators: label for "has translation" search form filter
 #: corpus/forms.py:277 corpus/forms.py:323
 #: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:508
+#: footnotes/models.py:500
 msgid "Translation"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgid "Image"
 msgstr ""
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:327 footnotes/models.py:509
+#: corpus/forms.py:327 footnotes/models.py:501
 msgid "Discussion"
 msgstr ""
 
@@ -181,80 +181,95 @@ msgstr "Search Documents"
 msgid "RegEx search field"
 msgstr ""
 
-#: corpus/forms.py:386
+#: corpus/forms.py:367
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses. Regular expression may also "
+"be too complex to compute. If using numeric ranges such as {0,19}, consider "
+"using * (match 0 or more times) or + (match one or more times) instead."
+msgstr ""
+
+#: corpus/forms.py:394
 msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:394 corpus/models.py:1089 corpus/solr_queryset.py:342
+#: corpus/forms.py:402 corpus/models.py:1092 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
 #: corpus/templates/corpus/snippets/document_transcription.html:243
-#: entities/views.py:425
+#: entities/views.py:426
 msgid "Unknown type"
 msgstr ""
 
-#: corpus/forms.py:441
+#: corpus/forms.py:449
 msgid "Relevance sort is not available without a keyword search term."
 msgstr ""
 
-#: corpus/forms.py:457
+#: corpus/forms.py:464
 #, python-format
 msgid ""
 "Regular expression cannot contain { without a preceding character, without "
 "an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:466
+#: corpus/forms.py:473
 #, python-format
 msgid ""
 "Regular expression cannot contain * without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:475
+#: corpus/forms.py:482
 #, python-format
 msgid ""
 "Regular expression cannot contain + without a preceding character, or "
 "multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:484
+#: corpus/forms.py:491
 #, python-format
 msgid ""
 "Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:494
+#: corpus/forms.py:501
 #, python-format
 msgid ""
 "Regular expression cannot contain the escape character \\ followed by an "
 "alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
 msgstr ""
 
+#: corpus/forms.py:514
+#, python-format
+msgid ""
+"Regular expression cannot contain nested quantifiers, such as *{0,1} or +*. "
+"%s (or \\*, \\?, \\{, \\} for those characters)"
+msgstr ""
+
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/models.py:829 entities/templates/entities/person_detail.html:150
+#: corpus/models.py:832 entities/templates/entities/person_detail.html:150
 msgid "Permalink"
 msgstr ""
 
-#: corpus/models.py:1214 templates/base.html:21
+#: corpus/models.py:1217 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1216
+#: corpus/models.py:1219
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr ""
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1219
+#: corpus/models.py:1222
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr ""
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1221
+#: corpus/models.py:1224
 msgid "Additional restrictions may apply."
 msgstr ""
 
@@ -802,40 +817,34 @@ msgstr ""
 
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
-#: corpus/views.py:82 templates/snippets/menu.html:11
+#: corpus/views.py:87 templates/snippets/menu.html:11
 #, fuzzy
 #| msgid "Input date"
 msgid "Documents"
 msgstr "Input date"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:84
+#: corpus/views.py:89
 msgid "Search and browse Geniza documents."
 msgstr ""
 
-#: corpus/views.py:337 entities/views.py:874
+#: corpus/views.py:342 entities/views.py:875
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:339 entities/views.py:876
+#: corpus/views.py:344 entities/views.py:877
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:410
-msgid ""
-"Error retrieving search results. Check regular expression for errors such as "
-"unescaped or unclosed brackets or parentheses."
-msgstr ""
-
 #. Translators: title of document scholarship page
-#: corpus/views.py:545
+#: corpus/views.py:546
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr ""
 
-#: corpus/views.py:552
+#: corpus/views.py:553
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -843,12 +852,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of related documents page
-#: corpus/views.py:593
+#: corpus/views.py:594
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr ""
 
-#: corpus/views.py:600 entities/views.py:347
+#: corpus/views.py:601 entities/views.py:348
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -873,7 +882,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:890
+#: entities/forms.py:206 entities/views.py:891
 msgid "Detail page available"
 msgstr ""
 
@@ -1174,18 +1183,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:341
+#: entities/views.py:342
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:547
+#: entities/views.py:548
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:555 entities/views.py:626
+#: entities/views.py:556 entities/views.py:627
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1193,12 +1202,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:685
+#: entities/views.py:686
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:693
+#: entities/views.py:694
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1207,28 +1216,28 @@ msgstr[1] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:799 templates/snippets/menu.html:19
+#: entities/views.py:800 templates/snippets/menu.html:19
 msgid "People"
 msgstr ""
 
 #. Translators: description of people list/browse page
-#: entities/views.py:801
+#: entities/views.py:802
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:1000 templates/snippets/menu.html:26
+#: entities/views.py:1001 templates/snippets/menu.html:26
 msgid "Places"
 msgstr ""
 
 #. Translators: description of places list/browse page
-#: entities/views.py:1002
+#: entities/views.py:1003
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
 #. Translators: number of results
-#: entities/views.py:1126
+#: entities/views.py:1127
 #, python-format
 msgid "%(count)d result"
 msgid_plural "%(count)d results"
@@ -1236,14 +1245,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. Translators: number of places
-#: entities/views.py:1130
+#: entities/views.py:1131
 #, python-format
 msgid "%(count)d place"
 msgid_plural "%(count)d places"
 msgstr[0] ""
 msgstr[1] ""
 
-#: footnotes/models.py:507
+#: footnotes/models.py:499
 msgid "Edition"
 msgstr ""
 
@@ -1374,7 +1383,7 @@ msgid "Princeton Center for Digital Humanities homepage"
 msgstr ""
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:9
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr ""
@@ -1387,4 +1396,16 @@ msgstr ""
 #. Translators: label for dark mode/light mode theme switcher
 #: templates/snippets/theme_toggle.html:5
 msgid "Enable dark mode"
+msgstr ""
+
+#. Translators: title for solr Service Outage (503) error page
+#: templates/solr_error.html:5 templates/solr_error.html:19
+msgid "Service Outage"
+msgstr ""
+
+#. Translators: description for solr Service Outage (503) error page
+#: templates/solr_error.html:7 templates/solr_error.html:20
+msgid ""
+"The application server was unable to reach the Solr service. This is a "
+"temporary service disruption, and site administrators are working on a fix."
 msgstr ""

--- a/geniza/locale/he/LC_MESSAGES/django.po
+++ b/geniza/locale/he/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: princeton-geniza-project\n"
 "Report-Msgid-Bugs-To: cdhdevteam@princeton.edu\n"
-"POT-Creation-Date: 2025-08-28 15:27-0400\n"
+"POT-Creation-Date: 2025-10-02 13:30-0400\n"
 "PO-Revision-Date: 2025-09-04 22:20\n"
 "Last-Translator: \n"
 "Language-Team: Hebrew\n"
@@ -10,7 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Crowdin-Project: princeton-geniza-project\n"
 "X-Crowdin-Project-ID: 520356\n"
 "X-Crowdin-Language: he\n"
@@ -111,7 +112,7 @@ msgstr "תיאור"
 #. Translators: label for "has translation" search form filter
 #: corpus/forms.py:277 corpus/forms.py:323
 #: corpus/templates/corpus/snippets/document_transcription.html:71
-#: footnotes/models.py:508
+#: footnotes/models.py:500
 msgid "Translation"
 msgstr "תרגום"
 
@@ -141,7 +142,6 @@ msgstr ""
 
 #. Translators: label for document type search form filter
 #: corpus/forms.py:311
-#| msgid "Input date"
 msgid "Document type"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgid "Image"
 msgstr ""
 
 #. Translators: label for "has discussion" search form filter
-#: corpus/forms.py:327 footnotes/models.py:509
+#: corpus/forms.py:327 footnotes/models.py:501
 msgid "Discussion"
 msgstr "דיון"
 
@@ -171,7 +171,6 @@ msgstr ""
 
 #. Translators: label for "search mode" (general or regex)
 #: corpus/forms.py:344
-#| msgid "Search Documents"
 msgid "Search mode"
 msgstr ""
 
@@ -179,71 +178,95 @@ msgstr ""
 msgid "RegEx search field"
 msgstr ""
 
-#: corpus/forms.py:386
+#: corpus/forms.py:367
+msgid ""
+"Error retrieving search results. Check regular expression for errors such as "
+"unescaped or unclosed brackets or parentheses. Regular expression may also "
+"be too complex to compute. If using numeric ranges such as {0,19}, consider "
+"using * (match 0 or more times) or + (match one or more times) instead."
+msgstr ""
+
+#: corpus/forms.py:394
 msgid "Search by regular expression"
 msgstr ""
 
 #. Translators: Default label when document does not have a type
-#: corpus/forms.py:394 corpus/models.py:1089 corpus/solr_queryset.py:342
+#: corpus/forms.py:402 corpus/models.py:1092 corpus/solr_queryset.py:342
 #: corpus/templates/corpus/snippets/document_header.html:17
 #: corpus/templates/corpus/snippets/document_transcription.html:243
-#: entities/views.py:425
+#: entities/views.py:426
 msgid "Unknown type"
 msgstr "סוג לא ידוע"
 
-#: corpus/forms.py:441
+#: corpus/forms.py:449
 msgid "Relevance sort is not available without a keyword search term."
 msgstr "מיון על פי רלוונטיות אינו זמין ללא מילת מפתח לחיפוש."
 
-#: corpus/forms.py:457
+#: corpus/forms.py:464
 #, python-format
-msgid "Regular expression cannot contain { without a preceding character, without an integer afterwards, or without a closing }. %s"
+msgid ""
+"Regular expression cannot contain { without a preceding character, without "
+"an integer afterwards, or without a closing }. %s"
 msgstr ""
 
-#: corpus/forms.py:466
+#: corpus/forms.py:473
 #, python-format
-msgid "Regular expression cannot contain * without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain * without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:475
+#: corpus/forms.py:482
 #, python-format
-msgid "Regular expression cannot contain + without a preceding character, or multiple times in a row. %s"
+msgid ""
+"Regular expression cannot contain + without a preceding character, or "
+"multiple times in a row. %s"
 msgstr ""
 
-#: corpus/forms.py:484
+#: corpus/forms.py:491
 #, python-format
-msgid "Regular expression cannot contain < or use a negative lookbehind query. %s"
+msgid ""
+"Regular expression cannot contain < or use a negative lookbehind query. %s"
 msgstr ""
 
-#: corpus/forms.py:494
+#: corpus/forms.py:501
 #, python-format
-msgid "Regular expression cannot contain the escape character \\ followed by an alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgid ""
+"Regular expression cannot contain the escape character \\ followed by an "
+"alphanumeric character other than one of DdSsWw, or at the end of a query. %s"
+msgstr ""
+
+#: corpus/forms.py:514
+#, python-format
+msgid ""
+"Regular expression cannot contain nested quantifiers, such as *{0,1} or +*. "
+"%s (or \\*, \\?, \\{, \\} for those characters)"
 msgstr ""
 
 #. Translators: accessibility label for permanent link to a document
 #. Translators: accessibility label for permanent link to a person
-#: corpus/models.py:829 entities/templates/entities/person_detail.html:150
+#: corpus/models.py:832 entities/templates/entities/person_detail.html:150
 msgid "Permalink"
 msgstr "קישור קבוע"
 
-#: corpus/models.py:1214 templates/base.html:21
+#: corpus/models.py:1217 templates/base.html:21
 msgid "Princeton Geniza Project"
 msgstr "Princeton Geniza Project"
 
 #. Translators: attribution for local IIIF manifests
-#: corpus/models.py:1216
+#: corpus/models.py:1219
 #, python-format
 msgid "Compilation by %(pgp)s."
 msgstr "קובץ על-ידי %(pgp)s."
 
 #. Translators: attribution for local IIIF manifests that include transcription
-#: corpus/models.py:1219
+#: corpus/models.py:1222
 #, python-format
 msgid "Compilation and transcription by %(pgp)s."
 msgstr "קובץ ותועתק על-ידי %(pgp)s."
 
 #. Translators: manifest attribution note that content from other institutions may have restrictions
-#: corpus/models.py:1221
+#: corpus/models.py:1224
 msgid "Additional restrictions may apply."
 msgstr "ייתכנו מגבלות נוספות."
 
@@ -407,7 +430,8 @@ msgstr "תאריך קלט"
 #. Translators: Date document was first added to the PGP
 #: corpus/templates/corpus/document_detail.html:273
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "                    In PGP since %(date)s\n"
 "                "
 msgstr ""
@@ -450,8 +474,10 @@ msgid "in"
 msgstr ""
 
 #: corpus/templates/corpus/document_list.html:59
-msgid "\n"
-"                            Case sensitive, must match entire shelfmark. Type one shelfmark,\n"
+msgid ""
+"\n"
+"                            Case sensitive, must match entire shelfmark. "
+"Type one shelfmark,\n"
 "                            even if part of a join, for best results.\n"
 "                        "
 msgstr ""
@@ -539,13 +565,11 @@ msgid "Jewish Theological Seminary logo"
 msgstr "סמל Jewish Theological Seminary"
 
 #: corpus/templates/corpus/snippets/document_result.html:23
-#| msgid "Input date"
 msgid "Document date"
 msgstr ""
 
 #. Translators: label for inferred date on a document
 #: corpus/templates/corpus/snippets/document_result.html:33
-#| msgid "Input date"
 msgid "Inferred date"
 msgstr ""
 
@@ -563,7 +587,6 @@ msgstr[3] ""
 #: entities/forms.py:221 entities/forms.py:358
 #: entities/templates/entities/person_list.html:211
 #: entities/templates/entities/snippets/place_results.html:27
-#| msgid "Search Documents"
 msgid "Related Documents"
 msgstr ""
 
@@ -644,8 +667,10 @@ msgstr ""
 
 #. Translators: general search help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:7
-msgid "\n"
-"        Use keywords or phrases in any language to return matching or similar\n"
+msgid ""
+"\n"
+"        Use keywords or phrases in any language to return matching or "
+"similar\n"
 "        results across all fields. Arabic script searches will return both\n"
 "        Arabic and Judaeo-Arabic transcription content.\n"
 "    "
@@ -659,7 +684,8 @@ msgstr ""
 #. Translators: regular expressions search mode help text
 #: corpus/templates/corpus/snippets/document_search_helptext.html:18
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "        Use Hebrew or Arabic script to find precise matches in the\n"
 "        transcriptions. See\n"
 "        <a data-turbo=\"false\" href=\"%(howto_url)s\">How to Search</a>\n"
@@ -674,10 +700,13 @@ msgstr ""
 
 #. Translators: regular expression tip 1
 #: corpus/templates/corpus/snippets/document_search_helptext.html:31
-msgid "\n"
+msgid ""
+"\n"
 "            If you're looking for a word with one missing letter, use a\n"
-"            period. Two missing letters, use two periods or <code>{2}</code>.\n"
-"            Increase the number in the curly brackets to increase the number of\n"
+"            period. Two missing letters, use two periods or <code>{2}</"
+"code>.\n"
+"            Increase the number in the curly brackets to increase the number "
+"of\n"
 "            characters, or insert a range with a comma in between, ex.\n"
 "            <code>{0,5}</code>.\n"
 "        "
@@ -685,7 +714,8 @@ msgstr ""
 
 #. Translators: regular expression tip 2
 #: corpus/templates/corpus/snippets/document_search_helptext.html:41
-msgid "\n"
+msgid ""
+"\n"
 "            If you don't know how many characters are missing, use\n"
 "            <code>.*</code>.\n"
 "        "
@@ -693,8 +723,10 @@ msgstr ""
 
 #. Translators: regular expression tip 3
 #: corpus/templates/corpus/snippets/document_search_helptext.html:48
-msgid "\n"
-"            If you know which characters you want, use square brackets to find\n"
+msgid ""
+"\n"
+"            If you know which characters you want, use square brackets to "
+"find\n"
 "            multiple spellings, ex. <code>[יו]</code> for yud or vav.\n"
 "        "
 msgstr ""
@@ -806,37 +838,32 @@ msgstr "הבא"
 
 #. Translators: title of document search page
 #. Translators: label for link to document search page in main navigation
-#: corpus/views.py:82 templates/snippets/menu.html:11
-#| msgid "Input date"
+#: corpus/views.py:87 templates/snippets/menu.html:11
 msgid "Documents"
 msgstr "מסמכים"
 
 #. Translators: description of document search page, for search engines
-#: corpus/views.py:84
+#: corpus/views.py:89
 msgid "Search and browse Geniza documents."
 msgstr "חיפוש וצפיה במסמכי הגניזה."
 
-#: corpus/views.py:337 entities/views.py:874
+#: corpus/views.py:342 entities/views.py:875
 #, python-format
 msgid "After %s"
 msgstr ""
 
-#: corpus/views.py:339 entities/views.py:876
+#: corpus/views.py:344 entities/views.py:877
 #, python-format
 msgid "Before %s"
 msgstr ""
 
-#: corpus/views.py:410
-msgid "Error retrieving search results. Check regular expression for errors such as unescaped or unclosed brackets or parentheses."
-msgstr ""
-
 #. Translators: title of document scholarship page
-#: corpus/views.py:545
+#: corpus/views.py:546
 #, python-format
 msgid "Scholarship on %(doc)s"
 msgstr "רשומה קשורה ל-%(doc)s"
 
-#: corpus/views.py:552
+#: corpus/views.py:553
 #, python-format
 msgid "%(count)d scholarship record"
 msgid_plural "%(count)d scholarship records"
@@ -846,12 +873,12 @@ msgstr[2] "%(count)d רשומות קשורות"
 msgstr[3] "%(count)d רשומות קשורות"
 
 #. Translators: title of related documents page
-#: corpus/views.py:593
+#: corpus/views.py:594
 #, python-format
 msgid "Related documents for %(doc)s"
 msgstr "מסמכים קשורים %(doc)s"
 
-#: corpus/views.py:600 entities/views.py:347
+#: corpus/views.py:601 entities/views.py:348
 #, python-format
 msgid "%(count)d related document"
 msgid_plural "%(count)d related documents"
@@ -878,7 +905,7 @@ msgstr ""
 msgid "Gender"
 msgstr ""
 
-#: entities/forms.py:206 entities/views.py:890
+#: entities/forms.py:206 entities/views.py:891
 msgid "Detail page available"
 msgstr ""
 
@@ -1061,7 +1088,8 @@ msgstr ""
 #. Translators: range of search results on the current page, out of total
 #: entities/templates/entities/person_list.html:230
 #, python-format
-msgid "\n"
+msgid ""
+"\n"
 "            <div>%(start)s – %(end)s of %(count_humanized)s</div>\n"
 "        "
 msgstr ""
@@ -1171,7 +1199,6 @@ msgstr ""
 
 #. Translators: table header for document name (shelfmark)
 #: entities/templates/entities/snippets/related_documents_table.html:10
-#| msgid "Input date"
 msgid "Document"
 msgstr ""
 
@@ -1181,18 +1208,18 @@ msgid "Type"
 msgstr ""
 
 #. Translators: title of entity "related documents" page
-#: entities/views.py:341
+#: entities/views.py:342
 #, python-format
 msgid "Related documents for %(p)s"
 msgstr ""
 
 #. Translators: title of entity "related people" page
-#: entities/views.py:547
+#: entities/views.py:548
 #, python-format
 msgid "Related people for %(p)s"
 msgstr ""
 
-#: entities/views.py:555 entities/views.py:626
+#: entities/views.py:556 entities/views.py:627
 #, python-format
 msgid "%(count)d related person"
 msgid_plural "%(count)d related people"
@@ -1202,12 +1229,12 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: title of person "related places" page
-#: entities/views.py:685
+#: entities/views.py:686
 #, python-format
 msgid "Related places for %(p)s"
 msgstr ""
 
-#: entities/views.py:693
+#: entities/views.py:694
 #, python-format
 msgid "%(count)d related place"
 msgid_plural "%(count)d related places"
@@ -1218,28 +1245,28 @@ msgstr[3] ""
 
 #. Translators: title of people list/browse page
 #. Translators: label for link to people browse page in main navigation
-#: entities/views.py:799 templates/snippets/menu.html:19
+#: entities/views.py:800 templates/snippets/menu.html:19
 msgid "People"
 msgstr "אנשים"
 
 #. Translators: description of people list/browse page
-#: entities/views.py:801
+#: entities/views.py:802
 msgid "Browse people present in Geniza documents."
 msgstr ""
 
 #. Translators: title of places list/browse page
 #. Translators: label for link to places browse page in main navigation
-#: entities/views.py:1000 templates/snippets/menu.html:26
+#: entities/views.py:1001 templates/snippets/menu.html:26
 msgid "Places"
 msgstr "מקומות"
 
 #. Translators: description of places list/browse page
-#: entities/views.py:1002
+#: entities/views.py:1003
 msgid "Browse places present in Geniza documents."
 msgstr ""
 
 #. Translators: number of results
-#: entities/views.py:1126
+#: entities/views.py:1127
 #, python-format
 msgid "%(count)d result"
 msgid_plural "%(count)d results"
@@ -1249,7 +1276,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. Translators: number of places
-#: entities/views.py:1130
+#: entities/views.py:1131
 #, python-format
 msgid "%(count)d place"
 msgid_plural "%(count)d places"
@@ -1258,18 +1285,26 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: footnotes/models.py:507
+#: footnotes/models.py:499
 msgid "Edition"
 msgstr "מהדורה"
 
 #: pages/models.py:13
-msgid "Alternative text for visually impaired users to\n"
+msgid ""
+"Alternative text for visually impaired users to\n"
 "briefly communicate the intended message of the image in this context."
-msgstr "טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום בהקשר זה."
+msgstr ""
+"טקסט אלטרנטיבי למשתמשים כבדי ראייה שמטרתו להעביר בתמצית את המסר של התצלום "
+"בהקשר זה."
 
 #: pages/models.py:44
-msgid "This text will only be read to     non-sighted users and should describe the major insights or     takeaways from the graphic. Multiple paragraphs are allowed."
-msgstr "טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
+msgid ""
+"This text will only be read to     non-sighted users and should describe the "
+"major insights or     takeaways from the graphic. Multiple paragraphs are "
+"allowed."
+msgstr ""
+"טקסט זה יוקרא למשתמשים עיוורים בלבד ותכליתו לתאר את התובנות והמסרים המרכזיים "
+"שעולים מהתוכן הגרפי. ניתן לכלול מספר פסקאות."
 
 #. Translators: title for Not Found (404) error page
 #: templates/404.html:5 templates/404.html:13
@@ -1385,7 +1420,7 @@ msgid "Princeton Center for Digital Humanities homepage"
 msgstr "Princeton Center for Digital Humanities עמוד הבית"
 
 #. Translators: label for language choices in navigation
-#: templates/snippets/language_switcher.html:11
+#: templates/snippets/language_switcher.html:9
 #, python-format
 msgid "read this page in %(language_name)s (%(language_code)s)"
 msgstr "קריאת העמוד ב-%(language_name)s (%(language_code)s)"
@@ -1400,3 +1435,14 @@ msgstr "חזרה לתפריט הראשי"
 msgid "Enable dark mode"
 msgstr "הפעלת מצב כהה"
 
+#. Translators: title for solr Service Outage (503) error page
+#: templates/solr_error.html:5 templates/solr_error.html:19
+msgid "Service Outage"
+msgstr ""
+
+#. Translators: description for solr Service Outage (503) error page
+#: templates/solr_error.html:7 templates/solr_error.html:20
+msgid ""
+"The application server was unable to reach the Solr service. This is a "
+"temporary service disruption, and site administrators are working on a fix."
+msgstr ""

--- a/geniza/templates/solr_error.html
+++ b/geniza/templates/solr_error.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{# Translators: title for solr Service Outage (503) error page #}
+{% block meta_title %}{% translate "Service Outage" %}{% endblock meta_title %}
+{# Translators: description for solr Service Outage (503) error page #}
+{% block meta_description %}{% translate "The application server was unable to reach the Solr service. This is a temporary service disruption, and site administrators are working on a fix." %}{% endblock meta_description %}
+
+{% block page_type %}error{% endblock %}
+
+{% block body %}
+    {% with skip_nav=1 %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock %}
+
+{# "translate" tags need to be duplicated since these are in separate blocks #}
+{% block main %}
+    <h1 class="e500">{% translate "Service Outage" %}</h1>
+    <p>{% translate "The application server was unable to reach the Solr service. This is a temporary service disruption, and site administrators are working on a fix." %}</p>
+{% endblock %}


### PR DESCRIPTION
**Associated Issue(s):** #1819

### Changes in this PR

- Show a custom error message when Solr is unreachable in views that use it (Documents, People, Places searches; Document and Person admin list views)
   - Use the first encountered solr call (date aggregation with `get_stats()` on public search pages; `get_results()` call on admin list view searches) to handle connection errors
   - Reroute to new custom error template with a 503 error code

### Notes

- We will need to think through how to test this on the staging server. Maybe we coordinate with QA testers and infra folks and designate a time to briefly take the staging Solr servers offline?
- This assumes the solr outage conditions will match what I see locally when I turn off solr; namely, a `ConnectionError` is raised by parasolr.
   - If it's different, hopefully we can observe the real behavior in testing.

### Reviewer Checklist

If testing locally:
- [x] You will need to set `DEBUG = False` in your `local_settings.py` to see the error page, and run the software with `./manage.py runserver --insecure` to see static assets on it.
   - [x] You may also need to `npm run build` and `./manage.py collectstatic`.
   - [x] Then, turn off your local solr service and visit the application search pages to see the error message.
- [x] It's recommended to turn `DEBUG = True` back on after this.
- [x] In order for automated unit tests to run, the solr service must be back up and running.
