### PR TITLE
Revisions to tag backspace clear bugfix (#1916)

### DIFF
--- a/sitemedia/js/admin.js
+++ b/sitemedia/js/admin.js
@@ -153,23 +153,32 @@ window.addEventListener("DOMContentLoaded", () => {
     // https://github.com/select2/select2/issues/3335#issuecomment-1218072422
     // https://github.com/yourlabs/django-autocomplete-light/issues/1398
     document.addEventListener("dal-init-function", function () {
-        if (window.django?.jQuery) {
-            const AllowClear = window.django.jQuery.fn.select2.amd.require(
-                "select2/selection/allowClear"
+        setTimeout(function () {
+            const $ = window.django?.jQuery || window.jQuery;
+            // find all select2 widgets currently initialized by DAL
+            const selects = document.querySelectorAll(
+                "select.select2-hidden-accessible"
             );
-            const handleKeyboardClear =
-                AllowClear.prototype._handleKeyboardClear;
-            AllowClear.prototype._handleKeyboardClear = function (
-                _,
-                evt,
-                container
-            ) {
-                if (this.$element?.prop("multiple")) {
-                    return;
-                }
-                return handleKeyboardClear.call(this, _, evt, container);
-            };
-        }
+            if ($ && selects.length > 0) {
+                selects.forEach((select2El) => {
+                    // patch select2 instance on widgets directly
+                    const select2 = $(select2El).data("select2");
+                    const original = select2?.selection?._handleKeyboardClear;
+                    if (original) {
+                        select2.selection._handleKeyboardClear = function (
+                            _,
+                            evt,
+                            container
+                        ) {
+                            if (this.$element?.prop("multiple")) {
+                                return;
+                            }
+                            return original.call(this, _, evt, container);
+                        };
+                    }
+                });
+            }
+        }, 10); // a bit hacky, but select2 initializes one tick later than DAL
     });
 });
 


### PR DESCRIPTION
**Associated Issue(s):** #1916

### Changes in this PR

- Revises the code to monkey-patch select2, applying it to instances of select2 attached to elements, rather than global jQuery (due to peculiarities with production webpack bundling + django static assets)
- Also adds a timeout of 10ms to apply the patch, due to the way that django-autocomplete-light initiates one tick before select2 under some conditions