### PR TITLE
Allow reordering placeholder canvases with transcription/translation content (#1942)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -2,6 +2,9 @@
 
 ## 4.28
 
+-   Old placeholder canvases must be manually migrated using the new management
+    command: `python manage.py migrate_orphan_placeholders` in order to allow
+    reordering placeholder canvases alongside images.
 -   Logic for date formatting has changed, affecting data indexed in Solr.
     Reindex all content to get the updated date display in search results:
     `python manage.py index`.

--- a/geniza/annotations/management/commands/migrate_orphan_placeholders.py
+++ b/geniza/annotations/management/commands/migrate_orphan_placeholders.py
@@ -1,0 +1,237 @@
+import csv
+import re
+from collections import OrderedDict, defaultdict
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+from django.urls import reverse
+from parasolr.django.signals import IndexableSignalHandler
+from rich.progress import track
+
+from geniza.annotations.models import Annotation
+from geniza.common.utils import absolutize_url
+from geniza.corpus.models import Document
+
+
+class Command(BaseCommand):
+    """One-time management command to migrate annotations from the old style of placeholders,
+    which were only linked to Document ID, to the new style, which includes a TextBlock ID
+    in its URI.
+
+    /documents/{document.pk}/iiif/canvas/{canvas_number}/
+    --> /documents/{document.pk}/iiif/textblock/{textblock.pk}/canvas/{canvas_number}/
+
+    Outputs a report as a CSV with one row per document, indicating how many annotations
+    were migrated, whether they were placed on existing images, and whether there were
+    more than two placeholder canvases per fragment.
+
+    Also prints any failures, and the total number of documents and annotations updated.
+    """
+
+    # track statistics
+    updated_documents = defaultdict(
+        lambda: {
+            "annotation_count": 0,
+            "had_extra_canvases": False,
+            "moved_to_last_canvas": False,
+        }
+    )
+    report_fields = [
+        "pgpid",
+        "annotation_count",
+        "had_extra_canvases",
+        "moved_to_last_canvas",
+        "url",
+    ]
+    unmigrated = {"documents": set(), "annotations": set()}
+
+    # regex patterns
+    doc_pk_re = re.compile(r"/documents/(\d+)/")
+    placeholder_url_re = re.compile(r"^(.*?/documents)/\d+/iiif/canvas/(\d+)/?$")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "report-path",
+            type=str,
+            nargs="?",
+            default="annotation-migration-report.csv",
+        )
+
+    def handle(self, *args, **options):
+        # find all placeholders using the old style of URI, namely:
+        # /documents/{document.pk}/iiif/canvas/{canvas_number}/
+        old_style_placeholder_annotations = Annotation.objects.filter(
+            Q(content__target__source__id__icontains="iiif/canvas")
+            & Q(content__target__source__id__icontains="geniza.princeton.edu")
+        ).order_by("content__schema:position", "created")
+
+        # group anotations by document PGPID
+        annotations_by_doc = self.group_by_document(old_style_placeholder_annotations)
+
+        # disconnect solr indexing signals; this script will reindex documents manually
+        IndexableSignalHandler.disconnect()
+
+        # attempt to migrate
+        for pgpid, annotations in track(
+            annotations_by_doc.items(), description="Reassigning annotations..."
+        ):
+            document = Document.objects.get(pk=pgpid)
+            self.reassign_placeholder_annotations(document, annotations)
+
+        self.stdout.write("Reindexing documents...")
+        pgpids_to_index = list(self.updated_documents.keys())
+        docs_to_index = Document.objects.filter(pk__in=pgpids_to_index)
+        Document.index_items(docs_to_index)
+
+        self.stdout.write("Exporting stats CSV...")
+        self.export_csv(options["report-path"])
+        total_annotations = sum(
+            stats["annotation_count"] for stats in self.updated_documents.values()
+        )
+        self.stdout.write("Done!")
+        self.stdout.write("- Total annotations updated: %d" % total_annotations)
+        self.stdout.write(
+            "- Total documents affected: %d" % len(self.updated_documents)
+        )
+        if self.unmigrated["documents"]:
+            self.stdout.write(
+                "The following PGPIDs encountered errors during migration:"
+            )
+            for doc in self.unmigrated["documents"]:
+                self.stdout.write("- %d" % doc)
+        if self.unmigrated["annotations"]:
+            self.stdout.write(
+                "The following annotation canvas URIs could not be migrated:"
+            )
+            for canvas_uri in self.unmigrated["annotations"]:
+                self.stdout.write("- %s" % canvas_uri)
+
+    def export_csv(self, path):
+        """Generate a CSV to report results, with one document per row"""
+        with open(path, "w", newline="") as csvfile:
+            csvwriter = csv.writer(csvfile)
+            csvwriter.writerow(self.report_fields)
+            for pgpid, stats in self.updated_documents.items():
+                csvwriter.writerow(
+                    [
+                        pgpid,
+                        stats["annotation_count"],
+                        stats["had_extra_canvases"],
+                        stats["moved_to_last_canvas"],
+                        absolutize_url(reverse("corpus:document", args=[str(pgpid)])),
+                    ]
+                )
+
+    def group_by_document(self, annotations):
+        """Group annotations by document PGPID, checking old PGPIDs,
+        and tracking when documents could not be found."""
+        annotations_by_doc = defaultdict(list)
+        for annotation in track(annotations, description="Collecting annotations..."):
+            match = self.doc_pk_re.search(annotation.target_source_id)
+            if match:
+                pgpid = int(match.group(1))
+                try:
+                    document = Document.objects.get_by_any_pgpid(pgpid)
+                except Document.DoesNotExist:
+                    self.unmigrated["documents"].add(pgpid)
+                    continue
+                annotations_by_doc[document.pk].append(annotation)
+            else:
+                self.unmigrated["annotations"].add(annotation.target_source_id)
+        # order keys by PGPID
+        return OrderedDict(sorted(annotations_by_doc.items()))
+
+    def get_last_position(self, canvas_uri):
+        """Get the max annotation schema:position for a given canvas URI"""
+        annotations = Annotation.objects.filter(
+            content__target__source__id=canvas_uri
+        ).values_list("content__schema:position", flat=True)
+        positions = [int(pos) for pos in annotations if pos is not None]
+        return max(positions, default=0)
+
+    def reassign_placeholder_annotations(self, document, annotations):
+        """Reassign annotations on placeholders to appopriate canvases."""
+
+        # find textblocks for fragments without images on the document
+        non_image_textblocks = document.textblock_set.filter(
+            Q(fragment__iiif_url__isnull=True) | Q(fragment__iiif_url="")
+        )
+
+        # handle placeholder annotations --> real iiif image
+        iiif_images = document.iiif_images()
+
+        # known edge case: mixed iiif and placeholders, but annotation header
+        # includes ALL shelfmarks, so just put on first image (PGPID 5575)
+        is_mixed_document = document.pk == 5575
+
+        if not non_image_textblocks.exists() or is_mixed_document:
+            # ONLY textblocks with images: use the last canvas on the document,
+            # using the existing order (so that placeholder positions match
+            # existing behavior)
+            if iiif_images:
+                # grab last canvas from document images (unless is_mixed_document)
+                canvases = list(iiif_images.keys())
+                canvas_uri = canvases[0] if is_mixed_document else canvases[-1]
+                self.updated_documents[document.pk]["moved_to_last_canvas"] = (
+                    False if is_mixed_document else True
+                )
+                # grab last annotation position so we can append these to the end
+                last_anno_position = self.get_last_position(canvas_uri)
+                for idx, annotation in enumerate(annotations, start=1):
+                    # reassign to last canvas, update position
+                    annotation.content["target"]["source"]["id"] = canvas_uri
+                    annotation.content["schema:position"] = last_anno_position + idx
+                    annotation.save()
+                    self.updated_documents[document.pk]["annotation_count"] += 1
+            return  # that's all we need to do here
+
+        # handle placeholder annotations --> placeholder image
+        textblock = None
+        if non_image_textblocks.count() == 1 or not iiif_images:
+            # only one non-image textblock, or all textblocks are non-image
+            textblock = non_image_textblocks.first()
+
+        # reassign annotations to textblock-identified placeholders
+        last_positions_cache = {}
+        for annotation in annotations:
+            # grab base uri and canvas from original uri
+            uri = annotation.target_source_id
+            match = self.placeholder_url_re.match(uri)
+            base_uri = match.group(1)
+            canvas_number = int(match.group(2))
+
+            # handle any that did not get a textblock
+            if not textblock:
+                if (
+                    "label" in annotation.content["body"][0]
+                    and "TS NS 92, f. 33" in annotation.content["body"][0]["label"]
+                ):
+                    # known edge case 2: mixed iiif and placeholders with annotations;
+                    # annotation label contains shelfmark
+                    textblock = document.textblock_set.get(
+                        fragment__shelfmark="T-S NS 92.33"
+                    )
+                else:
+                    self.unmigrated["documents"].add(document.pk)
+                    return
+
+            # old placeholders could have more than 2 canvases, so move all of
+            # the later ones to canvas 2, and update stats
+            if canvas_number > 2:
+                canvas_number = 2
+                self.updated_documents[document.pk]["had_extra_canvases"] = True
+
+            # generate new placeholder URI
+            new_placeholder_uri = f"{base_uri}/{document.pk}/iiif/textblock/{textblock.pk}/canvas/{canvas_number}/"
+
+            # ensure ordering remains (cache ordering result for efficiency)
+            last_anno_position = last_positions_cache.get(new_placeholder_uri)
+            if last_anno_position is None:
+                last_anno_position = self.get_last_position(new_placeholder_uri)
+            last_positions_cache[new_placeholder_uri] = last_anno_position + 1
+
+            # update annotation uri and stats
+            annotation.content["schema:position"] = last_anno_position + 1
+            annotation.content["target"]["source"]["id"] = new_placeholder_uri
+            annotation.save()
+            self.updated_documents[document.pk]["annotation_count"] += 1

