### PR TITLE
Align transcription and translation list headers (#1917)

### DIFF
--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -165,16 +165,16 @@ export default class extends Controller {
 
     getListHeader(listElement) {
         // given a list, find the nearest H3 before it (and after any prior list)
-        const siblings = [];
         let sibling = listElement.previousElementSibling;
         // iterate through all non-list previous siblings
         while (sibling && sibling.tagName !== "OL") {
-            siblings.push(sibling);
+            if (sibling.tagName === "H3") {
+                // return when we find an H3
+                return sibling;
+            }
             sibling = sibling.previousElementSibling;
         }
-        // get the first H3 in the list (i.e. the nearest previous one)
-        const h3s = siblings.filter((el) => el.tagName === "H3");
-        return h3s.length > 0 ? h3s[0] : null;
+        return null;
     }
 
     alignTops(edElement, trElement) {

--- a/sitemedia/js/controllers/ittpanel_controller.js
+++ b/sitemedia/js/controllers/ittpanel_controller.js
@@ -163,6 +163,39 @@ export default class extends Controller {
         }
     }
 
+    getListHeader(listElement) {
+        // given a list, find the nearest H3 before it (and after any prior list)
+        const siblings = [];
+        let sibling = listElement.previousElementSibling;
+        // iterate through all non-list previous siblings
+        while (sibling && sibling.tagName !== "OL") {
+            siblings.push(sibling);
+            sibling = sibling.previousElementSibling;
+        }
+        // get the first H3 in the list (i.e. the nearest previous one)
+        const h3s = siblings.filter((el) => el.tagName === "H3");
+        return h3s.length > 0 ? h3s[0] : null;
+    }
+
+    alignTops(edElement, trElement) {
+        // align the tops of a transcription and translation element
+        if (!edElement || !trElement) return;
+
+        // reset styles
+        edElement.style.paddingTop = "0px";
+        trElement.style.paddingTop = "0px";
+
+        // compare tops and align
+        const edTop = edElement.getBoundingClientRect().top;
+        const trTop = trElement.getBoundingClientRect().top;
+
+        if (edTop < trTop) {
+            edElement.style.paddingTop = `${trTop - edTop}px`;
+        } else if (trTop < edTop) {
+            trElement.style.paddingTop = `${edTop - trTop}px`;
+        }
+    }
+
     alignLines() {
         if (this.transcriptionAndTranslationOpen()) {
             // get the currently selected transcription and translation
@@ -210,19 +243,13 @@ export default class extends Controller {
                     // first, align tops of lists (using inline styles)
                     const edOl = edOls[j];
                     const trOl = trOls[j];
-                    const edTop = edOl.getBoundingClientRect().top;
-                    // translation is always 1 pixel difference
-                    const trTop = trOl.getBoundingClientRect().top - 1;
-                    if (edTop < trTop) {
-                        edOl.style.paddingTop = `${trTop - edTop}px`;
-                        trOl.style.paddingTop = "0px";
-                    } else if (trTop < edTop) {
-                        trOl.style.paddingTop = `${edTop - trTop}px`;
-                        edOl.style.paddingTop = "0px";
-                    } else {
-                        trOl.style.paddingTop = "0px";
-                        edOl.style.paddingTop = "0px";
+                    const edHeader = this.getListHeader(edOl);
+                    const trHeader = this.getListHeader(trOl);
+                    if (edHeader && trHeader) {
+                        // align headers if present
+                        this.alignTops(edHeader, trHeader);
                     }
+                    this.alignTops(edOl, trOl);
                     // then, align each line of transcription to translation
                     const edLines = edOl.querySelectorAll("li");
                     const trLines = trOl.querySelectorAll("li");
@@ -265,14 +292,14 @@ export default class extends Controller {
         // then remove padding-top alignment of the two lists
         if (this.hasTranscriptionTarget) {
             this.transcriptionTargets.forEach((target) => {
-                const edOL = target.querySelector("ol");
-                if (edOL) edOL.removeAttribute("style");
+                const edElems = target.querySelectorAll("h3, ol");
+                edElems.forEach((edElem) => edElem.removeAttribute("style"));
             });
         }
         if (this.hasTranslationTarget) {
             this.translationTargets.forEach((target) => {
-                const trOL = target.querySelector("ol");
-                if (trOL) trOL.removeAttribute("style");
+                const trElems = target.querySelectorAll("h3, ol");
+                trElems.forEach((trElem) => trElem.removeAttribute("style"));
             });
         }
     }


### PR DESCRIPTION
**Associated Issue(s):** #1917

### Changes in this PR

- When both a transcription and translation are present and visible, align not only the numbered lines of the transcription/translation content (`ol`), but also their headers (`h3`)