### PR TITLE
Fix alignment line height for nested p elements inside li (#1977)

### DIFF
--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -265,7 +265,8 @@ class Annotation(TrackChangesModel):
 
         # if resulting text has any span elements with no attributes, remove them;
         # if resulting text has any p elements inside li, unwrap them
-        if "<span>" in cleaned_html or "<p>" in cleaned_html:
+        # (leave out ">" from opening tag in case of attributes)
+        if "<span" in cleaned_html or "<p" in cleaned_html:
             # parse as html to identify spans with no attributes
             soup = BeautifulSoup(cleaned_html)
             for span in soup.find_all("span"):

--- a/geniza/annotations/models.py
+++ b/geniza/annotations/models.py
@@ -263,14 +263,22 @@ class Annotation(TrackChangesModel):
         # replace Unicode non-breaking space \xa0
         cleaned_html = re.sub(r"[\xa0 ]+", " ", cleaned_html)
 
-        # if resulting text has any span elements with no attributes, remove them
-        if "<span>" in cleaned_html:
+        # if resulting text has any span elements with no attributes, remove them;
+        # if resulting text has any p elements inside li, unwrap them
+        if "<span>" in cleaned_html or "<p>" in cleaned_html:
             # parse as html to identify spans with no attributes
             soup = BeautifulSoup(cleaned_html)
             for span in soup.find_all("span"):
                 # if span has no attributes, unwrap the text and remove the span tag
                 if not span.attrs:
                     span.unwrap()
+            # unwrap nested <p> inside <li>
+            for li in soup.find_all("li"):
+                for p in li.find_all("p"):
+                    # ensure dir attr (ltr or rtl) is propagated back up to the parent li
+                    if p.has_attr("dir"):
+                        li["dir"] = p["dir"]
+                    p.unwrap()
             # serialize back out as html without wrapping html/body tags
             cleaned_html = "".join(str(el) for el in soup.html.body.children)
         return cls.flatten_html_list(cleaned_html)

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -184,7 +184,6 @@ class TestAnnotation:
     def test_sanitize_html(self):
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'
         # should strip out all unwanted elements and attributes (table, div, style)
-        # (\n is added because bleach replaces block-level elements with newline)
         assert Annotation.sanitize_html(html) == "<p>test</p><ol><li>line</li></ol>"
 
         # should do nothing to html with all allowed elements

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -185,7 +185,7 @@ class TestAnnotation:
         html = '<table><div><p style="foo:bar;">test</p></div><ol><li>line</li></ol></table>'
         # should strip out all unwanted elements and attributes (table, div, style)
         # (\n is added because bleach replaces block-level elements with newline)
-        assert Annotation.sanitize_html(html) == "\n<p>test</p><ol><li>line</li></ol>"
+        assert Annotation.sanitize_html(html) == "<p>test</p><ol><li>line</li></ol>"
 
         # should do nothing to html with all allowed elements
         html = '<p>test <span lang="en">en</span></p><ol><li>line 1</li><li>line 2</li></ol>'

--- a/geniza/annotations/tests/test_annotations_models.py
+++ b/geniza/annotations/tests/test_annotations_models.py
@@ -195,6 +195,16 @@ class TestAnnotation:
         html_dir = '<p dir="rtl">test <span dir="ltr">en</span></p><ol dir="rtl"><li dir="rtl">line 1</li></ol>'
         assert Annotation.sanitize_html(html_dir) == html_dir
 
+        # should unwrap <p> tags nested inside <li> tags
+        html_nested_p = "<ol><li><p>line 1</p></li></ol>"
+        assert Annotation.sanitize_html(html_nested_p) == "<ol><li>line 1</li></ol>"
+
+        # should propagate dir attribute up from <p> to <li>
+        html_p_dir = '<ol><li><p dir="ltr">line 1</p></li></ol>'
+        assert (
+            Annotation.sanitize_html(html_p_dir) == '<ol><li dir="ltr">line 1</li></ol>'
+        )
+
         # should remove span elements with no attributes after bleaching
         html = '<p>text <span style="foo:bar">and</span> more text</p>'
         assert Annotation.sanitize_html(html) == "<p>text and more text</p>"

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -615,7 +615,8 @@
             }
             // adjust line heights to align transcription with translation when both visible
             // give li a standard line height (using largest among transcription/translation styles)
-            li {
+            li,
+            li p {
                 line-height: calc(34 / 22 * 1.375rem);
             }
             // remove margin/padding that could interrupt alignment


### PR DESCRIPTION
**Associated Issue(s):** #1977

### Changes in this PR

- Ensures `p` elements nested inside `li` get the correct standardized transcription/translation line height, when there are both a transcription and translation present, so that total height of text per `li` is correctly calculated. This fixes a regression introduced [here](https://github.com/Princeton-CDH/geniza/blob/c98709b1faea7c0ada7621177bb6faf330eb3a2b/sitemedia/scss/components/_transcription.scss#L1569-L1574) in 94b4786180ed58a70a810ca7bc1b09d3076f5b3a.
  - (generally these should still get the `body` line-height, but it needs to be overridden in the specific case that we're aligning transcription and translation, i.e. both are visible)
- Adds code to sanitization process to unwrap `<p>` inside `<li>`, ensuring any `dir` attribute on the `<p>` is preserved and propagated back up