### PR TITLE
Resolve CUDL manifest import error (#1936)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rich",
     "wagtail>=7.1,<7.2",
     "wagtail-localize>=1.12,<1.13",
-    "djiffy>=1.0.1,<1.1",
+    "djiffy>=1.0.2,<1.1",
     "natsort",
     "django-widget-tweaks",
     "django-csp-helpers",


### PR DESCRIPTION
**Associated Issue(s):** #1936

### Changes in this PR

- Fixes a bug where manifest caching logic was not gracefully handling CUDL manifests that had switched their internal manifest/canvas URIs from https to http (but still served over https)

### Reviewer Checklist

- [x] Run `pip install -e '.[dev]'` to get all of the latest python dependencies
