### PR TITLE
Prevent year zero-padding in public date display strings (#1924)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,11 @@
 # Deploy Notes
 
+## 4.27
+
+-   Logic for date formatting has changed, affecting data indexed in Solr.
+    Reindex all content to get the updated date display in search results:
+    `python manage.py index`.
+
 ## 4.26
 
 -   Solr configuration has changed. Ensure Solr configset has been updated

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -42,9 +42,8 @@ class PartialDate:
     available_precision = ["year", "month", "day"]
     #: public display format based on date precision
     display_format = {
-        "year": "Y",
-        "month": "F Y",
-        "day": "j F Y",
+        "month": "F",
+        "day": "j F",
     }
     #: ISO format based on date precision
     iso_format = {
@@ -70,8 +69,15 @@ class PartialDate:
         self.date = date(*[int(p) for p in date_parts])
 
     def __str__(self):
-        # format the date based on known precision
-        return date_format(self.date, format=self.display_format[self.precision])
+        # format the date for public display, based on known precision
+        # avoid zero-padding automatically applied to year by django date_format
+        year = str(self.date.year)
+        if self.precision == "year":
+            # skip date_format entirely
+            return year
+        # use normal year combined with date_formatted month and day
+        month_day = date_format(self.date, format=self.display_format[self.precision])
+        return " ".join([month_day, year])
 
     def __repr__(self) -> str:
         return f"PartialDate({self.isoformat()})"

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -273,6 +273,17 @@ class TestPartialDate:
         # year only
         assert str(PartialDate("1569")) == "1569"
 
+    def test_partialdate_str_threedigit(self):
+        # three-digit years should not be zero-padded in public display string
+        # single day
+        assert str(PartialDate("0850-10-23")) == "23 October 850"
+
+        # month/year
+        assert str(PartialDate("0850-10")) == "October 850"
+
+        # year only
+        assert str(PartialDate("0850")) == "850"
+
     def test_partialdate_init(self):
         # raise value error for too many parts
         with pytest.raises(ValueError):


### PR DESCRIPTION
**Associated Issue(s):** resolves #1924

### Changes in this PR

- Avoids using django's `date_format` function to format years for public display, in order to prevent automatic zero-padding of years with less than four digits


### Notes

- See [django's `date_format` source code](https://github.com/django/django/blob/aca28b50d6c55eb07f971ab2805d72d12e0e487e/django/utils/dateformat.py#L309-L315) for why this bug happens; the formatting string only accepts year options that include padding of some sort. We still want to use their formatting for month names and days of the month, so I only intercept formatting at the year level.

### Reviewer Checklist
If testing locally:

- [x] Reindex all content with `python ./manage.py index`, as the year string formatting propagates to the Document solr index.