### PR TITLE
Return a 500 status code on the solr error page (#1819)

### DIFF
--- a/geniza/common/admin.py
+++ b/geniza/common/admin.py
@@ -226,11 +226,12 @@ class PreventLogEntryDeleteMixin:
 
 
 class SolrDownAdminMixin:
-    """Admin mixin to use the solr_error template with a 503 status code when a
+    """Admin mixin to use the solr_error template with a 500 status code when a
     changelist view encounters a solr error"""
 
     def changelist_view(self, request, extra_context=None):
         try:
             return super().changelist_view(request, extra_context)
         except SolrDownError:
-            return render(request, "solr_error.html", {}, status=503)
+            # NOTE: Should be switched to 503 if/when infra issue is resolved
+            return render(request, "solr_error.html", {}, status=500)

--- a/geniza/common/views.py
+++ b/geniza/common/views.py
@@ -50,11 +50,12 @@ class SolrDownError(Exception):
 
 
 class SolrDownMixin:
-    """Mixin to use the solr_error template with a 503 status code when a view
+    """Mixin to use the solr_error template with a 500 status code when a view
     encounters a solr error"""
 
     def dispatch(self, request, *args, **kwargs):
         try:
             return super().dispatch(request, *args, **kwargs)
         except SolrDownError:
-            return render(request, "solr_error.html", {}, status=503)
+            # NOTE: Should be switched to 503 if/when infra issue is resolved
+            return render(request, "solr_error.html", {}, status=500)

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -129,14 +129,14 @@ class TestDocumentAdmin:
 
     @pytest.mark.django_db
     def test_solr_down_admin_mixin(self, admin_client):
-        # SolrDownError should redirect to solr error template w/ 503 response
+        # SolrDownError should redirect to solr error template w/ 500 response
         changelist_url = reverse("admin:corpus_document_changelist")
         with patch(
             "geniza.corpus.admin.DocumentAdmin.get_search_results",
             side_effect=SolrDownError,
         ):
             response = admin_client.get(changelist_url)
-            assert response.status_code == 503
+            assert response.status_code == 500
             assert "unable to reach the Solr service" in response.content.decode()
 
     def test_rev_dates(self, db, admin_client):

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -9,7 +9,7 @@ from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import resolve, reverse
 from django.utils.text import Truncator, slugify
 from django.utils.timezone import get_current_timezone, make_aware
@@ -382,7 +382,7 @@ def test_pgp_metadata_for_old_site():
 class TestDocumentSearchView:
     @pytest.mark.django_db
     def test_solr_down_mixin(self, client):
-        # SolrDownError should redirect to solr error template w/ 500 response
+        # SolrDownError: should redirect to solr error template w/ 500 response
         docsearch_url = reverse("corpus:document-search")
         with patch(
             "geniza.corpus.views.DocumentSearchView.get_range_stats",
@@ -391,6 +391,37 @@ class TestDocumentSearchView:
             response = client.get(docsearch_url)
             assert response.status_code == 500
             assert "unable to reach the Solr service" in response.content.decode()
+
+        # generic exception: should use the normal error template w/ 500 response
+        with patch(
+            "geniza.corpus.views.DocumentSearchView.get_range_stats",
+            side_effect=Exception,
+        ):
+            with pytest.raises(Exception):
+                response = client.get(docsearch_url)
+                assert response.status_code == 500
+                # should NOT contain solr related message
+                assert (
+                    "unable to reach the Solr service" not in response.content.decode()
+                )
+
+        # generic and solr exceptions: should use the normal error template w/ 500 response
+        with patch(
+            "geniza.corpus.views.DocumentSearchView.get_range_stats",
+            side_effect=Exception,
+        ):
+            with patch(
+                "geniza.corpus.views.DocumentSearchView.get_context_data",
+                side_effect=SolrDownError,
+            ):
+                with pytest.raises(Exception):
+                    response = client.get(docsearch_url)
+                    assert response.status_code == 500
+                    # should NOT contain solr related message
+                    assert (
+                        "unable to reach the Solr service"
+                        not in response.content.decode()
+                    )
 
     def test_ignore_suppressed_documents(self, document, empty_solr):
         suppressed_document = Document.objects.create(status=Document.SUPPRESSED)

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -382,14 +382,14 @@ def test_pgp_metadata_for_old_site():
 class TestDocumentSearchView:
     @pytest.mark.django_db
     def test_solr_down_mixin(self, client):
-        # SolrDownError should redirect to solr error template w/ 503 response
+        # SolrDownError should redirect to solr error template w/ 500 response
         docsearch_url = reverse("corpus:document-search")
         with patch(
             "geniza.corpus.views.DocumentSearchView.get_range_stats",
             side_effect=SolrDownError,
         ):
             response = client.get(docsearch_url)
-            assert response.status_code == 503
+            assert response.status_code == 500
             assert "unable to reach the Solr service" in response.content.decode()
 
     def test_ignore_suppressed_documents(self, document, empty_solr):

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -4,12 +4,13 @@ from time import sleep
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
+import requests
 from django.conf import settings
 from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
+from django.test import LiveServerTestCase, TestCase
 from django.urls import resolve, reverse
 from django.utils.text import Truncator, slugify
 from django.utils.timezone import get_current_timezone, make_aware
@@ -379,33 +380,31 @@ def test_pgp_metadata_for_old_site():
     assert b"Legal" in row1
 
 
-class TestDocumentSearchView:
-    @pytest.mark.django_db
-    def test_solr_down_mixin(self, client):
+class TestDocumentSearchViewErrors(LiveServerTestCase):
+    def setUp(self):
+        self.docsearch_url = self.live_server_url + reverse("corpus:document-search")
+
+    def test_solr_down_mixin(self):
         # SolrDownError: should redirect to solr error template w/ 500 response
-        docsearch_url = reverse("corpus:document-search")
-        with patch(
-            "geniza.corpus.views.DocumentSearchView.get_range_stats",
-            side_effect=SolrDownError,
+        with patch.object(
+            DocumentSearchView, "get_range_stats", side_effect=SolrDownError
         ):
-            response = client.get(docsearch_url)
-            assert response.status_code == 500
-            assert "unable to reach the Solr service" in response.content.decode()
+            response = requests.get(self.docsearch_url)
+        self.assertEqual(response.status_code, 500)
+        # should include solr error message
+        self.assertIn("unable to reach the Solr service", response.text)
 
-        # generic exception: should use the normal error template w/ 500 response
-        with patch(
-            "geniza.corpus.views.DocumentSearchView.get_range_stats",
-            side_effect=Exception,
-        ):
-            with pytest.raises(Exception):
-                response = client.get(docsearch_url)
-                assert response.status_code == 500
-                # should NOT contain solr related message
-                assert (
-                    "unable to reach the Solr service" not in response.content.decode()
-                )
+    def test_generic_exception(self):
+        # generic Exception: should use the generic 500 error template
+        with patch.object(DocumentSearchView, "get_range_stats", side_effect=Exception):
+            response = requests.get(self.docsearch_url)
 
-        # generic and solr exceptions: should use the normal error template w/ 500 response
+        self.assertEqual(response.status_code, 500)
+        # should NOT include solr error message
+        self.assertNotIn("unable to reach the Solr service", response.text)
+
+    def test_both_exceptions(self):
+        # both Exception and SolrDownError: should use the generic 500 error template
         with patch(
             "geniza.corpus.views.DocumentSearchView.get_range_stats",
             side_effect=Exception,
@@ -414,15 +413,14 @@ class TestDocumentSearchView:
                 "geniza.corpus.views.DocumentSearchView.get_context_data",
                 side_effect=SolrDownError,
             ):
-                with pytest.raises(Exception):
-                    response = client.get(docsearch_url)
-                    assert response.status_code == 500
-                    # should NOT contain solr related message
-                    assert (
-                        "unable to reach the Solr service"
-                        not in response.content.decode()
-                    )
+                response = requests.get(self.docsearch_url)
 
+        self.assertEqual(response.status_code, 500)
+        # should NOT include solr error message
+        self.assertNotIn("unable to reach the Solr service", response.text)
+
+
+class TestDocumentSearchView:
     def test_ignore_suppressed_documents(self, document, empty_solr):
         suppressed_document = Document.objects.create(status=Document.SUPPRESSED)
         Document.index_items([document, suppressed_document])

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -120,14 +120,14 @@ class TestPersonAdmin:
 
     @pytest.mark.django_db
     def test_solr_down_admin_mixin(self, admin_client):
-        # SolrDownError should redirect to solr error template w/ 503 response
+        # SolrDownError should redirect to solr error template w/ 500 response
         changelist_url = reverse("admin:entities_person_changelist")
         with patch(
             "geniza.entities.admin.PersonAdmin.get_search_results",
             side_effect=SolrDownError,
         ):
             response = admin_client.get(changelist_url)
-            assert response.status_code == 503
+            assert response.status_code == 500
             assert "unable to reach the Solr service" in response.content.decode()
 
     def test_get_form(self):


### PR DESCRIPTION
**Associated Issue(s):** #1819

### Changes in this PR

- Return a 500 status code instead of a 503 when solr cannot be reached, to get around PUL infrastructure issues with 503 errors.
