### PR TITLE
Alphabetize Person and Place admin lists (#1907)

### DIFF
--- a/geniza/entities/admin.py
+++ b/geniza/entities/admin.py
@@ -5,8 +5,11 @@ from dal import autocomplete
 from django.contrib import admin, messages
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import OuterRef, Subquery, Value
 from django.db.models.fields import CharField, TextField
+from django.db.models.functions import Coalesce
 from django.forms import ModelChoiceField, ModelForm, ValidationError
 from django.forms.models import ModelChoiceIterator
 from django.forms.widgets import Textarea, TextInput
@@ -295,9 +298,37 @@ class PersonForm(ModelForm):
         widgets = {"tags": autocomplete.TaggitSelect2("tag-autocomplete")}
 
 
+class NamedAdminMixin:
+    def get_queryset(self, request):
+        """Override get_queryset to annotate with primary_name for list view sorting,
+        and with name_unaccented, so that places can be searched from admin list view
+        without entering diacritics"""
+        qs = super().get_queryset(request)
+
+        # pull content type
+        contenttype = ContentType.objects.get_for_model(self.model)
+        # get the first primary name, or the first non-primary name if none exists
+        primary_name_subquery = (
+            Name.objects.filter(content_type=contenttype, object_id=OuterRef("pk"))
+            .order_by("-primary", "id")
+            .values("name")[:1]
+        )
+        # annotate primary name, fallback to empty string; order by primary name by default
+        return qs.annotate(
+            primary_name=Coalesce(Subquery(primary_name_subquery), Value("")),
+            name_unaccented=ArrayAgg("names__name__unaccent", distinct=True),
+        ).order_by("primary_name")
+
+    @admin.display(ordering="primary_name", description="Display name")
+    def display_name(self, obj):
+        """Use the annotated primary name if found, otherwise use __str__"""
+        return getattr(obj, "primary_name", None) or str(obj)
+
+
 @admin.register(Person)
 class PersonAdmin(
     TabbedTranslationAdmin,
+    NamedAdminMixin,
     SortableAdminBase,
     PreventLogEntryDeleteMixin,
     admin.ModelAdmin,
@@ -306,7 +337,7 @@ class PersonAdmin(
 
     form = PersonForm
     list_display = (
-        "__str__",
+        "display_name",
         "slug",
         "gender",
         "all_roles",
@@ -628,9 +659,17 @@ class PlaceEventInline(admin.TabularInline):
 
 
 @admin.register(Place)
-class PlaceAdmin(SortableAdminBase, admin.ModelAdmin):
+class PlaceAdmin(SortableAdminBase, NamedAdminMixin, admin.ModelAdmin):
     """Admin for Place entities in the PGP"""
 
+    list_display = (
+        "display_name",
+        "slug",
+        "latitude",
+        "longitude",
+        "containing_region",
+        "is_region",
+    )
     search_fields = ("name_unaccented", "names__name")
     fields = (
         "slug",
@@ -672,18 +711,6 @@ class PlaceAdmin(SortableAdminBase, admin.ModelAdmin):
         if not place.slug:
             place.generate_slug()
             place.save()
-
-    def get_queryset(self, request):
-        """Modify queryset to add unaccented name annotation field, so that places
-        can be searched from admin list view without entering diacritics"""
-        return (
-            super()
-            .get_queryset(request)
-            .annotate(
-                # ArrayAgg to group together related values from related model instances
-                name_unaccented=ArrayAgg("names__name__unaccent", distinct=True),
-            )
-        )
 
     @admin.display(description="Export selected places to CSV")
     def export_to_csv(self, request, queryset=None):

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -470,13 +470,39 @@ class TestPlaceAdmin:
 
     def test_get_queryset(self):
         # create a place
-        place = Place.objects.create()
-        Name.objects.create(name="Fusṭāṭ", content_object=place, primary=True)
+        fustat = Place.objects.create()
+        Name.objects.create(name="Fusṭāṭ", content_object=fustat, primary=True)
         place_admin = PlaceAdmin(Place, admin_site=admin.site)
 
         # queryset should include name_unaccented field without diacritics
         qs = place_admin.get_queryset(Mock())
         assert qs.filter(name_unaccented__icontains="fustat").exists()
+
+        # should include primary_name field
+        mosul = Place.objects.create()
+        Name.objects.create(name="Mosul", content_object=mosul, primary=True)
+        Name.objects.create(name="الموصل", content_object=mosul)
+
+        qs = place_admin.get_queryset(Mock())
+        assert qs.filter(primary_name__icontains="mosul").exists()
+
+        # should order by primary_name by default (Fustat before Mosul)
+        assert qs.first().pk == fustat.pk
+
+    def test_display_name(self):
+        place_admin = PlaceAdmin(Place, admin_site=admin.site)
+
+        place = Place.objects.create()
+        # should fallback to default string representation
+        assert place_admin.display_name(place) == str(place)
+        # should be primary nmae
+        Name.objects.create(name="Fusṭāṭ", content_object=place, primary=True)
+        assert place_admin.display_name(place) == "Fusṭāṭ"
+        # which should still be str() (but avoids an additional join query)
+        assert place_admin.display_name(place) == str(place)
+        # should still be primary name
+        Name.objects.create(name="Other", content_object=place)
+        assert place_admin.display_name(place) == "Fusṭāṭ"
 
     @pytest.mark.django_db
     def test_export_to_csv(self):


### PR DESCRIPTION
**Associated Issue(s):** #1907

### Changes in this PR

- Add `primary_name` annotation to Person and Place querysets in the admin list view, in order to sort records by primary name (a related `Name` record meeting the condition `primary == True`)
- Sort these list views by primary name by default