--- a/geniza/annotations/tests/test_migrate_orphan_placeholders.py
+++ b/geniza/annotations/tests/test_migrate_orphan_placeholders.py
@@ -1,0 +1,446 @@
+import csv
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from parasolr.django.signals import IndexableSignalHandler
+
+from geniza.annotations.management.commands.migrate_orphan_placeholders import Command
+from geniza.annotations.models import Annotation
+from geniza.corpus.models import Document, Fragment, TextBlock
+from geniza.corpus.tests.conftest import MockImporter
+from geniza.footnotes.models import Footnote
+
+
+@pytest.mark.django_db
+def test_group_by_document(annotation, source):
+    # create some documents
+    doc1 = Document.objects.create()
+    footnote1 = Footnote.objects.create(
+        source=source, content_object=doc1, doc_relation=Footnote.DIGITAL_EDITION
+    )
+    doc2 = Document.objects.create()
+    footnote2 = Footnote.objects.create(
+        source=source, content_object=doc2, doc_relation=Footnote.DIGITAL_EDITION
+    )
+
+    # annotations attached by target_source_id to doc1 and doc2
+    anno1 = Annotation.objects.create(
+        footnote=footnote1,
+        content={
+            **annotation.content,
+            "target": {"source": {"id": f"/documents/{doc1.pk}/iiif/canvas/1/"}},
+        },
+    )
+    anno2 = Annotation.objects.create(
+        footnote=footnote1,
+        content={
+            **annotation.content,
+            "target": {"source": {"id": f"/documents/{doc1.pk}/iiif/canvas/2/"}},
+        },
+    )
+    anno3 = Annotation.objects.create(
+        footnote=footnote2,
+        content={
+            **annotation.content,
+            "target": {"source": {"id": f"/documents/{doc2.pk}/iiif/canvas/1/"}},
+        },
+    )
+
+    cmd = Command()
+
+    annotations = [anno1, anno2, anno3]
+    result = cmd.group_by_document(annotations)
+
+    # should be a dict keyed on document pks, ordered by pk
+    assert list(result.keys()) == [doc1.pk, doc2.pk]
+    # should assign annotations to the correct document pk
+    assert anno1 in result[doc1.pk] and anno2 in result[doc1.pk]
+    assert result[doc2.pk] == [anno3]
+
+    # bad source id: should get added to command's `unmigrated` dict
+    bad_source_id = Annotation.objects.create(
+        footnote=footnote1,
+        content={
+            **annotation.content,
+            "target": {"source": {"id": "/notmatching"}},
+        },
+    )
+    # bad document PK: should get added to command's `unmigrated` dict
+    bad_pk = 123456789
+    assert not Document.objects.filter(pk=bad_pk).exists()
+    bad_document_pk = Annotation.objects.create(
+        footnote=footnote1,
+        content={
+            **annotation.content,
+            "target": {"source": {"id": f"/documents/{bad_pk}/iiif/canvas/1/"}},
+        },
+    )
+    cmd.group_by_document([bad_source_id, bad_document_pk])
+    assert "/notmatching" in cmd.unmigrated["annotations"]
+    assert bad_pk in cmd.unmigrated["documents"]
+
+
+@pytest.mark.django_db
+def test_get_last_position(source, document):
+    # should return the highest schema:position for an annotation on a uri
+    uri = f"/documents/{document.pk}/iiif/canvas/1/"
+    footnote = Footnote.objects.create(
+        source=source, content_object=document, doc_relation=Footnote.DIGITAL_EDITION
+    )
+    Annotation.objects.create(
+        footnote=footnote,
+        content={"schema:position": 5, "target": {"source": {"id": uri}}},
+    )
+    Annotation.objects.create(
+        footnote=footnote,
+        content={"schema:position": 12, "target": {"source": {"id": uri}}},
+    )
+
+    cmd = Command()
+    assert cmd.get_last_position(uri) == 12
+
+    # for a uri with no annotations, should return 0
+    doc2 = Document.objects.create()
+    uri = f"/documents/{doc2.pk}/iiif/canvas/1/"
+    assert cmd.get_last_position(uri) == 0
+
+
+@pytest.mark.django_db
+def test_export_csv(tmp_path):
+    cmd = Command()
+    cmd.updated_documents = {
+        1: {
+            "annotation_count": 3,
+            "had_extra_canvases": False,
+            "moved_to_last_canvas": True,
+        },
+        2: {
+            "annotation_count": 10,
+            "had_extra_canvases": True,
+            "moved_to_last_canvas": False,
+        },
+    }
+
+    out_file = tmp_path / "report.csv"
+    cmd.export_csv(str(out_file))
+
+    with open(out_file, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    # should have exactly two data rows
+    assert len(rows) == 2
+
+    # should match doc data
+    row = rows[0]
+    assert row["pgpid"] == "1"
+    assert row["annotation_count"] == "3"
+    assert row["had_extra_canvases"] == "False"
+    assert row["moved_to_last_canvas"] == "True"
+    assert row["url"].endswith("/documents/1/")
+
+
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__last_canvas(source):
+    doc = Document.objects.create()
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+
+    # mock case with only real image textblocks
+    with patch.object(
+        doc,
+        "iiif_images",
+        return_value={
+            f"/documents/{doc.pk}/iiif/canvas/1/": {},
+            f"/documents/{doc.pk}/iiif/canvas/2/": {},
+        },
+    ):
+        with patch.object(
+            doc.textblock_set, "filter", return_value=doc.textblock_set.none()
+        ):
+            annotation = Annotation.objects.create(
+                footnote=footnote,
+                content={
+                    "schema:position": 0,
+                    "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/1/"}},
+                },
+            )
+
+            cmd = Command()
+            IndexableSignalHandler.disconnect()
+            cmd.reassign_placeholder_annotations(doc, [annotation])
+
+            # should have moved to last canvas
+            assert annotation.content["target"]["source"]["id"].endswith("/canvas/2/")
+            assert cmd.updated_documents[doc.pk]["annotation_count"] == 1
+            assert cmd.updated_documents[doc.pk]["moved_to_last_canvas"] is True
+
+
+@patch("geniza.corpus.models.GenizaManifestImporter", MockImporter)
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__one_non_image_textblock(source):
+    # only one non-image textblock
+    doc = Document.objects.create()
+    frag = Fragment.objects.create(shelfmark="T-S NS 1.100")
+    tb = TextBlock.objects.create(document=doc, fragment=frag)
+    frag_img = Fragment.objects.create(
+        shelfmark="T-S NS 2.100",
+        iiif_url="https://iiif.example.com/TS-NS-2.100/manifest/",
+    )
+    TextBlock.objects.create(document=doc, fragment=frag_img)
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+    annotation = Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "schema:position": 0,
+            "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/1/"}},
+            "body": [],
+        },
+    )
+
+    # prevent network request to fake iiif url
+    with patch.object(
+        doc,
+        "iiif_images",
+        return_value={"https://iiif.example.com/TS-NS-2.100/canvas/1/": {}},
+    ):
+        cmd = Command()
+        IndexableSignalHandler.disconnect()
+        cmd.reassign_placeholder_annotations(doc, [annotation])
+        # should assign to the one non-image textblock
+        assert annotation.content["target"]["source"]["id"] == (
+            f"/documents/{doc.pk}/iiif/textblock/{tb.pk}/canvas/1/"
+        )
+        assert cmd.updated_documents[doc.pk]["annotation_count"] == 1
+
+
+@patch("geniza.corpus.models.GenizaManifestImporter", MockImporter)
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__multiple_tbs(source):
+    # multiple non-image textblocks
+    doc = Document.objects.create()
+    frag = Fragment.objects.create(shelfmark="T-S 1")
+    frag_2 = Fragment.objects.create(shelfmark="ENA 1000")
+    TextBlock.objects.create(document=doc, fragment=frag)
+    TextBlock.objects.create(document=doc, fragment=frag_2)
+
+    # one image textblock
+    frag_3 = Fragment.objects.create(
+        shelfmark="T-S NS 2.1",
+        iiif_url="https://iiif.example.com/TS-NS-2.1/manifest/",
+    )
+    TextBlock.objects.create(document=doc, fragment=frag_3)
+
+    # annotation on old placeholder
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+    annotation = Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "schema:position": 0,
+            "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/1/"}},
+            "body": [{"label": "Recto"}],
+        },
+    )
+
+    # prevent network request to fake iiif url
+    with patch.object(
+        doc,
+        "iiif_images",
+        return_value={"https://iiif.example.com/TS-NS-2.1/canvas/1/": {}},
+    ):
+        cmd = Command()
+        IndexableSignalHandler.disconnect()
+        cmd.reassign_placeholder_annotations(doc, [annotation])
+
+        # should add to unmigrated since we don't know which textblock to assign
+        assert doc.pk in cmd.unmigrated["documents"]
+
+
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__extra_canvases(source):
+    doc = Document.objects.create()
+    frag = Fragment.objects.create(shelfmark="T-S NS 1.1")
+    tb = TextBlock.objects.create(document=doc, fragment=frag)
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+
+    # annotation on a canvas > 2, even though we only have one fragment
+    annotation = Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "schema:position": 0,
+            "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/5/"}},
+            "body": [],
+        },
+    )
+
+    # should reassign canvas > 2 to 2
+    cmd = Command()
+    IndexableSignalHandler.disconnect()
+    cmd.reassign_placeholder_annotations(doc, [annotation])
+    assert annotation.content["target"]["source"]["id"].endswith(
+        f"/textblock/{tb.pk}/canvas/2/"
+    )
+    assert cmd.updated_documents[doc.pk]["had_extra_canvases"] is True
+
+
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__mixed_edge_case(source):
+    # create the doc with the known mixed iiif and placeholders
+    doc = Document.objects.create(pk=5575)
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+
+    # mock case with some real image textblocks
+    real_canvas = lambda i: f"http://ex.co/iiif/canvas/{i}/"
+    with patch.object(
+        doc,
+        "iiif_images",
+        return_value={real_canvas(1): {}, real_canvas(2): {}},
+    ):
+        # add a few annotations on the "real" iiif images (mocked)
+        for i in range(3):
+            Annotation.objects.create(
+                footnote=footnote,
+                content={
+                    "schema:position": i,
+                    "target": {"source": {"id": real_canvas(1)}},
+                },
+            )
+            Annotation.objects.create(
+                footnote=footnote,
+                content={
+                    "schema:position": i,
+                    "target": {"source": {"id": real_canvas(2)}},
+                },
+            )
+
+        # add an annotation on an old-style placeholder
+        annotation = Annotation.objects.create(
+            footnote=footnote,
+            content={
+                "schema:position": 0,
+                "target": {"source": {"id": "/documents/5575/iiif/canvas/1/"}},
+            },
+        )
+
+        cmd = Command()
+        IndexableSignalHandler.disconnect()
+        cmd.reassign_placeholder_annotations(doc, [annotation])
+
+        # should get moved to the first real canvas
+        assert annotation.content["target"]["source"]["id"] == real_canvas(1)
+        assert cmd.updated_documents[5575]["moved_to_last_canvas"] is False
+        # should be ordered last (0, 1, 2 are the existing positions)
+        assert annotation.content["schema:position"] == 3
+
+
+@patch("geniza.corpus.models.GenizaManifestImporter", MockImporter)
+@pytest.mark.django_db
+def test_reassign_placeholder_annotations__known_shelfmark_edge_case(source):
+    # create a document on a fragment with the shelfmark T-S NS 92.33
+    doc = Document.objects.create()
+    frag = Fragment.objects.create(shelfmark="T-S NS 92.33")
+    tb = TextBlock.objects.create(document=doc, fragment=frag)
+    # create an additional non-image fragment
+    frag_2 = Fragment.objects.create(shelfmark="ENA 3765.3")
+    TextBlock.objects.create(document=doc, fragment=frag_2)
+    # create an image fragment
+    frag_3 = Fragment.objects.create(
+        shelfmark="TS-NS-2.22", iiif_url="https://iiif.example.com/TS-NS-2.22/manifest/"
+    )
+    TextBlock.objects.create(document=doc, fragment=frag_3)
+
+    # annotate on the old style placeholder
+    footnote = Footnote.objects.create(
+        source=source, content_object=doc, doc_relation=Footnote.DIGITAL_EDITION
+    )
+    annotation = Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "schema:position": 0,
+            "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/1/"}},
+            # label points to T-S NS 92.33
+            "body": [{"label": "TS NS 92, f. 33"}],
+        },
+    )
+
+    # mock one image
+    with patch.object(
+        Document,
+        "iiif_images",
+        return_value={"https://iiif.example.com/TS-NS-2.22/canvas/1/": {}},
+    ):
+        cmd = Command()
+        IndexableSignalHandler.disconnect()
+        cmd.reassign_placeholder_annotations(doc, [annotation])
+
+        # should assign to the correct textblock
+        assert annotation.content["target"]["source"]["id"].endswith(
+            f"textblock/{tb.pk}/canvas/1/"
+        )
+        assert cmd.updated_documents[doc.pk]["annotation_count"] == 1
+
+
+@pytest.mark.django_db
+def test_handle(tmp_path, capsys, source):
+    # minimal document + annotation needed for command to run
+    doc = Document.objects.create()
+    footnote = Footnote.objects.create(
+        source=source,
+        content_object=doc,
+        doc_relation=Footnote.DIGITAL_TRANSLATION,
+    )
+    Annotation.objects.create(
+        footnote=footnote,
+        content={
+            "schema:position": 0,
+            "target": {"source": {"id": f"/documents/{doc.pk}/iiif/canvas/1/"}},
+        },
+    )
+
+    report_path = tmp_path / "out.csv"
+
+    # mock all the helper functions
+    with patch.object(
+        Command, "group_by_document", return_value={doc.pk: ["dummy_annotation"]}
+    ):
+        with patch.object(Command, "reassign_placeholder_annotations"):
+            with patch.object(Command, "export_csv") as mock_export:
+                # simulate csv writing from export_csv
+                mock_export.side_effect = lambda path: open(path, "w").write("header\n")
+                # simulate unmigrated results
+                with patch.object(
+                    Command,
+                    "unmigrated",
+                    {"documents": {999}, "annotations": {"/bad/uri/"}},
+                ):
+                    # avoid actual reindexing
+                    with patch.object(Document, "index_items"):
+                        call_command("migrate_orphan_placeholders", str(report_path))
+
+    # should write csv file
+    assert report_path.exists()
+
+    # should write to stdout
+    out = capsys.readouterr().out
+    assert "Reassigning annotations..." in out
+    assert "Done!" in out
+
+    # should print totals
+    assert "- Total annotations updated:" in out
+    assert "- Total documents affected:" in out
+
+    # should print unmigrated
+    assert "The following PGPIDs encountered errors during migration:" in out
+    assert "- 999" in out
+    assert "The following annotation canvas URIs could not be migrated:" in out
+    assert "- /bad/uri/" in out

