### PR TITLE
Fixing a bug where some columns of some export CSVs are replicated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Python 3.12 / Django 5.2 / Node 22 / Postgresql 16 / Solr 9.9
    :target: https://doi.org/10.5281/zenodo.7347726
 
 .. image:: https://github.com/Princeton-CDH/geniza/workflows/unit%20tests/badge.svg
-    :target: https://github.com/Princeton-CDH/geniza/actions?query=workflow%3Aunit&20tests
+    :target: https://github.com/Princeton-CDH/geniza/actions/workflows/unit_tests.yml?query=branch%3Amain++
     :alt: Unit Test status
 
 .. image:: https://codecov.io/gh/Princeton-CDH/geniza/branch/main/graph/badge.svg

--- a/geniza/corpus/metadata_export.py
+++ b/geniza/corpus/metadata_export.py
@@ -69,6 +69,7 @@ class DocumentExporter(Exporter):
 
     def __init__(self, queryset=None, progress=False):
         """Adds fields to the export based on PersonPlaceRelationType names"""
+        self.csv_fields = list(self.csv_fields)
         self.csv_fields[31:31] = [
             slugify(dpr_type.name).replace("-", "_")
             for dpr_type in DocumentPlaceRelationType.objects.order_by("name")

--- a/geniza/corpus/tests/test_metadata_export.py
+++ b/geniza/corpus/tests/test_metadata_export.py
@@ -143,6 +143,17 @@ def test_iter_dicts(document):
 
 
 @pytest.mark.django_db
+def test_doc_export_columns_unique():
+
+    from geniza.corpus.metadata_export import AdminDocumentExporter
+
+    exp1 = AdminDocumentExporter()
+    len1 = len(exp1.csv_fields)
+    exp2 = AdminDocumentExporter()
+    len2 = len(exp2.csv_fields)
+    assert len1 == len2
+
+
 def test_export_doc_places(document):
 
     mosul = Place.objects.create(slug="mosul")

--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -58,6 +58,7 @@ class PublicPersonExporter(Exporter):
 
     def __init__(self, queryset=None, progress=False):
         """Adds fields to the export based on PersonPlaceRelationType names"""
+        self.csv_fields = list(self.csv_fields)
         self.csv_fields[9:9] = [
             slugify(ppr_type.name).replace("-", "_")
             for ppr_type in PersonPlaceRelationType.objects.order_by("name")

--- a/geniza/entities/tests/test_entities_metadata_export.py
+++ b/geniza/entities/tests/test_entities_metadata_export.py
@@ -386,3 +386,15 @@ def test_place_relations_csv(person, document, join):
             assert "relationship_type" not in obj
             assert obj["related_object_name"] == evt.name
             assert obj["relationship_notes"] == "test"
+
+
+@pytest.mark.django_db
+def test_people_export_columns_unique():
+
+    from geniza.entities.metadata_export import AdminPersonExporter
+
+    exp1 = AdminPersonExporter()
+    len1 = len(exp1.csv_fields)
+    exp2 = AdminPersonExporter()
+    len2 = len(exp2.csv_fields)
+    assert len1 == len2

--- a/geniza/entities/tests/test_entities_metadata_export.py
+++ b/geniza/entities/tests/test_entities_metadata_export.py
@@ -391,8 +391,6 @@ def test_place_relations_csv(person, document, join):
 @pytest.mark.django_db
 def test_people_export_columns_unique():
 
-    from geniza.entities.metadata_export import AdminPersonExporter
-
     exp1 = AdminPersonExporter()
     len1 = len(exp1.csv_fields)
     exp2 = AdminPersonExporter()


### PR DESCRIPTION
**Associated Issue(s):** resolves #1966 and #1964 

### Changes in this PR

- Fixes for places and documents exports
- A test for each
- Correcting the unit tests badge on the readme to display success based on the stable (main) branch only

### Reviewer Checklist

- [x] Can't replicate the bug for places export
- [x] Can't replicate the bug for documents export
- [x] All tests pass 100%
