### PR TITLE
Add document URLs (admin and public) to person relations export

### DIFF
--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -439,7 +439,7 @@ class PersonRelationsExporter(RelationsExporter):
                         "relationship_type": place_relation_typedict.get(rel[RTID]),
                         "shared_documents": ", ".join(
                             [
-                                docs_dict.get(doc_id)
+                                str(docs_dict.get(doc_id))
                                 for doc_id in placedocs_dict.get(rel[ID], [])
                             ]
                         ),

--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -244,7 +244,7 @@ class PersonRelationsExporter(RelationsExporter):
     """
 
     model = Person
-    csv_fields = ["source_person"] + RelationsExporter.csv_fields
+    csv_fields = ["source_person"] + RelationsExporter.csv_fields + ["url", "admin_url"]
 
     def get_queryset(self):
         """Override get_queryset to get related items for the single item"""
@@ -386,7 +386,7 @@ class PersonRelationsExporter(RelationsExporter):
                 ),
             )
         ).filter(id__in=related_docs)
-        docs_dict = {d.id: str(d) for d in docs}
+        docs_dict = {d.id: d for d in docs}
 
         # get Event names
         events = Event.objects.filter(id__in=related_events).values("id", "name")
@@ -449,9 +449,11 @@ class PersonRelationsExporter(RelationsExporter):
                 # get doc name, doc relation type name from precomputed querysets
                 rel.update(
                     {
-                        "related_object_name": docs_dict.get(rel[ID]),
+                        "related_object_name": str(docs_dict.get(rel[ID])),
                         "relationship_type": doc_relation_typedict.get(rel[RTID])
                         + (" (uncertain)" if rel["is_uncertain"] else ""),
+                        "url": f"{self.url_scheme}{self.site_domain}/en/documents/{rel[ID]}/",
+                        "admin_url": f"{self.url_scheme}{self.site_domain}/admin/corpus/document/{rel[ID]}/change/",
                     }
                 )
             elif rel[TYPE] == "Event":
@@ -461,7 +463,7 @@ class PersonRelationsExporter(RelationsExporter):
                         "related_object_name": events_dict.get(rel[ID]),
                         "shared_documents": ", ".join(
                             [
-                                docs_dict.get(doc_id)
+                                str(docs_dict.get(doc_id))
                                 for doc_id in eventdocs_dict.get(rel[ID], [])
                             ]
                         ),

--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -420,7 +420,7 @@ class PersonRelationsExporter(RelationsExporter):
                         ),
                         "shared_documents": ", ".join(
                             [
-                                docs_dict.get(doc_id)
+                                str(docs_dict.get(doc_id))
                                 for doc_id in persondocs_dict.get(rel[ID], [])
                             ]
                         ),


### PR DESCRIPTION
**Associated Issue(s):** resolves #1945

### Changes in this PR
Identifying the documents related to a person in the person relation export

- Linking the public site's document
- Linking the admin module's document

### Notes
To generate the export:

- Open the admin site and login
- Click into the people module
- Click into an individual person
- Click on "Download relations as CSV" at the top right corner
- The downloaded CSV should have two new columns "url" and "admin_url" linking to the document where this person is mentioned

### Reviewer Checklist

- [x] Automated tests pass 100%
- [x] Exports have the new columns with correct linking to the correct documents
