### PR TITLE
Make desktop Person network graph square (#1944)

### DIFF
--- a/sitemedia/scss/pages/_person.scss
+++ b/sitemedia/scss/pages/_person.scss
@@ -367,6 +367,9 @@ main.person {
     .network-graph {
         width: 100%;
         height: 24.125rem;
+        @include breakpoints.for-tablet-landscape-up {
+            height: 56rem;
+        }
         margin-top: (2.25rem + spacing.$spacing-xs);
         background-color: var(--network-graph-bg);
         cursor: grab;


### PR DESCRIPTION
**Associated Issue(s):** #1944

### Changes in this PR

- Add some CSS to make the person network graph square (1:1 aspect ratio) on desktop
