### PR TITLE
Add LTR and RTL buttons to transcription/translation text editor (#1974)

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -109,7 +109,7 @@ class Annotation(TrackChangesModel):
 
     # allowed tags and attributes for annotation body content HTML
     ALLOWED_TAGS = ["del", "li", "ol", "p", "span", "sup", "i"]
-    ALLOWED_ATTRIBUTES = ["lang"]
+    ALLOWED_ATTRIBUTES = ["lang", "dir"]
 
     # error message for malformed annotations
     MALFORMED_ERROR = (

--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -232,11 +232,14 @@ class Annotation(TrackChangesModel):
         top_list = soup.find(["ul", "ol"])
         if not top_list:
             return html_string
+        # allow attrs in top-level list
         top_list_with_attrs, _ = str(top_list).split(">", 1)
         start = f"{top_list_with_attrs}>"
         end = f"</{top_list.name}>"
-        needs_closing = re.sub(r"</?(ol|ul)[^>]*>", "", html_string).replace(
-            "<li>", f"{start}<li>", 1
+        needs_closing = re.sub(r"</?(ol|ul)[^>]*>", "", html_string)
+        # prepend start tag before first li, while allowing li attrs to remain
+        needs_closing = re.sub(
+            r"(<li[^>]*>)", lambda m: f"{start}{m.group(1)}", needs_closing, count=1
         )
         splitted = needs_closing.rsplit("</li>", 1)
         if len(splitted) >= 2:

--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -230,20 +230,20 @@ class Annotation(TrackChangesModel):
         if not li_elem:
             return html_string
         top_list = soup.find(["ul", "ol"])
-        start, end = "", ""
-        if str(top_list)[:4] == "<ol>":
-            start, end = "<ol>", "</ol>"
-        else:
-            start, end = "<ul>", "</ul>"
-        needs_closing = (
-            html_string.replace("<ol>", "")
-            .replace("</ol>", "")
-            .replace("<ul>", "")
-            .replace("</ul>", "")
-            .replace("<li>", f"{start}<li>", 1)
+        if not top_list:
+            return html_string
+        top_list_with_attrs, _ = str(top_list).split(">", 1)
+        start = f"{top_list_with_attrs}>"
+        end = f"</{top_list.name}>"
+        needs_closing = re.sub(r"</?(ol|ul)[^>]*>", "", html_string).replace(
+            "<li>", f"{start}<li>", 1
         )
         splitted = needs_closing.rsplit("</li>", 1)
-        return f"{splitted[0]}</li>{end}{splitted[1]}"
+        if len(splitted) >= 2:
+            return f"{splitted[0]}</li>{end}{splitted[1]}"
+
+        # fallback
+        return html_string
 
     @classmethod
     def sanitize_html(cls, html):

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -169,6 +169,18 @@ class TestAnnotation:
             == '<p></p><ol dir="rtl"><li><p>First</p></li><li><p>First.one</p></li></ol>'
         )
 
+        # should fallback to original string if there are no <li> elements
+        html_no_li = "<p>Just a standard paragraph</p>"
+        assert Annotation.flatten_html_list(html_no_li) == html_no_li
+
+        # should fallback to original string if there is an <li> but no <ol> or <ul>
+        html_orphan_li = "<li>orphan item</li>"
+        assert Annotation.flatten_html_list(html_orphan_li) == html_orphan_li
+
+        # should fallback to original string if there is no closing </li> tag
+        html_unclosed_li = "<ul><li>unclosed item</ul>"
+        assert Annotation.flatten_html_list(html_unclosed_li) == html_unclosed_li
+
     def test_sanitize_html(self):
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'
         # should strip out all unwanted elements and attributes (table, div, style)

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -151,12 +151,23 @@ class TestAnnotation:
         assert "@context" not in compiled
 
     def test_flatten_html_lists(self):
-        html_nested_ol = '<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>'
-        assert Annotation.flatten_html_list(
-            html_nested_ol) == '<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>'
-        html_nested_ul = '<p></p><ul><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ul>'
-        assert Annotation.flatten_html_list(
-            html_nested_ul) == '<p></p><ul><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ul>'
+        html_nested_ol = "<p></p><ol><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ol>"
+        assert (
+            Annotation.flatten_html_list(html_nested_ol)
+            == "<p></p><ol><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ol>"
+        )
+        html_nested_ul = "<p></p><ul><li><p>First</p></li><ol><li><p>First.one</p></li><li><p>First.two</p></li></ol><li><p>Second</p></li><ul><li><p>Second.one</p></li><li><p>Second.two</p></li></ul><li><p>Third</p></li><ol><li><p>Third.one</p></li><li><p>Third.two</p></li></ol></ul>"
+        assert (
+            Annotation.flatten_html_list(html_nested_ul)
+            == "<p></p><ul><li><p>First</p></li><li><p>First.one</p></li><li><p>First.two</p></li><li><p>Second</p></li><li><p>Second.one</p></li><li><p>Second.two</p></li><li><p>Third</p></li><li><p>Third.one</p></li><li><p>Third.two</p></li></ul>"
+        )
+
+        # should preserve attributes on the top-level list
+        html_nested_ol_attr = '<p></p><ol dir="rtl"><li><p>First</p></li><ol><li><p>First.one</p></li></ol></ol>'
+        assert (
+            Annotation.flatten_html_list(html_nested_ol_attr)
+            == '<p></p><ol dir="rtl"><li><p>First</p></li><li><p>First.one</p></li></ol>'
+        )
 
     def test_sanitize_html(self):
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'
@@ -167,6 +178,10 @@ class TestAnnotation:
         # should do nothing to html with all allowed elements
         html = '<p>test <span lang="en">en</span></p><ol><li>line 1</li><li>line 2</li></ol>'
         assert Annotation.sanitize_html(html) == html
+
+        # should allow dir attribute on permitted elements
+        html_dir = '<p dir="rtl">test <span dir="ltr">en</span></p><ol dir="rtl"><li dir="rtl">line 1</li></ol>'
+        assert Annotation.sanitize_html(html_dir) == html_dir
 
         # should remove span elements with no attributes after bleaching
         html = '<p>text <span style="foo:bar">and</span> more text</p>'

--- a/geniza/footnotes/tests/test_footnote_models.py
+++ b/geniza/footnotes/tests/test_footnote_models.py
@@ -550,6 +550,24 @@ class TestFootnote:
         # handle None as input
         assert Footnote.explicit_line_numbers(None) is None
 
+        # should propagate ol dir attribute to li (without overriding existing li dir)
+        doc4 = Document.objects.create()
+        digital_edition4 = Footnote.objects.create(
+            content_object=doc4, source=source, doc_relation=[Footnote.DIGITAL_EDITION]
+        )
+        Annotation.objects.create(
+            footnote=digital_edition4,
+            content={
+                "body": [
+                    {"value": '<ol dir="rtl"><li>one</li><li dir="ltr">two</li></ol>'}
+                ],
+            },
+        )
+        assert (
+            Footnote.explicit_line_numbers(digital_edition4.content_html_str)
+            == '<ol dir="rtl"><li value="1" dir="rtl">one</li><li dir="ltr" value="2">two</li></ol>'
+        )
+
 
 class TestFootnoteQuerySet:
     @pytest.mark.django_db

--- a/geniza/footnotes/utils.py
+++ b/geniza/footnotes/utils.py
@@ -2,29 +2,37 @@ from html.parser import HTMLParser
 
 
 class HTMLLineNumberParser(HTMLParser):
-    """HTML parser to add numbering to line elements for search indexing purposes"""
+    """HTML parser to add numbering and directionality to line elements for search indexing purposes"""
 
     def __init__(self, *args, **kwargs):
-        """Initialize empty string and line numbering at 1"""
+        """Initialize empty string, line numbering at 1, and directionality"""
         self.html_str = ""
         self.line_number = 1
         self.within_ol = False
+        self.current_dir = None
         super().__init__(*args, **kwargs)
 
     def handle_starttag(self, tag, attrs):
-        """Restart line numbering on <ol>, include line number with <li>, and construct
+        """Restart line numbering on <ol>, capture its dir, include line number with <li>, and construct
         start tags with included attributes"""
         if tag == "ol":
             # restart line numbering, ol state indicator on encountering ol
             self.within_ol = True
             self.line_number = 1
-            for (attr, val) in attrs:
+            self.current_dir = None
+            for attr, val in attrs:
                 # if start present in attrs, restart to start number
                 if attr == "start":
                     self.line_number = int(val)
+                # capture the directionality of the list
+                elif attr == "dir":
+                    self.current_dir = val
         elif tag == "li" and self.within_ol:
             # append the line number as a data attribute
             attrs += [("value", str(self.line_number))]
+            # propagate directionality to li if parent ol had one
+            if self.current_dir and not any(a[0] == "dir" for a in attrs):
+                attrs += [("dir", self.current_dir)]
             # increment line number
             self.line_number += 1
         # construct attribute definitions and final start tag string
@@ -35,6 +43,7 @@ class HTMLLineNumberParser(HTMLParser):
         """Close all encountered HTML endtags"""
         if tag == "ol":
             self.within_ol = False
+            self.current_dir = None
         self.html_str += "</%s>" % (tag,)
 
     def handle_data(self, data):

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hotwired/turbo": "^8.0.13",
         "@recogito/annotorious": "^2.7.14",
         "@recogito/annotorious-openseadragon": "^2.7.19",
-        "annotorious-tahqiq": "^1.5.1",
+        "annotorious-tahqiq": "^1.6.0",
         "autoprefixer": "^10.3.2",
         "babel-loader": "^8.2.2",
         "core-js": "^3.16.3",
@@ -2620,9 +2620,10 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/annotorious-tahqiq": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.1.tgz",
-      "integrity": "sha512-PmVYtDdSwGBXHbB4pJZ4Xx4YMg8lIpqleBHI4lP2Ax1GJaImz/hEqQDQ/eMODWrsxE0KIkksGSZ/9gs65LH1sA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.6.0.tgz",
+      "integrity": "sha512-nUwA61luLCSB5KSpEja1uz9EuIjW3XQsx3YpPGdt006mExRX1B9H7rYErI7nTwCzs2dFDrCxr8FO+FdtbHN4lQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"
@@ -11085,9 +11086,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "annotorious-tahqiq": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.5.1.tgz",
-      "integrity": "sha512-PmVYtDdSwGBXHbB4pJZ4Xx4YMg8lIpqleBHI4lP2Ax1GJaImz/hEqQDQ/eMODWrsxE0KIkksGSZ/9gs65LH1sA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/annotorious-tahqiq/-/annotorious-tahqiq-1.6.0.tgz",
+      "integrity": "sha512-nUwA61luLCSB5KSpEja1uz9EuIjW3XQsx3YpPGdt006mExRX1B9H7rYErI7nTwCzs2dFDrCxr8FO+FdtbHN4lQ==",
       "requires": {
         "@tinymce/tinymce-webcomponent": "^2.0.0",
         "@ungap/custom-elements": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hotwired/turbo": "^8.0.13",
     "@recogito/annotorious": "^2.7.14",
     "@recogito/annotorious-openseadragon": "^2.7.19",
-    "annotorious-tahqiq": "^1.5.1",
+    "annotorious-tahqiq": "^1.6.0",
     "autoprefixer": "^10.3.2",
     "babel-loader": "^8.2.2",
     "core-js": "^3.16.3",

--- a/sitemedia/js/controllers/annotation_controller.js
+++ b/sitemedia/js/controllers/annotation_controller.js
@@ -10,6 +10,7 @@ import "tinymce/tinymce";
 import "tinymce/icons/default";
 import "tinymce/themes/silver";
 import "tinymce/plugins/lists";
+import "tinymce/plugins/directionality";
 import contentUiCss from "tinymce/skins/ui/oxide/content.css";
 import contentCss from "tinymce/skins/content/default/content.css";
 import skinCss from "tinymce/skins/ui/oxide/skin.min.css";
@@ -149,8 +150,8 @@ export default class extends Controller {
                 content_css: false,
                 // use css modules for tinyMCE editor inner content style
                 content_style: `${contentUiCss} ${contentCss}
-                    ::marker { margin-left: 1em; }
-                    li { padding-right: 1em; } ins { color: gray; }`,
+                    ::marker { margin-inline-end: 1em; }
+                    li { padding-inline-start: 1em; } ins { color: gray; }`,
                 setup: (editor) => {
                     editor.on("init", () => {
                         // place imported CSS modules into <style> element inside shadow root.

--- a/sitemedia/scss/components/_results.scss
+++ b/sitemedia/scss/components/_results.scss
@@ -178,6 +178,12 @@ section#document-list {
 
         .transcription {
             @include typography.transcription-search;
+            &:dir(ltr),
+            p:dir(ltr),
+            li:dir(ltr) {
+                // LTR transcription should not use hebrew/arabic fonts
+                @include typography.body-sm;
+            }
         }
         .transcription,
         .translation {
@@ -187,10 +193,13 @@ section#document-list {
             span[lang="ar"] {
                 @include typography.arabic-transcription-search;
             }
-            // hebrew script
+            // hebrew script or non-arabic-tagged rtl
             &[lang="he"],
             &[data-lang-script="hebrew"],
-            span[lang="he"] {
+            span[lang="he"],
+            &:dir(rtl):not(:lang(ar)),
+            p:dir(rtl):not(:lang(ar)),
+            li:dir(rtl):not(:lang(ar)) {
                 @include typography.transcription-search;
             }
             // labels for snippets when applicable
@@ -380,6 +389,9 @@ section#document-list {
             @include typography.transcription-numerals;
             content: attr(value);
             height: 100%;
+            margin-inline-start: -2rem;
+            text-align: start;
+            float: inline-start;
         }
         &:empty::before,
         &:has(p:empty)::before,
@@ -387,37 +399,26 @@ section#document-list {
             display: none;
         }
     }
-    .transcription[dir="ltr"] li::before,
-    .translation[dir="ltr"] li::before {
-        margin-left: -2rem;
-        text-align: left;
-        float: left;
+    .transcription:dir(rtl):has(*:dir(ltr)) {
+        align-self: flex-start;
     }
-    .transcription[dir="rtl"] li,
-    .translation[dir="rtl"] li {
-        direction: rtl;
-        &::before {
-            margin-right: -2rem; /* shift outside text margin */
-            text-align: right;
-            float: right;
-        }
-    }
-    .transcription[dir="ltr"] > p,
-    .translation[dir="ltr"] > p {
+    .transcription:dir(ltr) > p,
+    .translation:dir(ltr) > p {
         @include breakpoints.for-phone-only {
-            margin-left: 0;
-            padding-left: 0;
+            margin-inline-start: 0;
+            padding-inline-start: 0;
         }
     }
 
     /* set height on empty transcription/translation li to prevent overlap issue */
-    .translation li:empty {
+    .translation li:empty,
+    .transcription:dir(ltr) li:empty {
         height: calc(1.125rem * 1.5);
         @include breakpoints.for-tablet-landscape-up {
             height: calc(1.25rem * 1.5);
         }
     }
-    .transcription li:empty {
+    .transcription:dir(rtl) li:empty {
         height: calc(27 / 20 * 1.25rem);
         @include breakpoints.for-tablet-landscape-up {
             height: calc(32 / 22 * 1.375rem);
@@ -676,13 +677,21 @@ html[dir="rtl"] .search-result {
             right: 0;
         }
     }
-    .transcription[dir="rtl"],
-    .translation[dir="rtl"] {
+    .transcription:dir(rtl),
+    .translation:dir(rtl) {
         align-self: flex-start;
     }
-    .transcription[dir="ltr"],
-    .translation[dir="ltr"] {
+    .transcription:dir(rtl):has(*:dir(ltr)),
+    .translation:dir(rtl):has(*:dir(ltr)) {
         align-self: flex-end;
+    }
+    .transcription:dir(ltr),
+    .translation:dir(ltr) {
+        align-self: flex-end;
+    }
+    .transcription:dir(ltr):has(*:dir(rtl)),
+    .translation:dir(ltr):has(*:dir(rtl)) {
+        align-self: flex-start;
     }
     dt[lang="en"] {
         line-height: calc(19.4 / 14);

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1430,85 +1430,67 @@
         }
     }
 
-    // RTL content (all transcriptions, some translations)
+    // handle RTL vs LTR content--at transcription, list, or line level
     &[dir="rtl"] {
         align-self: flex-end;
-
-        text-align: right;
-        // direction: rtl; /* search results are mixed rtl/ltr and include unicode order mark characters */
-
-        .search-result & p {
-            text-align: right;
-        }
-
-        li {
-            margin-right: 1.5em;
-            padding-right: 1em; /* shift to make space for line numbers */
-            direction: rtl;
-        }
-
-        p {
-            // match alignment of list items
-            margin-right: 1em;
-            padding-right: 1.5em;
-        }
-
-        li > p {
-            // if inside a list item, don't pad <p>
-            margin-right: 0;
-            padding-right: 0;
-        }
-
-        // line number dot cover
-        ol li:not([value])::before {
-            /* make font larger than list number font to cover completely;
-            shrink line height to adjust placement */
-            right: -35.75px;
-            font-size: 37px;
-            line-height: 19px;
-
-            @include breakpoints.for-tablet-landscape-up {
-                font-size: 45px;
-                line-height: 25px;
-                right: -36px;
-            }
-        }
-
-        // NOTE: Broken in stable Safari for now, but fixed in Safari preview release.
-        li::marker {
-            text-align: right;
-            float: right;
+    }
+    .search-result & p {
+        text-align: start;
+    }
+    li {
+        padding-inline-start: 1em;
+        margin-inline-start: 1.6em;
+        &:dir(rtl) {
+            margin-inline-start: 1.5em;
         }
     }
-
-    &[dir="ltr"] {
-        li {
-            margin-left: 1.6em;
-            padding-left: 1em; /* shift to make space for line numbers */
+    p {
+        // match alignment of list items
+        margin-inline-start: 1em;
+        padding-inline-start: 1.6em;
+        &:dir(rtl) {
+            padding-inline-start: 1.5em;
         }
-        p {
-            // match alignment of list items
-            margin-left: 1em;
-            padding-left: 1.6em;
-        }
-        li > p {
-            // if inside a list item, don't pad <p>
-            margin-left: 0;
-            padding-left: 0;
-        }
+    }
+    li > p {
+        // if inside a list item, don't pad <p>
+        margin-inline-start: 0;
+        padding-inline-start: 0;
+    }
 
-        // line number dot cover
-        ol li:not([value])::before {
-            /* make font larger than list number font to cover completely;
-                   shrink line height to adjust placement */
-            font-size: 37px;
-            line-height: 13px;
-            left: -9.5px;
+    // line number dot covers
+    ol {
+        /* make font larger than list number font to cover completely;
+        shrink line height to adjust placement */
+        &:dir(rtl) {
+            li:not([value])::before {
+                inset-inline-start: -35.75px;
+                font-size: 37px;
+                line-height: 19px;
 
-            @include breakpoints.for-tablet-landscape-up {
-                font-size: 50px;
-                line-height: 16px;
-                left: -12px;
+                @include breakpoints.for-tablet-landscape-up {
+                    font-size: 45px;
+                    line-height: 25px;
+                    inset-inline-start: -36px;
+                }
+            }
+            // NOTE: Broken in stable Safari for now, but fixed in Safari preview release.
+            li::marker {
+                text-align: start;
+                float: inline-start;
+            }
+        }
+        &:dir(ltr) {
+            li:not([value])::before {
+                inset-inline-start: -9.5px;
+                font-size: 37px;
+                line-height: 13px;
+
+                @include breakpoints.for-tablet-landscape-up {
+                    font-size: 50px;
+                    line-height: 16px;
+                    inset-inline-start: -12px;
+                }
             }
         }
     }
@@ -1522,10 +1504,10 @@
     ~ .panel-container
     .translation {
     @include breakpoints.for-tablet-landscape-up {
-        &[dir="rtl"] ol li:not([value])::before {
+        ol:dir(rtl) li:not([value])::before {
             line-height: 19px;
         }
-        &[dir="ltr"] ol li:not([value])::before {
+        ol:dir(ltr) li:not([value])::before {
             line-height: 12px;
         }
     }
@@ -1537,37 +1519,34 @@
 @supports (font: -apple-system-body) and (-webkit-appearance: none) {
     .transcription,
     .translation {
-        &[dir="rtl"] ol li:not([value])::before {
-            right: -41px;
-            line-height: 21px;
+        ol:dir(rtl) {
             @include breakpoints.for-tablet-landscape-up {
-                line-height: 24px;
+                margin-inline-start: 10px;
+            }
+            li:not([value])::before {
+                inset-inline-start: -41px;
+                line-height: 21px;
+                @include breakpoints.for-tablet-landscape-up {
+                    line-height: 24px;
+                }
             }
         }
-        // handle RTL line numbers cut off horizontally
-        &[dir="rtl"] ol {
+        ol:dir(ltr) {
+            margin-inline-start: 5px;
             @include breakpoints.for-tablet-landscape-up {
-                margin-right: 10px;
+                margin-inline-start: 10px;
             }
-        }
-    }
-    .translation {
-        &[dir="ltr"] ol li:not([value])::before {
-            left: -14px;
-            line-height: 12px;
-            @include breakpoints.for-tablet-landscape-up {
-                left: -17px;
-                line-height: 17px;
-            }
-        }
-        // handle LTR line numbers cut off horizontally
-        &[dir="ltr"] ol {
-            margin-left: 5px;
-            @include breakpoints.for-tablet-landscape-up {
-                margin-left: 10px;
+            li:not([value])::before {
+                inset-inline-start: -14px;
+                line-height: 12px;
+                @include breakpoints.for-tablet-landscape-up {
+                    inset-inline-start: -17px;
+                    line-height: 17px;
+                }
             }
         }
     }
+
     #toggles:has(#transcription-on:not(:checked) ~ #translation-on:checked)
         ~ .panel-container
         .translation,
@@ -1575,10 +1554,10 @@
         ~ .panel-container
         .transcription {
         @include breakpoints.for-tablet-landscape-up {
-            &[dir="rtl"] ol li:not([value])::before {
+            ol:dir(rtl) li:not([value])::before {
                 line-height: 21px;
             }
-            &[dir="ltr"] ol li:not([value])::before {
+            ol:dir(ltr) li:not([value])::before {
                 line-height: 11px;
             }
         }
@@ -1587,6 +1566,12 @@
 
 .transcription {
     @include typography.transcription;
+    &:dir(ltr),
+    p:dir(ltr),
+    li:dir(ltr) {
+        // LTR transcription should not use hebrew/arabic fonts
+        @include typography.body;
+    }
 }
 .transcription,
 .translation {
@@ -1596,10 +1581,13 @@
     span[lang="ar"] {
         @include typography.arabic-transcription;
     }
-    // hebrew script
+    // hebrew script or non-arabic-tagged rtl
     &[lang="he"],
     &[data-lang-script="hebrew"],
-    span[lang="he"] {
+    span[lang="he"],
+    &:dir(rtl):not(:lang(ar)),
+    p:dir(rtl):not(:lang(ar)),
+    li:dir(rtl):not(:lang(ar)) {
         @include typography.transcription;
     }
 }


### PR DESCRIPTION
**Associated Issue(s):** #1974

### Changes in this PR

- Update `annotorious-tahqiq` to 1.6.0 and include `directionality` TinyMCE plugin to get the new LTR and RTL buttons in the text editor
- Add `dir` to allowed attributes for HTML sanitization
- Ensure attributes like `dir` are preserved during list flattening (and add a small amount of fallback behavior)
- Update `HTMLLineNumberParser`, which is used only in solr indexing, to propagate the `dir` attribute down to all `li` elements in the indexed HTML
   - Search results often return highlighted transcription/translation snippets with _just_ the `li`s and no surrounding list—this ensures they get the correct directionality
- Update all CSS to support transcription/translation block-level `dir` (and also make it a little more DRY and generalized using `inline` properties)

### Reviewer Checklist

- [x] Run `npm install` to get the latest version of `annotorious-tahqiq` that includes the new buttons
