### PR TITLE
Allow Place records to be merged (#1906)

### DIFF
--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -323,8 +323,95 @@ class PersonSignalHandlers:
         PersonSignalHandlers.related_change(instance, raw, "delete")
 
 
+class EntityMergeMixin:
+    """Reusable mixin for merging entities"""
+
+    def _merge_related(
+        self,
+        entity,
+        entity_name,
+        related_model_name,
+        related_manager_name,
+        reverse_field,
+        self_referential=False,
+        has_type=True,
+    ):
+        # reassociate related documents, places, people, and events
+        # (originally Person._merge_related)
+
+        # iterate through the join table to preserve metadata on the joins (type, notes)
+        primary_entity_relations = getattr(self, related_manager_name).all()
+        merge_entity_relations = getattr(entity, related_manager_name).all()
+        if self_referential:
+            # prevent self-self relationship from being created during merge
+            merge_entity_relations = merge_entity_relations.exclude(
+                **{f"{related_model_name}__pk": self.pk}
+            )
+        for relation in merge_entity_relations:
+            # filter existing relationships to find a match
+            filter_kwargs = {related_model_name: getattr(relation, related_model_name)}
+            if has_type:
+                # on person, document, and place, match by relation type as well
+                filter_kwargs.update({"type": relation.type})
+            same_relation = primary_entity_relations.filter(**filter_kwargs)
+            if same_relation.exists():
+                # if a relationship already exists, combine the notes
+                existing_rel = same_relation.first()
+                if relation.notes and relation.notes not in existing_rel.notes:
+                    existing_rel.notes = "\n".join(
+                        note
+                        for note in [
+                            existing_rel.notes,
+                            "Notes from merged record %s: %s"
+                            % (entity_name, relation.notes),
+                        ]
+                        if note  # filter out empty strings
+                    )
+                    existing_rel.save()
+            else:
+                # otherwise simply reassign the relationship to the primary entity
+                setattr(relation, reverse_field, self)
+                relation.save()
+
+    def _merge_logentries(self, entity, entity_type):
+        # reassociate log entries; logic for merge_with
+        # make a list of currently associated log entries to skip duplicates
+        current_logs = [
+            "%s_%s" % (le.user_id, le.action_time.isoformat())
+            for le in self.log_entries.all()
+        ]
+        for log_entry in entity.log_entries.all():
+            # check duplicate log entries, based on user id and time
+            # (likely only applies to historic input & revision)
+            if (
+                "%s_%s" % (log_entry.user_id, log_entry.action_time.isoformat())
+                in current_logs
+            ):
+                # skip if it's a duplicate
+                continue
+
+            # otherwise annotate and reassociate
+            # - modify change message to entity which object this event applied to
+            log_entry.change_message = "%s [merged %s %s (id = %d)]" % (
+                log_entry.change_message,
+                entity_type.__name__,
+                str(entity),
+                entity.pk,
+            )
+
+            # - associate with the primary entity
+            log_entry.object_id = self.id
+            log_entry.content_type_id = ContentType.objects.get_for_model(entity_type)
+            log_entry.save()
+
+
 class Person(
-    ModelIndexable, SlugMixin, DocumentDatableMixin, PermalinkMixin, TaggableMixin
+    ModelIndexable,
+    EntityMergeMixin,
+    SlugMixin,
+    DocumentDatableMixin,
+    PermalinkMixin,
+    TaggableMixin,
 ):
     """A person entity that appears within the PGP corpus."""
 
@@ -368,7 +455,7 @@ class Person(
     # sources for the information gathered here
     footnotes = GenericRelation(Footnote, blank=True, related_name="people")
 
-    log_entries = GenericRelation(LogEntry, related_query_name="document")
+    log_entries = GenericRelation(LogEntry, related_query_name="person")
 
     tags = TaggableManager(blank=True, related_name="tagged_person")
 
@@ -751,7 +838,7 @@ class Person(
                 )
 
             # combine log entries (before name, since name used in log entries)
-            self._merge_logentries(person)
+            self._merge_logentries(person, Person)
 
             # combine names
             for name in person.names.all():
@@ -793,11 +880,26 @@ class Person(
             )
             # combine person-document, person-place, person-event relationships
             self._merge_related(
-                person, person_name, "document", "persondocumentrelation_set"
+                person,
+                person_name,
+                "document",
+                "persondocumentrelation_set",
+                reverse_field="person",
             )
-            self._merge_related(person, person_name, "place", "personplacerelation_set")
             self._merge_related(
-                person, person_name, "event", "personeventrelation_set", has_type=False
+                person,
+                person_name,
+                "place",
+                "personplacerelation_set",
+                reverse_field="person",
+            )
+            self._merge_related(
+                person,
+                person_name,
+                "event",
+                "personeventrelation_set",
+                reverse_field="person",
+                has_type=False,
             )
 
             # combine footnotes
@@ -838,83 +940,6 @@ class Person(
             change_message="merged with %s" % (", ".join(merge_people_names),),
             action_flag=CHANGE,
         )
-
-    def _merge_logentries(self, person):
-        # reassociate log entries; logic for merge_with
-        # make a list of currently associated log entries to skip duplicates
-        current_logs = [
-            "%s_%s" % (le.user_id, le.action_time.isoformat())
-            for le in self.log_entries.all()
-        ]
-        for log_entry in person.log_entries.all():
-            # check duplicate log entries, based on user id and time
-            # (likely only applies to historic input & revision)
-            if (
-                "%s_%s" % (log_entry.user_id, log_entry.action_time.isoformat())
-                in current_logs
-            ):
-                # skip if it's a duplicate
-                continue
-
-            # otherwise annotate and reassociate
-            # - modify change message to person which object this event applied to
-            log_entry.change_message = "%s [merged person %s (id = %d)]" % (
-                log_entry.change_message,
-                str(person),
-                person.pk,
-            )
-
-            # - associate with the primary person
-            log_entry.object_id = self.id
-            log_entry.content_type_id = ContentType.objects.get_for_model(Person)
-            log_entry.save()
-
-    def _merge_related(
-        self,
-        person,
-        person_name,
-        related_model_name,
-        related_manager_name,
-        reverse_field="person",
-        self_referential=False,
-        has_type=True,
-    ):
-        # reassociate related documents, places, people, and events
-        # (adapted from Document._merge_entities)
-
-        # iterate through the join table to preserve metadata on the joins (type, notes)
-        primary_person_relations = getattr(self, related_manager_name).all()
-        merge_person_relations = getattr(person, related_manager_name).all()
-        if self_referential:
-            # prevent self-self relationship from being created during merge
-            merge_person_relations = merge_person_relations.exclude(
-                **{f"{related_model_name}__pk": self.pk}
-            )
-        for relation in merge_person_relations:
-            # filter existing relationships to find a match
-            filter_kwargs = {related_model_name: getattr(relation, related_model_name)}
-            if has_type:
-                # on person, document, and place, match by relation type as well
-                filter_kwargs.update({"type": relation.type})
-            same_relation = primary_person_relations.filter(**filter_kwargs)
-            if same_relation.exists():
-                # if a relationship already exists, combine the notes
-                existing_rel = same_relation.first()
-                if relation.notes and relation.notes not in existing_rel.notes:
-                    existing_rel.notes = "\n".join(
-                        note
-                        for note in [
-                            existing_rel.notes,
-                            "Notes from merged record %s: %s"
-                            % (person_name, relation.notes),
-                        ]
-                        if note  # filter out empty strings
-                    )
-                    existing_rel.save()
-            else:
-                # otherwise simply reassign the relationship to the primary person
-                setattr(relation, reverse_field, self)
-                relation.save()
 
     @classmethod
     def total_to_index(cls):
@@ -1469,7 +1494,7 @@ class PlaceSignalHandlers:
         PlaceSignalHandlers.related_change(instance, raw, "delete")
 
 
-class Place(ModelIndexable, SlugMixin, PermalinkMixin):
+class Place(ModelIndexable, EntityMergeMixin, SlugMixin, PermalinkMixin):
     """A named geographical location, which may be associated with documents or people."""
 
     names = GenericRelation(Name, related_query_name="place")
@@ -1513,6 +1538,7 @@ class Place(ModelIndexable, SlugMixin, PermalinkMixin):
         blank=True,
         help_text="The geographic area containing this place. For internal use and CSV exports only.",
     )
+    log_entries = GenericRelation(LogEntry, related_query_name="place")
 
     def __str__(self):
         """
@@ -1669,6 +1695,125 @@ class Place(ModelIndexable, SlugMixin, PermalinkMixin):
 
         return relation_list
 
+    def merge_with(self, merge_places, user=None):
+        """Merge the specified places into this one. Combines all metadata
+        into this place and creates a log entry documenting the merge.
+
+        Closely adapted from :class:`Person` merge."""
+
+        # if user is not specified, log entry will be associated with script
+        if user is None:
+            user = User.objects.get(username=settings.SCRIPT_USERNAME)
+
+        # collect names as strings (since that's the important part for comparison)
+        self_names = [str(name) for name in self.names.all()]
+        merge_places_names = []
+
+        for place in merge_places:
+            place_name = str(place)
+            merge_places_names.append(place_name)
+            # check for conflicts in is_region
+            if self.is_region != place.is_region:
+                raise ValidationError(
+                    "Merged places must not have conflicting values for 'is region'; resolve before merge"
+                )
+
+            # combine log entries (before name, since name used in log entries)
+            self._merge_logentries(place, Place)
+
+            # combine names
+            for name in place.names.all():
+                if str(name) not in self_names:
+                    # if not duplicated, make non-primary and add
+                    name.primary = False
+                    name.save()
+                    self.names.add(name)
+
+            # if coordinates and containing region unset on primary record, use merged
+            if not self.coordinates and place.coordinates:
+                self.latitude = place.latitude
+                self.longitude = place.longitude
+            if not self.containing_region and place.containing_region:
+                self.containing_region = place.containing_region
+
+            # add notes if set and not duplicated
+            person_notes = place.notes
+            current_notes = self.notes or ""
+            if person_notes and person_notes not in current_notes:
+                self.notes += "\n\nNotes from merged entry:\n%s" % (person_notes,)
+
+            # combine place-place relationships (self-referential M2M relationship)
+            # place_b = added on the form field of place to be merged in
+            self._merge_related(
+                place,
+                place_name,
+                "place_b",
+                "place_b",
+                reverse_field="place_a",
+                self_referential=True,
+            )
+            # place_a = added on the form field of the place on the other side of the relationship
+            self._merge_related(
+                place,
+                place_name,
+                "place_a",
+                "place_a",
+                reverse_field="place_b",
+                self_referential=True,
+            )
+            # combine place-document, place-place, place-event relationships
+            self._merge_related(
+                place,
+                place_name,
+                "document",
+                "documentplacerelation_set",
+                reverse_field="place",
+            )
+            self._merge_related(
+                place,
+                place_name,
+                "person",
+                "personplacerelation_set",
+                reverse_field="place",
+            )
+            self._merge_related(
+                place,
+                place_name,
+                "event",
+                "placeeventrelation_set",
+                reverse_field="place",
+                has_type=False,
+            )
+
+            # combine footnotes
+            for footnote in place.footnotes.all():
+                if not self.footnotes.includes_footnote(footnote):
+                    # if there is not a matching one on this place, can add footnote
+
+                    # first remove any doc relations; place footnotes should not have
+                    # doc_relation anyway, but just in case...
+                    if footnote.doc_relation:
+                        footnote.doc_relation = ""
+                        footnote.save()
+
+                    # then add to this place
+                    self.footnotes.add(footnote)
+
+        # save current place with changes; delete merged places
+        self.save()
+        for place in merge_places:
+            place.delete()
+        # create log entry documenting the merge; include rationale
+        place_contenttype = ContentType.objects.get_for_model(Place)
+        LogEntry.objects.log_action(
+            user_id=user.id,
+            content_type_id=place_contenttype.pk,
+            object_id=self.pk,
+            object_repr=str(self),
+            change_message="merged with %s" % (", ".join(merge_places_names),),
+            action_flag=CHANGE,
+        )
+
     def index_data(self):
         """data for indexing in Solr"""
         index_data = super().index_data()
@@ -1708,6 +1853,10 @@ class Place(ModelIndexable, SlugMixin, PermalinkMixin):
             "pre_delete": PlaceSignalHandlers.related_delete,
         },
     }
+
+
+# attach pre-delete for generic relation to log entries
+pre_delete.connect(detach_logentries, sender=Place)
 
 
 class PlaceSolrQuerySet(EntitySolrQuerySet):

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -1737,10 +1737,10 @@ class Place(ModelIndexable, EntityMergeMixin, SlugMixin, PermalinkMixin):
                 self.containing_region = place.containing_region
 
             # add notes if set and not duplicated
-            person_notes = place.notes
+            place_notes = place.notes
             current_notes = self.notes or ""
-            if person_notes and person_notes not in current_notes:
-                self.notes += "\n\nNotes from merged entry:\n%s" % (person_notes,)
+            if place_notes and place_notes not in current_notes:
+                self.notes += "\n\nNotes from merged entry:\n%s" % (place_notes,)
 
             # combine place-place relationships (self-referential M2M relationship)
             # place_b = added on the form field of place to be merged in

--- a/geniza/entities/templates/admin/entities/place/merge.html
+++ b/geniza/entities/templates/admin/entities/place/merge.html
@@ -1,0 +1,53 @@
+{% extends 'admin/base_site.html' %}
+
+{% load admin_urls static %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+    <link rel="stylesheet" href="{% static "css/admin-local.css" %}">
+{% endblock %}
+
+{% block title %} Merge selected places {% endblock %}
+
+{% block breadcrumbs %}
+    {% if not is_popup %}
+        <div class="breadcrumbs">
+            <a href="{% url 'admin:index' %}">Home</a>
+            &rsaquo;
+            <a href="{% url 'admin:app_list' app_label='entities' %}">Entities</a>
+            &rsaquo;
+            <a href="{% url 'admin:entities_place_changelist'%}">Places</a>
+            &rsaquo;
+            Merge selected places
+        </div>
+    {% endif %}
+{% endblock %}
+
+
+{% block content_title %}
+    <h1>Merge selected places</h1>
+    <h2>Note: there is no automated way to unmerge places! Please review to make sure these places should be merged before submitting the form.</h2>
+{% endblock %}
+
+{% block content %}
+    <form method="post" class="merge-document">
+        {% csrf_token %}
+        {% if form.errors|length > 0 %}
+            <p class="errornote">
+                Please correct the error below.
+            </p>
+        {% endif %}
+        <fieldset class="module aligned">
+            <div class="form-row">
+                {{ form.primary_place.label_tag }}
+                {{ form.primary_place }}
+                <p class="help">{{ form.primary_place.help_text|safe }}</p>
+            </div>
+
+            <div class="submit-row">
+                <input type="submit" value="Submit">
+            </div>
+        </field>
+    </form>
+{% endblock %}

--- a/geniza/entities/templates/entities/snippets/place_option_label.html
+++ b/geniza/entities/templates/entities/snippets/place_option_label.html
@@ -1,0 +1,87 @@
+{# template snippet for displaying place label on a form #}
+{# used on place merge form to provide enough information to merge accurately #}
+
+{% load admin_urls static %}
+
+<div class="merge-document-label">
+    <h2>{{ place }}
+        <a target="_blank" href="{% url 'admin:entities_place_change' place.pk %}"
+           title="Go to this place's admin edit page">
+            <img src="/static/admin/img/icon-changelink.svg" alt="Change"></a>
+    </h2>
+    {% for name in place.names.all %}
+        <div class="form-row">
+            <label>{% if name.primary %}Display n{% else %}N{% endif %}ame ({{ name.language }})</label><div>{{ name }}</div>
+        </div>
+    {% endfor %}
+    <div class="form-row">
+        <label>Is region</label>
+        <div>
+            <img src="
+                      {% if place.is_region %}
+                          {% static 'admin/img/icon-yes.svg' %}
+                      {% else %}
+                          {% static 'admin/img/icon-no.svg' %}
+                      {% endif %}
+                     ">
+        </div>
+    </div>
+    {% if place.coordinates %}
+        <div class="form-row">
+            <label>Coordinates</label><div>{{ place.coordinates }}</div>
+        </div>
+    {% endif %}
+    {% if place.notes %}
+        <div class="form-row">
+            <label>Notes</label><div>{{ place.notes }}</div>
+        </div>
+    {% endif %}
+    {% if place.containing_region %}
+        <div class="form-row">
+            <label>Geographic area</label><div>{{ place.containing_region }}</div>
+        </div>
+    {% endif %}
+    {% for rel in place.documentplacerelation_set.all %}
+        <div class="form-row">
+            <label>Related document</label><div>
+                <a target="_blank" href="{% url 'admin:corpus_document_change' rel.document.pk %}">
+                    {{ rel.document }}</a> ({{ rel.type }})</div>
+        </div>
+    {% endfor %}
+    {% for rel in place.place_a.all %}
+        <div class="form-row">
+            <label>Related place</label>
+            <div>
+                <a target="_blank" href="{% url 'admin:entities_place_change' rel.place_a.pk %}">
+                    {{ rel.place_a }}</a> ({{ rel.type }})
+            </div>
+        </div>
+    {% endfor %}
+    {% for rel in place.place_b.all %}
+        <div class="form-row">
+            {# these should use converse_name, if one exists for the relationship type #}
+            <label>Related place</label>
+            <div>
+                <a target="_blank" href="{% url 'admin:entities_place_change' rel.place_b.pk %}">
+                    {{ rel.place_b }}</a> ({{ rel.type.converse_name|default:rel.type }})
+            </div>
+        </div>
+    {% endfor %}
+    {% for rel in place.personplacerelation_set.all %}
+        <div class="form-row">
+            <label>Related person</label><div>
+                <a target="_blank" href="{% url 'admin:entities_person_change' rel.person.pk %}">
+                    {{ rel.person }}</a> ({{ rel.type }})</div>
+        </div>
+    {% endfor %}
+    {% for event in place.events.all %}
+        <div class="form-row">
+            <label>Related event</label><div><a target="_blank" href="{% url 'admin:entities_event_change' event.pk %}"> {{ event }}</a></div>
+        </div>
+    {% endfor %}
+    {% for footnote in place.footnotes.all %}
+        <div class="form-row">
+            <label>Data source (footnote)</label><div>{{ footnote.source.formatted_display|safe }}</div>
+        </div>
+    {% endfor %}
+</div>

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -536,6 +536,23 @@ class TestPlaceAdmin:
         assert str(person) in content
         assert "Home base" in content
 
+    def test_merge_places(self):
+        mockrequest = Mock()
+        test_ids = ["50344", "33003", "10100"]
+        mockrequest.POST.getlist.return_value = test_ids
+        resp = PlaceAdmin(Place, Mock()).merge_places(mockrequest, Mock())
+        assert isinstance(resp, HttpResponseRedirect)
+        assert resp.status_code == 303
+        assert resp["location"].startswith(reverse("admin:place-merge"))
+        assert resp["location"].endswith("?ids=%s" % ",".join(test_ids))
+
+        test_ids = ["50344"]
+        mockrequest.POST.getlist.return_value = test_ids
+        resp = PlaceAdmin(Place, Mock()).merge_places(mockrequest, Mock())
+        assert isinstance(resp, HttpResponseRedirect)
+        assert resp.status_code == 302
+        assert resp["location"] == reverse("admin:entities_place_changelist")
+
 
 class TestPersonDocumentRelationTypeAdmin:
     def test_merge_person_document_relation_types(self):

--- a/geniza/entities/tests/test_entities_views.py
+++ b/geniza/entities/tests/test_entities_views.py
@@ -35,6 +35,7 @@ from geniza.entities.views import (
     PlaceAutocompleteView,
     PlaceListSnippetView,
     PlaceListView,
+    PlaceMerge,
 )
 
 
@@ -213,6 +214,84 @@ class TestPersonPersonRelationTypeMergeView:
         assert "admin" in resolved_url.app_names
         assert resolved_url.url_name == "entities_personpersonrelationtype_change"
         assert resolved_url.kwargs["object_id"] == str(rel_type.pk)
+
+
+class TestPlaceMergeView:
+    # adapted from TestPersonMergeView
+    @pytest.mark.django_db
+    def test_get_success_url(self):
+        place = Place.objects.create()
+        merge_view = PlaceMerge()
+        merge_view.primary_place = place
+
+        resolved_url = resolve(merge_view.get_success_url())
+        assert "admin" in resolved_url.app_names
+        assert resolved_url.url_name == "entities_place_change"
+        assert resolved_url.kwargs["object_id"] == str(place.pk)
+
+    def test_get_initial(self):
+        merge_view = PlaceMerge()
+        merge_view.request = Mock(GET={"ids": "12,23,456,7"})
+
+        initial = merge_view.get_initial()
+        assert merge_view.place_ids == [12, 23, 456, 7]
+        # lowest id selected as default primary place
+        assert initial["primary_place"] == 7
+
+        # Test when no ids are provided (a user shouldn't get here,
+        # but shouldn't raise an error.)
+        merge_view.request = Mock(GET={"ids": ""})
+        initial = merge_view.get_initial()
+        assert merge_view.place_ids == []
+        merge_view.request = Mock(GET={})
+        initial = merge_view.get_initial()
+        assert merge_view.place_ids == []
+
+    def test_get_form_kwargs(self):
+        merge_view = PlaceMerge()
+        merge_view.request = Mock(GET={"ids": "12,23,456,7"})
+        form_kwargs = merge_view.get_form_kwargs()
+        assert form_kwargs["place_ids"] == merge_view.place_ids
+
+    def test_place_merge(self, admin_client, client):
+        # Ensure that the place merge view is not visible to public
+        response = client.get(reverse("admin:place-merge"))
+        assert response.status_code == 302
+        assert response.url.startswith("/accounts/login/")
+
+        # create test place records to merge
+        place = Place.objects.create()
+        dupe_place = Place.objects.create()
+
+        place_ids = [place.id, dupe_place.id]
+        idstring = ",".join(str(pid) for pid in place_ids)
+
+        # GET should display choices
+        response = admin_client.get(reverse("admin:place-merge"), {"ids": idstring})
+        assert response.status_code == 200
+
+        # POST should merge
+        merge_url = "%s?ids=%s" % (reverse("admin:place-merge"), idstring)
+        response = admin_client.post(
+            merge_url, {"primary_place": place.id}, follow=True
+        )
+        TestCase().assertRedirects(
+            response, reverse("admin:entities_place_change", args=[place.id])
+        )
+        message = list(response.context.get("messages"))[0]
+        assert message.tags == "success"
+        assert "Successfully merged" in message.message
+        assert f"with {str(place)} (id = {place.pk})" in message.message
+
+        with patch.object(Place, "merge_with") as mock_merge_with:
+            # should catch ValidationError and send back to form with error msg
+            mock_merge_with.side_effect = ValidationError("test message")
+            response = admin_client.post(
+                merge_url, {"primary_place": place.id}, follow=True
+            )
+            TestCase().assertRedirects(response, merge_url)
+            messages = [str(msg) for msg in list(response.context["messages"])]
+            assert "test message" in messages
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Associated Issue(s):** #1906

### Changes in this PR

- Allow admins to merge places using a dropdown in the admin list view
- Factor out shared logic between person and place merge features into a mixin, `EntityMergeMixin`