### PR TITLE
Respect TextBlock.order when arranging document images, including placeholders (#1922)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -981,7 +981,8 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             return dict(
                 sorted(
                     iiif_images.items(),
-                    key=lambda item: item[1].get("tb_order", float("inf")),
+                    key=lambda item: item[1].get("tb_order", float("inf"))
+                    or float("inf"),
                 )
             )
 

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -909,6 +909,9 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
         iiif_images = {}
         textblocks = self.textblock_set.all()
 
+        # map textblock pks to their order for sorting
+        tb_order_map = {tb.pk: tb.order for tb in textblocks}
+
         for b in textblocks:
             frag_images = b.fragment.iiif_images(allow_network_reqs=not thumbnail)
             if frag_images is not None:
@@ -928,6 +931,7 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                             "rotation": 0,  # rotation to 0 by default; will change if overridden
                             "excluded": len(b.selected_images)
                             and i not in b.selected_images,
+                            "tb_order": tb_order_map.get(b.pk, float("inf")),
                         }
 
         # when requested, include any placeholder canvas URIs referenced by any associated
@@ -956,10 +960,9 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                     if uri_match:
                         # if this was created using placeholders in the transcription editor,
                         # try to ascertain and display the right fragment shelfmark and label
+                        tb_pk = int(uri_match.group("tb_pk"))
                         tb_match_shelfmarks = [
-                            tb.fragment.shelfmark
-                            for tb in textblocks
-                            if tb.pk == int(uri_match.group("tb_pk"))
+                            tb.fragment.shelfmark for tb in textblocks if tb.pk == tb_pk
                         ]
                         if tb_match_shelfmarks:
                             iiif_images[canvas_uri]["shelfmark"] = tb_match_shelfmarks[
@@ -968,10 +971,19 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
                         iiif_images[canvas_uri]["label"] = (
                             "recto" if int(uri_match.group("canvas")) == 1 else "verso"
                         )
+                        # keep track of textblock order for later sort
+                        iiif_images[canvas_uri]["tb_order"] = tb_order_map.get(
+                            tb_pk, float("inf")
+                        )
 
-        # if image_overrides not present, return list, in original order
+        # if image_overrides not present, return list, sorted by TextBlock order
         if not self.image_overrides:
-            return iiif_images
+            return dict(
+                sorted(
+                    iiif_images.items(),
+                    key=lambda item: item[1].get("tb_order", float("inf")),
+                )
+            )
 
         # sort canvases by "order" value
         sorted_overrides = sorted(

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -947,7 +947,9 @@ class TestDocument:
         # Create a document and fragment and a TextBlock to associate them
         doc = Document.objects.create()
         frag = Fragment.objects.create(shelfmark="T-S 8J22.21")
-        tb = TextBlock.objects.create(document=doc, fragment=frag, selected_images=[0])
+        tb = TextBlock.objects.create(
+            document=doc, fragment=frag, selected_images=[0], order=1
+        )
         # create a digital edition footnote with an associated annotation
         fn = Footnote.objects.create(
             source=source,
@@ -982,6 +984,36 @@ class TestDocument:
         assert len(images) == 2
         # second image should get verso because of /2/
         assert images[bad_canvas_str]["label"] == "verso"
+
+        # create a second textblock, joining with a fragment with a locally cached manifest
+        # (one image)
+        frag_2 = Fragment(shelfmark="TS 1")
+        frag_2.save()
+        TextBlock.objects.create(document=doc, fragment=frag_2, order=2)
+
+        # patch frag_2.iiif_images() to return (images, labels, canvases);
+        # use conditional mock based on pk to avoid instance mock overwritten
+        # by ORM when calling via Document.textblock_set --> TextBlock.fragment
+        real_iiif_images = Fragment.iiif_images
+
+        def conditional_mock_iiif_images(self, *args, **kwargs):
+            if self.pk == frag_2.pk:
+                return ([Mock()], ["real image"], ["http://example.co/iiif/ts-1/00001"])
+            return real_iiif_images(self, *args, **kwargs)
+
+        with patch.object(Fragment, "iiif_images", conditional_mock_iiif_images):
+            # should include all three images: two placeholders and 1 "real" iiif image
+            images = doc.iiif_images(with_placeholders=True)
+            assert len(images) == 3
+            # the placeholder on the textblock with order=1 should be first, even though it's a placeholder
+            ordered_images = list(images.items())
+            first_image = ordered_images[0]
+            assert first_image[0] == canvas_str
+            # the first two images should have tb_order 1 and 2 respectively
+            assert first_image[1]["tb_order"] == 1
+            assert ordered_images[1][1]["tb_order"] == 2
+            # the last image didn't have a textblock connecting it to the doc, so ordered last
+            assert ordered_images[-1][1]["tb_order"] == float("inf")
 
     def test_iiif_images_with_rotation(self, source):
         # Create a document and fragment and a TextBlock to associate them

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -985,8 +985,7 @@ class TestDocument:
         # second image should get verso because of /2/
         assert images[bad_canvas_str]["label"] == "verso"
 
-        # create a second textblock, joining with a fragment with a locally cached manifest
-        # (one image)
+        # create a second textblock on a new fragment
         frag_2 = Fragment(shelfmark="TS 1")
         frag_2.save()
         TextBlock.objects.create(document=doc, fragment=frag_2, order=2)


### PR DESCRIPTION
**Associated Issue(s):** #1922

### Changes in this PR

 - Respect `TextBlock.order` when arranging document images for display, including Fragments with placeholders
   - This allows placeholders to theoretically be ordered first before real IIIF images (i.e. when Fragments ordered first have placeholders with transcription/translation content, and Fragments ordered later have real images)
   - This order will not be used if `image_overrides` is set, as its order always takes priority