--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -15,6 +15,7 @@ from django.http import HttpResponseRedirect
 from django.urls import path, resolve, reverse
 from django.utils import timezone
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from modeltranslation.admin import TabbedTranslationAdmin
 from requests.exceptions import ConnectionError
 
@@ -619,12 +620,19 @@ class DocumentAdmin(
     def get_form(self, request, obj=None, **kwargs):
         # Override to inject help text into display field
         help_texts = {
-            "admin_thumbnails": """Drag image thumbnails to customize order when necessary (i.e.
-            image sequence does not follow fragment/shelfmark sequence). Click rotation buttons to
-            rotate images, and use checkboxes to select or deselect images as part of the document.
-            Changes will be applied on save. NOTE: Deselecting ALL images from a fragment will
-            be treated the same as selecting all images from that fragment, since a fragment must
-            have at least one selected image; if not, the fragment should be removed from the document."""
+            "admin_thumbnails": mark_safe(
+                """Drag image thumbnails to customize order when necessary (i.e.
+                image sequence does not follow fragment/shelfmark sequence). Click rotation buttons
+                to rotate images, and use checkboxes to select or deselect images as part of the
+                document. Changes will be applied on save.
+                <br />
+                <strong>NOTE</strong>: Deselecting ALL images from a fragment will be treated the
+                same as selecting all images from that fragment, since a fragment must have at
+                least one selected image; if not, the fragment should be removed from the document.
+                <br />
+                <strong>NOTE</strong>: Placeholder images will only appear in this section if they
+                have transcription or translation content."""
+            )
         }
         kwargs.update({"help_texts": help_texts})
         return super().get_form(request, obj, **kwargs)

--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -321,19 +321,23 @@ class Fragment(TrackChangesModel):
             " ".join(
                 # include label as title for now; include canvas as data attribute for reordering
                 # on Document
-                '<div class="admin-thumbnail%s" %s><img src="%s" loading="lazy" height="%d" title="%s" /></div>'
+                '<div class="admin-thumbnail%s" title="%s" %s><img src="%s" loading="lazy" height="%d" /></div>'
                 % (
                     " selected" if i in selected else "",
-                    f'data-canvas="{list(canvases)[i]}"' if canvases else "",
+                    labels[i],
+                    (
+                        f'data-canvas="{list(canvases)[i]}"'
+                        if canvases and len(canvases) > i
+                        else ""
+                    ),
                     img,
                     img.size.options["height"] if hasattr(img, "size") else 200,
-                    labels[i],
                 )
                 for i, img in enumerate(images)
             )
         )
 
