### PR TITLE
Add related places to documents' export

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -527,7 +527,7 @@ islamic_month_aliases = {
     "Rabi' I": "Rabi' al-`Awwal",
     # NOTE: trailing commas are typeod in convertdate; will be fixed in 2.4.1
     "Rabi' II": "Rabi' ath-Thani,",
-    "Jumada I": "Jumada al-`Awwal,",
+    "Jumada I": "Jumada al-`Awwal",
     "Jumada II": "Jumada ath-Thaniyah,",
     "Dhu l-Qa'da": "Zu al-Qa'dah",
     "Dhu l-Hijja": "Zu al-Hijjah",

--- a/geniza/corpus/metadata_export.py
+++ b/geniza/corpus/metadata_export.py
@@ -1,7 +1,13 @@
 from django.db.models.query import Prefetch
+from django.utils.text import slugify
 
 from geniza.common.metadata_export import Exporter
 from geniza.corpus.models import Document, Fragment
+from geniza.entities.models import (
+    DocumentPlaceRelation,
+    DocumentPlaceRelationType,
+    Place,
+)
 from geniza.footnotes.models import Footnote
 
 
@@ -61,6 +67,14 @@ class DocumentExporter(Exporter):
         ],
     }
 
+    def __init__(self, queryset=None, progress=False):
+        """Adds fields to the export based on PersonPlaceRelationType names"""
+        self.csv_fields[31:31] = [
+            slugify(dpr_type.name).replace("-", "_")
+            for dpr_type in DocumentPlaceRelationType.objects.order_by("name")
+        ]
+        super().__init__(queryset, progress)
+
     def get_queryset(self):
         """
         Applies some prefetching to the base Exporter's get_queryset functionality.
@@ -79,6 +93,7 @@ class DocumentExporter(Exporter):
                 "log_entries",
                 "log_entries__user",
                 "dating_set",
+                "documentplacerelation_set",
                 Prefetch(
                     "footnotes",
                     queryset=Footnote.objects.select_related(
@@ -138,9 +153,9 @@ class DocumentExporter(Exporter):
 
         # to make the download as efficient as possible, don't use
         # absolutize_url, reverse, or get_absolute_url methods
-        outd[
-            "url"
-        ] = f"{self.url_scheme}{self.site_domain}/documents/{doc.id}/"  # public site url
+        outd["url"] = (
+            f"{self.url_scheme}{self.site_domain}/documents/{doc.id}/"  # public site url
+        )
 
         sep_within_cells = self.sep_within_cells
 
@@ -196,6 +211,25 @@ class DocumentExporter(Exporter):
         outd["has_transcription"] = doc.has_transcription()
         outd["has_translation"] = doc.has_translation()
 
+        # group related places by relation type name
+        related_places = DocumentPlaceRelation.objects.filter(
+            document__id=doc.pk
+        ).values("place__id", "type__name")
+        rel_types = related_places.values_list("type__name", flat=True).distinct()
+        related_place_ids = {}
+        for type_name in rel_types:
+            related_place_ids[type_name] = (
+                related_places.filter(type__name=type_name)
+                .values_list("place__id", flat=True)
+                .distinct()
+            )
+
+        # get names of related places (grouped by type name) and set on output dict
+        for [type_name, place_ids] in related_place_ids.items():
+            outd[slugify(type_name).replace("-", "_")] = ", ".join(
+                sorted([str(place) for place in Place.objects.filter(id__in=place_ids)])
+            )
+
         return outd
 
 
@@ -216,9 +250,9 @@ class AdminDocumentExporter(DocumentExporter):
         outd["notes"] = doc.notes
         outd["needs_review"] = doc.needs_review
         outd["status"] = doc.get_status_display()
-        outd[
-            "url_admin"
-        ] = f"{self.url_scheme}{self.site_domain}/admin/corpus/document/{doc.id}/change/"
+        outd["url_admin"] = (
+            f"{self.url_scheme}{self.site_domain}/admin/corpus/document/{doc.id}/change/"
+        )
 
         return outd
 
@@ -255,7 +289,7 @@ class FragmentExporter(Exporter):
         "last_modified",
         "provenance_display",
         "provenance",
-        "material_support"
+        "material_support",
     ]
 
     # queryset filter for content types included in this import
@@ -290,7 +324,7 @@ class FragmentExporter(Exporter):
             "last_modified": fragment.last_modified,
             "provenance_display": fragment.provenance_display,
             "provenance": fragment.provenance,
-            "material_support": fragment.material_support
+            "material_support": fragment.material_support,
         }
         # it's possible (although unlikely) for collection to be unset
         if fragment.collection:
@@ -332,7 +366,7 @@ class AdminFragmentExporter(FragmentExporter):
         data = super().get_export_data_dict(fragment)
         data["notes"] = fragment.notes
         data["needs_review"] = fragment.needs_review
-        data[
-            "url_admin"
-        ] = f"{self.url_scheme}{self.site_domain}/admin/corpus/fragment/{fragment.id}/change/"
+        data["url_admin"] = (
+            f"{self.url_scheme}{self.site_domain}/admin/corpus/fragment/{fragment.id}/change/"
+        )
         return data

--- a/geniza/corpus/tests/test_metadata_export.py
+++ b/geniza/corpus/tests/test_metadata_export.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from geniza.corpus.metadata_export import (
     AdminDocumentExporter,
+    DocumentExporter,
     FragmentExporter,
     PublicDocumentExporter,
     PublicFragmentExporter,
@@ -18,6 +19,12 @@ from geniza.corpus.models import (
     DocumentType,
     Fragment,
     LanguageScript,
+)
+from geniza.entities.models import (
+    DocumentPlaceRelation,
+    DocumentPlaceRelationType,
+    Name,
+    Place,
 )
 from geniza.footnotes.models import Creator, Footnote, Source, SourceType
 
@@ -133,6 +140,31 @@ def test_iter_dicts(document):
                 "expect input date (%s) to be earlier than last modified (%s) [PGPID %s]"
                 % (input_date, last_modified, doc.id)
             )
+
+
+@pytest.mark.django_db
+def test_export_doc_places(document):
+
+    mosul = Place.objects.create(slug="mosul")
+    Name.objects.create(content_object=mosul, name="Mosul", primary=True)
+    Name.objects.create(content_object=mosul, name="الموصل", primary=False)
+    fustat = Place.objects.create(slug="fustat")
+    Name.objects.create(content_object=fustat, name="Fustat", primary=True)
+
+    (dest, _) = DocumentPlaceRelationType.objects.get_or_create(name="Destination")
+    (ment, _) = DocumentPlaceRelationType.objects.get_or_create(
+        name="Possibly mentioned"
+    )
+
+    DocumentPlaceRelation.objects.create(place=mosul, type=dest, document=document)
+    DocumentPlaceRelation.objects.create(place=fustat, type=ment, document=document)
+
+    doc_qs = Document.objects.all().order_by("id")
+    exporter = DocumentExporter(queryset=doc_qs)
+    print(exporter.iter_dicts())
+    for export_data in exporter.iter_dicts():
+        assert "Mosul" in export_data.get("destination")
+        assert "Fustat" in export_data.get("possibly_mentioned")
 
 
 @pytest.mark.django_db

--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -1,6 +1,5 @@
 from itertools import groupby
 from operator import itemgetter
-from time import sleep
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, Value
@@ -129,7 +128,7 @@ class PublicPersonExporter(Exporter):
         if person.get_absolute_url():
             outd["url"] = person.permalink
 
-        # grop related places by relation type name
+        # group related places by relation type name
         related_places = PersonPlaceRelation.objects.filter(
             person__id=person.pk
         ).values("place__id", "type__name")


### PR DESCRIPTION
**Associated Issue(s):** resolves #1947

### Changes in this PR
Displaying the related places to a person in the documents export

- Displaying a document's related places in the category `mentioned` separated by commas (if any)
- Displaying a document's related places in the category `location` separated by commas (if any)
- Displaying a document's related places in the category `destination` separated by commas (if any)
- Displaying a document's related places in the category `formerly believed to be mentioned` separated by commas (if any)
- Displaying a document's related places in the category `possibly mentioned` separated by commas (if any)
- Displaying a document's related places in the category `origin` separated by commas (if any)

### Notes
To generate the export:

- Open the admin site and login
- Click into the document module
- Check some documents (some of which or all have at least one related place)
- From the Combo box at the top choose the action of "Export selected documents into CSV" then push Go
- The downloaded CSV should have columns corresponding to the related places categories of the selected documents (mentioned, location, destination, formerly believed to be mentioned, possibly mentioned, and origin) or none if the selected documents have no related places

### Reviewer Checklist

- [x] Automated tests pass 100%
- [x] Exports have the new columns with correct linking to the correct documents

