### PR TITLE
Fix SourceAdmin duplicate results (#1911)

### DIFF
--- a/geniza/footnotes/admin.py
+++ b/geniza/footnotes/admin.py
@@ -5,6 +5,7 @@ from django.contrib.admin import SimpleListFilter
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.postgres.aggregates import StringAgg
 from django.db import models
 from django.db.models.fields import TextField
 from django.db.models.functions import Concat
@@ -268,9 +269,13 @@ class SourceAdmin(SortableAdminBase, TabbedTranslationAdmin, admin.ModelAdmin):
                 models.Q(authorship__isnull=True) | models.Q(authorship__sort_order=1)
             )
             .annotate(
-                first_author=Concat(
-                    "authorship__creator__last_name", "authorship__creator__first_name"
-                ),
+                first_author=StringAgg(
+                    Concat(
+                        "authorship__creator__last_name",
+                        "authorship__creator__first_name",
+                    ),
+                    delimiter=", ",
+                )
             )
         )
 


### PR DESCRIPTION
**Associated Issue(s):** #1911

### Changes in this PR

- Fixes a problem where `Concat` was creating duplicate entries for each person in a Source, during computation of the `first_author` sort field (it is used to sort sources by author). 
   - Wraps with `StringAgg` to ensure this result is a single string, rather than multiple values, thus de-duplicating the results.