-    def iiif_thumbnails(self, selected=[]):
+    def iiif_thumbnails(self, selected=[], canvases=[]):
         """html for thumbnails of iiif image, for display in admin"""
         iiif_images = self.iiif_images()
         if iiif_images is None:
@@ -342,10 +346,10 @@ class Fragment(TrackChangesModel):
             recto_img = static("img/ui/all/all/recto-placeholder.svg")
             verso_img = static("img/ui/all/all/verso-placeholder.svg")
             image_urls = [recto_img, verso_img]
-            labels = ["recto", "verso"]
-            canvases = []
+            labels = [f"{self.shelfmark} recto", f"{self.shelfmark} verso"]
         else:
             images, labels, canvases = iiif_images
+            labels = [f"{self.shelfmark} {label}" for label in labels]
             image_urls = [img.size(height=200) for img in images]
         return Fragment.admin_thumbnails(
             image_urls, labels, canvases=canvases, selected=selected
@@ -1027,16 +1031,36 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
 
     def admin_thumbnails(self):
         """generate html for thumbnails of all iiif images, for image reordering UI in admin"""
-        iiif_images = self.iiif_images()
+        iiif_images = self.iiif_images(with_placeholders=True)
         if not iiif_images:
             return ""
         images = iiif_images.values()
+        placeholder = lambda label: f"/static/img/ui/all/all/{label}-placeholder.svg"
+        default_placeholder = Document.PLACEHOLDER_CANVAS["image"]["info"]
+        # include shelfmark + page label
+        labels = [
+            " ".join(
+                [
+                    img["shelfmark"] if "shelfmark" in img else "",
+                    img["label"] if "label" in img else "",
+                ]
+            )
+            for img in images
+        ]
         return Fragment.admin_thumbnails(
             images=[
-                img["image"].size(height=200).rotation(degrees=img["rotation"])
+                (
+                    img["image"].size(height=200).rotation(degrees=img["rotation"])
+                    if hasattr(img["image"], "size")
+                    else (
+                        placeholder(img["label"])
+                        if "label" in img
+                        else default_placeholder
+                    )
+                )
                 for img in images
             ],
-            labels=[img["label"] for img in images],
+            labels=labels,
             canvases=iiif_images.keys(),
         )
 
@@ -1997,7 +2021,33 @@ class TextBlock(models.Model):
 
     def thumbnail(self):
         """iiif thumbnails for this TextBlock, with selected images highlighted"""
-        return self.fragment.iiif_thumbnails(selected=self.selected_images)
+        canvases = []
+        if not self.fragment.iiif_images():
+            # if no IIIF, get placeholder canvas URIs using annotations
+            annotated_canvases = (
+                Annotation.objects.filter(
+                    footnote__content_type=ContentType.objects.get_for_model(Document),
+                    footnote__object_id=self.document.pk,
+                    content__target__source__id__isnull=False,
+                )
+                .order_by()
+                .values_list("content__target__source__id", flat=True)
+                .distinct()
+            )
+            # match placeholder on document and textblock PK; extract canvas number
+            placeholder_re = re.compile(
+                rf"{self.document.pk}/iiif/textblock/{self.pk}/canvas/(\d+)/"
+            )
+            canvases = [
+                canvas_uri
+                for canvas_uri in annotated_canvases
+                if placeholder_re.search(canvas_uri)
+            ]
+            # ensure order of placeholders is 1, 2 (recto, verso) by canvas number
+            canvases.sort(key=lambda uri: int(placeholder_re.search(uri).group(1)))
+        return self.fragment.iiif_thumbnails(
+            selected=self.selected_images, canvases=canvases
+        )
 
 
 class Dating(models.Model):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -180,7 +180,7 @@ class TestFragment(TestCase):
         )
         assert all(
             label in placeholder_thumbnails
-            for label in ['title="recto"', 'title="verso"']
+            for label in ['title="TS 1 recto"', 'title="TS 1 verso"']
         )
         # test with recto side selected: should add class to recto div, but not verso div
         thumbnails_recto_selected = BeautifulSoup(
@@ -188,8 +188,8 @@ class TestFragment(TestCase):
         ).find_all("div", {"class": "selected"})
 
         assert len(thumbnails_recto_selected) == 1
