### PR TITLE
Auto-populate fragment IIIF URLs from view URL when possible (#848)

### DIFF
--- a/geniza/corpus/management/commands/add_fragment_urls.py
+++ b/geniza/corpus/management/commands/add_fragment_urls.py
@@ -68,21 +68,6 @@ class Command(BaseCommand):
         self.stdout.write(f"Fragments not found: {self.stats['not_found']}")
         self.stdout.write(f"Fragments skipped: {self.stats['skipped']}")
 
-    def view_to_iiif_url(self, url):
-        """Generate IIIF Manifest URL based on view url, if it can
-        be determined automatically"""
-
-        # cambridge iiif manifest links use the same id as view links
-        # NOTE: should exclude search link like this one:
-        # https://cudl.lib.cam.ac.uk/search?fileID=&keyword=T-s%2013J33.12&page=1&x=0&y=
-        if "cudl.lib.cam.ac.uk/view/" in url:
-            iiif_link = url.replace("/view/", "/iiif/")
-            # view links end with /1 or /2 but iiif link does not include it
-            iiif_link = re.sub(r"/\d$", "", iiif_link)
-            return iiif_link
-
-        return ""
-
     def add_fragment_urls(self, row):
         """add view and iiif urls to fragment and save if a match is found for the shelfmark"""
         try:
@@ -101,7 +86,7 @@ class Command(BaseCommand):
             return
 
         url = row.get("url")
-        iiif_url = row.get("iiif_url") or self.view_to_iiif_url(row["url"])
+        iiif_url = row.get("iiif_url") or Fragment.view_to_iiif_url(row["url"])
         save_needed = False
         log_message = []
 

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -392,14 +392,25 @@ class Fragment(TrackChangesModel):
         """Generate IIIF Manifest URL based on view url, if it can
         be determined automatically"""
 
-        # cambridge iiif manifest links use the same id as view links
-        # NOTE: should exclude search link like this one:
-        # https://cudl.lib.cam.ac.uk/search?fileID=&keyword=T-s%2013J33.12&page=1&x=0&y=
-        if "cudl.lib.cam.ac.uk/view/" in url:
+        if (
+            "cudl.lib.cam.ac.uk/view/" in url
+            or "digitalcollections.manchester.ac.uk/view/" in url
+        ):
+            # cambridge (and manchester digital collections) iiif manifest
+            # links use the same id as view links
+            # NOTE: should exclude search link like this one:
+            # https://cudl.lib.cam.ac.uk/search?fileID=&keyword=T-s%2013J33.12
             iiif_link = url.replace("/view/", "/iiif/")
             # view links end with /1 or /2 but iiif link does not include it
             return re.sub(r"/\d$", "", iiif_link)
-
+        elif "colenda.library.upenn.edu/catalog/" in url:
+            # UPenn view links are /catalog/81431-p3891287r
+            # and iiif links are /items/ark:/81431/p3891287r
+            return re.sub(
+                r"/catalog/([A-Za-z0-9]+)-([A-Za-z0-9]+)$",
+                r"/items/ark:/\1/\2/manifest",
+                url,
+            )
         return ""
 
     def save(self, *args, **kwargs):

--- a/geniza/corpus/tests/test_add_fragment_urls.py
+++ b/geniza/corpus/tests/test_add_fragment_urls.py
@@ -101,22 +101,6 @@ def test_handle_file_not_found():
 
 
 @pytest.mark.django_db
-def test_view_to_iiif_url():
-    command = add_fragment_urls.Command()
-    assert (
-        command.view_to_iiif_url("https://cudl.lib.cam.ac.uk/view/MS-ADD-02586")
-        == "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-02586"
-    )
-
-    assert (
-        command.view_to_iiif_url("https://cudl.lib.cam.ac.uk/view/MS-ADD-03430/1")
-        == "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-03430"
-    )
-
-    assert command.view_to_iiif_url("https://example.com/iiif/1234") == ""
-
-
-@pytest.mark.django_db
 @patch("geniza.corpus.management.commands.add_fragment_urls.Command.log_change")
 @patch("geniza.corpus.models.GenizaManifestImporter", MockImporter)
 def test_add_fragment_urls(mock_log_change):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -382,6 +382,25 @@ class TestFragment(TestCase):
         frag.save()
         assert frag.iiif_url == ""
 
+        # test manchester digital collections
+        frag.url = (
+            "https://www.digitalcollections.manchester.ac.uk/view/MS-GENIZAH-A-00897/1"
+        )
+        frag.save()
+        assert (
+            frag.iiif_url
+            == "https://www.digitalcollections.manchester.ac.uk/iiif/MS-GENIZAH-A-00897"
+        )
+
+        # test upenn
+        frag.iiif_url = ""
+        frag.url = "https://colenda.library.upenn.edu/catalog/81431-p3891287r"
+        frag.save()
+        assert (
+            frag.iiif_url
+            == "https://colenda.library.upenn.edu/items/ark:/81431/p3891287r/manifest"
+        )
+
     @pytest.mark.django_db
     @patch("geniza.corpus.models.GenizaManifestImporter")
     def test_save_import_manifest(self, mock_manifestimporter):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -363,6 +363,25 @@ class TestFragment(TestCase):
             frag.old_shelfmarks.split(";")
         )
 
