### PR TITLE
Only reindex docs on doctype en changes (#1189)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -801,6 +801,15 @@ class DocumentTypeAdmin(TabbedTranslationAdmin, admin.ModelAdmin):
     class Media:
         css = {"all": ("css/admin-local.css",)}
 
+    def save_model(self, request, obj, form, change):
+        """Override to pass update_fields along to signal handlers, for control over
+        related document indexing"""
+        if change:
+            update_fields = form.changed_data
+            obj.save(update_fields=update_fields)
+        else:
+            obj.save()
+
 
 @admin.register(Fragment)
 class FragmentAdmin(admin.ModelAdmin):

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -511,6 +511,20 @@ class DocumentSignalHandlers:
         # delegate to common method
         DocumentSignalHandlers.related_change(instance, raw, "delete")
 
+    @staticmethod
+    def related_save_doctype(
+        sender, instance=None, raw=False, update_fields=None, **_kwargs
+    ):
+        """reindex associated documents when a related DocumentType is saved"""
+        # for document type, if updating, only reindex docs if name_en or display_label_en updated
+        if (
+            not update_fields
+            or "name_en" in update_fields
+            or "display_label_en" in update_fields
+        ):
+            # delegate to common method
+            DocumentSignalHandlers.related_change(instance, raw, "save")
+
 
 class TagSignalHandlers:
     """Signal handlers for :class:`taggit.Tag` records."""
@@ -1559,7 +1573,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             "pre_delete": DocumentSignalHandlers.related_delete,
         },
         "doctype": {
-            "post_save": DocumentSignalHandlers.related_save,
+            "post_save": DocumentSignalHandlers.related_save_doctype,
             "pre_delete": DocumentSignalHandlers.related_delete,
         },
         "textblock_set": {


### PR DESCRIPTION
**Associated Issue(s):** #1189

### Changes in this PR

Per #1189:
- In order to prevent unnecessary indexing of thousands of documents, prevent documents from automated reindexing when all that has changed is a Hebrew/Arabic translated name or display label for a `DocumentType` instance
   - (This is because only `name_en` or `display_label_en` are indexed into Solr, and the other labels/names are resolved from the original model instance at runtime when needed)