-        assert 'title="recto"' in str(thumbnails_recto_selected[0])
-        assert 'title="verso"' not in str(thumbnails_recto_selected[0])
+        assert 'title="TS 1 recto"' in str(thumbnails_recto_selected[0])
+        assert 'title="TS 1 verso"' not in str(thumbnails_recto_selected[0])
 
         frag.iiif_url = "http://example.co/iiif/ts-1"
         # return simplified part of the manifest we need for this
@@ -235,8 +235,8 @@ class TestFragment(TestCase):
             '<img src="http://example.co/iiif/ts-1/00001/full/,200/0/default.jpg" loading="lazy"'
             in thumbnails
         )
-        assert 'title="1r"' in thumbnails
-        assert 'title="1v"' in thumbnails
+        assert 'title="TS 1 1r"' in thumbnails
+        assert 'title="TS 1 1v"' in thumbnails
         assert isinstance(thumbnails, SafeString)
 
         # test with verso side selected: should add class to 1v div, but not 1r div
@@ -245,8 +245,8 @@ class TestFragment(TestCase):
         ).find_all("div", {"class": "selected"})
 
         assert len(thumbnails_recto_selected) == 1
-        assert 'title="1v"' in str(thumbnails_recto_selected[0])
-        assert 'title="1r"' not in str(thumbnails_recto_selected[0])
+        assert 'title="TS 1 1v"' in str(thumbnails_recto_selected[0])
+        assert 'title="TS 1 1r"' not in str(thumbnails_recto_selected[0])
 
     @pytest.mark.django_db
     @patch("geniza.corpus.models.GenizaManifestImporter")