+        # mock a real manifest import; test view_to_iiif_url
+        mock_manifestimporter.return_value.import_paths.return_value = [
+            Manifest.objects.create(
+                uri="https://iiif.example.com/TS16.377", short_id="m2"
+            )
+        ]
+        frag.iiif_url = ""
+        frag.url = "https://cudl.lib.cam.ac.uk/view/MS-ADD-02586"
+        frag.save()
+        assert frag.iiif_url == "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-02586"
+        frag.iiif_url = ""
+        frag.url = "https://cudl.lib.cam.ac.uk/view/MS-ADD-03430/1"
+        frag.save()
+        assert frag.iiif_url == "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-03430"
+        frag.iiif_url = ""
+        frag.url = "https://example.com/iiif/1234"
+        frag.save()
+        assert frag.iiif_url == ""
+
     @pytest.mark.django_db
     @patch("geniza.corpus.models.GenizaManifestImporter")
     def test_save_import_manifest(self, mock_manifestimporter):
@@ -1097,6 +1116,7 @@ class TestDocument:
         assert document.has_image()
 
         # remove IIIF url from fragment; doc should no longer have image
+        fragment.url = ""
         fragment.iiif_url = ""
         fragment.save()
         assert not document.has_image()

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -1521,6 +1521,7 @@ class TestDocumentManifestView:
         fragment,
     ):
         # fixture document fragment has iiif, so remove it to test
+        fragment.url = ""
         fragment.iiif_url = ""
         fragment.save()
         # no iiif or transcription; should 404
@@ -1632,6 +1633,7 @@ class TestDocumentManifestView:
         fragment,
     ):
         # remove iiif url from fixture document fragment has iiif
+        fragment.url = ""
         fragment.iiif_url = ""
         fragment.save()
         # add a footnote with transcription content
@@ -1708,6 +1710,7 @@ class TestDocumentAnnotationListView:
         self, mockiifpres, client, document, source, fragment
     ):
         # remove iiif url from fixture document fragment has iiif
+        fragment.url = ""
         fragment.iiif_url = ""
         fragment.save()
         # add a footnote with transcription content


### PR DESCRIPTION
**Associated Issue(s):** #848

### Changes in this PR

- Migrate the `view_to_iiif_url` logic from `add_fragment_urls` to the `Fragment` class
- Run it on any Fragment save where the URL is set and the IIIF URL is not
- Add specs for auto-populating the UPenn and Manchester (digital collections, not Luna) IIIF URLs as well

### Notes

- Unrelated unit tests using the `fragment` Pytest fixture (via the `document` fixture) that were setting `iiif_url = ""` had to be updated to blank out the view URL as well, because otherwise the IIIF URL would be auto-repopulated. This is because it just so happened that the view URL was a valid CUDL URL that matches our spec, triggering the conversion logic on save.