### PR TITLE
Fix admin document date filter regression (#1909)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -286,9 +286,12 @@ class TextInputListFilter(admin.SimpleListFilter):
     def choices(self, changelist):
         # Grab only the "all" option.
         all_choice = next(super().choices(changelist))
+        # handle django 5 changes to get_filters_params, from:
+        # https://gist.github.com/hakib/1491a848e71078dae81fca48c46cc258?permalink_comment_id=5035675#gistcomment-5035675
         all_choice["query_parts"] = (
             (k, v)
-            for k, v in changelist.get_filters_params().items()
+            for k, values in changelist.get_filters_params().items()
+            for v in values
             if k != self.parameter_name
         )
         yield all_choice

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -647,6 +647,11 @@ class TestDateListFilter:
         all_option = next(filter.choices(changelist))
         assert all_option["display"] == "All"
 
+        # should handle list from get_filters_params appropriately
+        changelist.get_filters_params.return_value = {"date__lte": ["1200"]}
+        all_option = next(filter.choices(changelist))
+        assert dict(all_option["query_parts"])["date__lte"] == "1200"
+
     @patch("geniza.corpus.admin.DocumentSolrQuerySet")
     def test_get_queryset_date_after(self, mock_dqs):
         Document.objects.create(doc_date_standard="2000")


### PR DESCRIPTION
**Associated Issue(s):** #1909

### Changes in this PR

- Fix a regression introduced in Django 5 related to our custom `SimpleListFilter`, where values in `get_filters_params()` are now lists