@@ -2297,14 +2297,47 @@ class TestTextBlock:
         )
         assert str(block2) == "%s recto (?)" % frag.shelfmark
 
-    def test_thumbnail(self):
+    def test_thumbnail(self, source):
         doc = Document.objects.create()
         frag = Fragment.objects.create(shelfmark="T-S 8J22.21")
+
+        # case 1: fragment has IIIF images
         block = TextBlock.objects.create(
             document=doc, fragment=frag, selected_images=[0]
         )
         with patch.object(frag, "iiif_thumbnails") as mock_frag_thumbnails:
             assert block.thumbnail() == mock_frag_thumbnails.return_value
+            mock_frag_thumbnails.assert_called_with(selected=[0], canvases=[])
+
+        # case 2: fragment has no IIIF images, should use placeholder path
+        block2 = TextBlock.objects.create(document=doc, fragment=frag)
+        footnote = Footnote.objects.create(
+            content_object=doc, source=source, doc_relation=Footnote.DIGITAL_EDITION
+        )
+        with patch.object(frag, "iiif_images", return_value=None):
+            # create annotations that match this textblock
+            for i in range(2):
+                Annotation.objects.create(
+                    footnote=footnote,
+                    content={
+                        "target": {
+                            "source": {
+                                "id": f"{doc.pk}/iiif/textblock/{block2.pk}/canvas/{i+1}/"
+                            }
+                        },
+                        "body": [{"label": "Recto or Verso"}],
+                    },
+                )
+            with patch.object(frag, "iiif_thumbnails") as mock_frag_thumbs:
+                mock_frag_thumbs.return_value = "placeholder_thumbs"
+                result2 = block2.thumbnail()
+                # thumbnail canvases should be from annotations
+                canvases_passed = mock_frag_thumbs.call_args[1]["canvases"]
+                assert canvases_passed == [
+                    f"{doc.pk}/iiif/textblock/{block2.pk}/canvas/1/",
+                    f"{doc.pk}/iiif/textblock/{block2.pk}/canvas/2/",
+                ]
+                assert result2 == "placeholder_thumbs"
 
     def test_side(self):
         doc = Document.objects.create()

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -810,7 +810,8 @@ class TestDocumentSearchView:
         SolrClient().update.index(
             [
                 document.index_data(),  # shelfmark = CUL Add.2586
-                doc2.index_data(),  # shelfmark = T-S 16.377
+                doc2.index_data(),  # shelfmark = T-S 16.377,
+                doc3.index_data(),  # shelfmark = T-S 16.4,
             ],
             commit=True,
         )

