### PR TITLE
Admin and model revisions to Manual (#1712)

### DIFF
--- a/geniza/resources/admin.py
+++ b/geniza/resources/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from geniza.resources.models import Manual
 
@@ -6,9 +7,18 @@ from geniza.resources.models import Manual
 class ManualAdmin(admin.ModelAdmin):
     """Admin section for manuals, training materials, and quick links"""
 
-    list_display = ("name", "url")
+    list_display = ("name", "url_display")
     search_fields = ("name",)
     ordering = ("name",)
+
+    @admin.display(description="URL")
+    def url_display(self, obj):
+        """Override URL field display link to open in a new tab, with relevant
+        accessibility labels and security risk prevention"""
+        return format_html(
+            '<a href="{0}" target="_blank" rel="noopener noreferrer" aria-label="{0} (opens in a new tab)">{0}</a>',
+            obj.url,
+        )
 
 
 admin.site.register(Manual, ManualAdmin)

--- a/geniza/resources/models.py
+++ b/geniza/resources/models.py
@@ -6,3 +6,7 @@ class Manual(models.Model):
 
     name = models.CharField(max_length=255, blank=False)
     url = models.URLField("URL", blank=False)
+
+    def __str__(self):
+        """Use the name of the manual as its string representation"""
+        return self.name

--- a/geniza/resources/tests/test_resources_admin.py
+++ b/geniza/resources/tests/test_resources_admin.py
@@ -1,0 +1,20 @@
+import pytest
+from django.contrib import admin
+
+from geniza.resources.admin import ManualAdmin
+from geniza.resources.models import Manual
+
+
+@pytest.mark.django_db
+class TestManualAdmin:
+    def test_url_display(self):
+        manual = Manual.objects.create(
+            name="Manual", url="https://geniza.princeton.edu/"
+        )
+        manual_admin = ManualAdmin(model=Manual, admin_site=admin.site)
+        # should open in new tab
+        assert 'target="_blank"' in manual_admin.url_display(manual)
+        # should include security risk prevention
+        assert 'rel="noopener noreferrer"' in manual_admin.url_display(manual)
+        # should include accessibility label
+        assert "(opens in a new tab)" in manual_admin.url_display(manual)

--- a/geniza/resources/tests/test_resources_models.py
+++ b/geniza/resources/tests/test_resources_models.py
@@ -1,0 +1,13 @@
+import pytest
+
+from geniza.resources.models import Manual
+
+
+@pytest.mark.django_db
+class TestManual:
+    def test_str(self):
+        # should use name as string representation
+        manual = Manual.objects.create(
+            name="Manual", url="https://geniza.princeton.edu/"
+        )
+        assert str(manual) == "Manual"


### PR DESCRIPTION
**Associated Issue(s):** #1712

### Changes in this PR

- Opens manual URLs in a new window from the admin list view, per Amel's request via Slack
- Uses `name` as the string representation for a manual