### PR TITLE
Description language switcher on document detail page (#1949)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -878,6 +878,23 @@ class Document(ModelIndexable, DocumentDateMixin, PermalinkMixin, TaggableMixin)
             f"{long_name}. {available} {at_pgp} {permalink} (accessed {today})."
         )
 
+    @property
+    def description_translations(self):
+        """list of dictionaries of translated descriptions, with one dict per
+        language present, for the Document detail view.
+        ex. [{'lang': 'he', 'content': 'he description'},
+            {'lang': 'en', 'content': 'en description'}]
+        """
+        descriptions = []
+        # check all languages we have configured
+        for lang, _ in settings.LANGUAGES:
+            field_name = f"description_{lang}"
+            content = getattr(self, field_name, "")
+            # only include if it has content in this language
+            if content and content.strip():
+                descriptions.append({"lang": lang, "content": content})
+        return descriptions
+
     def is_public(self):
         """admin display field indicating if doc is public or suppressed"""
         return self.status == self.PUBLIC

--- a/geniza/corpus/templates/corpus/document_detail.html
+++ b/geniza/corpus/templates/corpus/document_detail.html
@@ -139,11 +139,49 @@
             {% endwith %}
         {% endif %}
 
-        <section class="description">
-            {# Translators: label for document description #}
-            <h2>{% translate 'Description' %}</h2>
-            <p>{{ document.description|pgp_urlize }}</p>
-        </section>
+        {% if descriptions %}
+            <section class="description">
+                {# if multiple description languages, show the dropdown + include stimulus controller #}
+                {% if descriptions|length > 1 %}
+                    <div
+                        data-controller="description"
+                        data-description-hidden-class="hidden"
+                    >
+                        <div class="description-header">
+                            {# Translators: label for document description #}
+                            <h2>{% translate 'Description' %}</h2>
+                            {# language selector dropdown #}
+                            <select
+                                data-description-target="selector"
+                                data-action="change->description#changeLanguage"
+                            >
+                                {% for description in descriptions %}
+                                    <option value="{{ description.lang }}" {% if description.lang == LANGUAGE_CODE %}selected{% endif %}>
+                                        {{ description.lang|upper }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        {# render descriptions in all languages and hide if not currently selected #}
+                        {% for description in descriptions %}
+                            <div
+                                data-description-target="description"
+                                lang="{{ description.lang }}"
+                                class="{% if description.lang != LANGUAGE_CODE %}hidden{% endif %}"
+                                {% if description.lang == "ar" or description.lang == "he" %} dir="rtl"{% endif %}
+                            >
+                                <p>{{ description.content|pgp_urlize }}</p>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    {# if only one translation exists, display it without controller & dropdown #}
+                    <h2>{% translate 'Description' %}</h2>
+                    <p>{{ descriptions.0.content|pgp_urlize }}</p>
+                {% endif %}
+            </section>
+
+        {% endif %}
 
         {# related people #}
         {% if related_people.exists %}

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1782,6 +1782,33 @@ class TestDocument:
         TextBlock.objects.create(fragment=f2, document=document)
         assert document.fragments_by_material_support[0].pk == f1.pk
 
+    def test_description_translations(self):
+        document = Document.objects.create(
+            description="Letter from Abū Zikrī Kohen, in Fustat, to Ḥalfon b. Netanʾel"
+        )
+        # should include just one language, english
+        assert len(document.description_translations) == 1
+        assert document.description_translations[0]["lang"] == "en"
+        assert document.description_translations[0]["content"] == document.description
+
+        # should include the hebrew description as a second dict
+        document.description_he = "מכתב קצר מאת אבו זִכְּרִי כהן אל חלפון"
+        assert len(document.description_translations) == 2
+        he_entry = next(
+            (t for t in document.description_translations if t["lang"] == "he"), None
+        )
+        assert he_entry is not None
+        assert he_entry["content"] == document.description_he
+
+        # should include the arabic description as a third dict
+        document.description_ar = "الفسطاط الى ابي الفرج عوكل ادام الله عزه"
+        assert len(document.description_translations) == 3
+        ar_entry = next(
+            (t for t in document.description_translations if t["lang"] == "ar"), None
+        )
+        assert ar_entry is not None
+        assert ar_entry["content"] == document.description_ar
+
 
 def test_document_merge_with(document, join):
     doc_id = document.id

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -558,6 +558,7 @@ class DocumentDetailView(DocumentDetailBase, DetailView):
                 "related_places": self.object.documentplacerelation_set.order_by(
                     "type__order", "type__name", "place__slug"
                 ),
+                "descriptions": self.object.description_translations,
             }
         )
         return context_data

--- a/sitemedia/js/controllers/description_controller.js
+++ b/sitemedia/js/controllers/description_controller.js
@@ -1,0 +1,25 @@
+// controllers/description_controller.js
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["description", "selector"];
+    static classes = ["hidden"];
+
+    connect() {
+        // set the description language to the user's preferred language first
+        this.changeLanguage();
+    }
+
+    changeLanguage() {
+        // change the description language by showing the selected one
+        // and hiding the deselected ones
+        const selectedLang = this.selectorTarget.value;
+        this.descriptionTargets.forEach((description) => {
+            if (description.getAttribute("lang") === selectedLang) {
+                description.classList.remove(this.hiddenClass);
+            } else {
+                description.classList.add(this.hiddenClass);
+            }
+        });
+    }
+}

--- a/sitemedia/scss/pages/_document.scss
+++ b/sitemedia/scss/pages/_document.scss
@@ -5,6 +5,7 @@
 @use "../base/breakpoints";
 @use "../base/colors";
 @use "../base/container";
+@use "../base/fonts";
 @use "../base/spacing";
 @use "../base/typography";
 
@@ -185,6 +186,26 @@ main.document {
             p {
                 white-space: pre-line;
                 padding-left: 1.25rem;
+            }
+            div.description-header {
+                display: flex;
+                flex-flow: row;
+                gap: 1rem;
+                select {
+                    cursor: pointer;
+                    font-family: fonts.$primary-bold;
+                    font-size: typography.$text-size-md;
+                    background-color: var(--background-light);
+                    color: var(--on-background-light);
+                    border: 1px solid var(--background-gray);
+                    border-radius: 5px;
+                    padding: 0.3rem 0.25rem;
+                    font-weight: 700;
+                }
+                margin-bottom: 0.25rem;
+            }
+            div.hidden {
+                display: none;
             }
         }
         // related entities


### PR DESCRIPTION
**Associated Issue(s):** #1949

### Changes in this PR

- When descriptions exist in more than one language on a document, show a switcher on the document detail page per designs
   - The switcher only selects which language is used for the description, but the rest of the page remains in the user's preferred langugae
- Only show languages that actually have description content