--- a/sitemedia/css/admin-local.css
+++ b/sitemedia/css/admin-local.css
@@ -333,6 +333,13 @@ div.field-admin_thumbnails img {
 #textblock_set-group td.field-thumbnail {
     min-width: 314px;
 }
+div.field-admin_thumbnails .admin-thumbnail::before {
+    content: attr(title);
+    display: block;
+    text-align: center;
+    margin-top: 8px;
+    font-size: 14px;
+}
 /* selected side thumbnail for fragment admin */
 #textblock_set-group td.field-thumbnail .admin-thumbnail.selected,
 div.field-admin_thumbnails .admin-thumbnail.selected {

--- a/sitemedia/js/admin.js
+++ b/sitemedia/js/admin.js
@@ -429,35 +429,42 @@ function rotate(node, degrees) {
         const img = node.querySelector("img");
         const src = img.getAttribute("src");
         const uriMatches = src.match(/\/\d+\//g);
-        const originalRotation = parseInt(
-            uriMatches[uriMatches.length - 1].replace(/\//g, "")
-        );
-        // set the new rotation (taking into consideration the original from URI) as a class
-        node.className = node.classList.contains("selected") ? "selected" : "";
-        const classList = [
-            "admin-thumbnail",
-            `rotate-${normalize360(newRotation - originalRotation)}`,
-        ];
-        node.classList.add(...classList);
+        if (uriMatches) {
+            const originalRotation = parseInt(
+                uriMatches[uriMatches.length - 1].replace(/\//g, "")
+            );
+            // set the new rotation (taking into consideration the original from URI) as a class
+            node.className = node.classList.contains("selected")
+                ? "selected"
+                : "";
+            const classList = [
+                "admin-thumbnail",
+                `rotate-${normalize360(newRotation - originalRotation)}`,
+            ];
+            node.classList.add(...classList);
 
-        // adjust the width and height of the container to accommodate the rotated image,
-        // accounting for controls
-        const rect = img.getBoundingClientRect();
-        const controlRect = node
-            .querySelector(".rotation-controls")
-            .getBoundingClientRect();
-        const checkboxRect = node
-            .querySelector("input[type='checkbox']")
-            .getBoundingClientRect();
+            // adjust the width and height of the container to accommodate the rotated image,
+            // accounting for controls
+            const rect = img.getBoundingClientRect();
+            const controlRect = node
+                .querySelector(".rotation-controls")
+                .getBoundingClientRect();
+            const checkboxRect = node
+                .querySelector("input[type='checkbox']")
+                .getBoundingClientRect();
 
-        node.style.minWidth = `${rect.width}px`;
-        node.style.minHeight = `${
-            rect.height + controlRect.height + checkboxRect.height
-        }px`;
+            node.style.minWidth = `${rect.width}px`;
+            node.style.minHeight = `${
+                rect.height + controlRect.height + checkboxRect.height
+            }px`;
 
-        // finally, update the rotations on the hidden rotation overrides field
-        overrides[canvasUri]["rotation"] = newRotation;
-        imageOverridesField.setAttribute("value", JSON.stringify(overrides));
+            // finally, update the rotations on the hidden rotation overrides field
+            overrides[canvasUri]["rotation"] = newRotation;
+            imageOverridesField.setAttribute(
+                "value",
+                JSON.stringify(overrides)
+            );
+        }
     };
 }
 


### PR DESCRIPTION
**Associated Issue(s):** #1942

### Changes in this PR

- Update the Document image reordering tool to allow reordering placeholders, when they include transcription or translation content
   - Include labels above each image showing both the shelfmark and the canvas label (e.g. "T-S 1 recto", "T-S 1 verso") so users know which placeholder is which
- Migrate all annotations using old-style placeholders (pre-[#1306](https://github.com/Princeton-CDH/geniza/pull/1306))—which were not associated with Fragment records—to allow integration with the reordering tool

### Notes

- The annotation migration is necessary since before [#1306](https://github.com/Princeton-CDH/geniza/pull/1306), our way of generating placeholder canvases just used the document id, but did not associate each placeholder canvas to a fragment.
   - This causes problems with the reordering logic, since the reordering tool must stay in sync with the fragments section in terms of which images are selected.
   - In addition, we wouldn't be able to label the placeholders as belonging to one fragment or another, so it would be impossible for the user to tell which placeholder canvas contains which content in the reordering tool.
- I decided to make it a manual migration using a management command, rather than an automated data migration, simply because the latter would require re-implementing a _ton_ of custom model methods, which automated data migrations [cannot use](https://docs.djangoproject.com/en/6.0/topics/migrations/#historical-models).

Screenshot of the new reordering section, with labels and a placeholder:

<img width="1109" height="370" alt="Screenshot 2025-12-08 at 2 43 16 PM" src="https://github.com/user-attachments/assets/c508db25-567e-475a-8145-bb8b6e4ecc5e" />


### Reviewer Checklist

- [ ] Run `python manage.py migrate_orphan_placeholders` to ensure all placeholder canvases work with the reordering tool