### PR TITLE
Validating input dates to error out on future dates

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -244,6 +244,16 @@ class DocumentDateMixin(TrackChangesModel):
             raise ValidationError("Original date is required when calendar is set")
         if self.doc_date_original and not self.doc_date_calendar:
             raise ValidationError("Calendar is required when original date is set")
+        date_to_check = self.doc_date_standard
+        if not self.doc_date_standard and self.doc_date_original:
+            date_to_check = self.standardize_date(update=False)
+        if (
+            date.fromisoformat(
+                PartialDate(date_to_check).isoformat(mode="max", fmt="full")
+            )
+            >= date.today()
+        ):
+            raise ValidationError("Can't input a date in the future!")
 
     def standardize_date(self, update=False):
         """
@@ -283,7 +293,6 @@ class DocumentDateMixin(TrackChangesModel):
                     end = start
                 else:
                     end = PartialDate(date_parts[1])
-
                 self._parsed_date = {"start": start, "end": end}
             except ValueError:
                 # ignore if it can't be parsed (records before validation added)

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -236,6 +236,7 @@ class DocumentDateMixin(TrackChangesModel):
         return self.get_document_date(self.doc_date_standard, self.original_date)
 
     def get_doc_date(self):
+        """Utility method to validate / vet document's date"""
         date_to_check = (
             self.doc_date_standard.split("/") if self.doc_date_standard else None
         )

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -236,9 +236,12 @@ class DocumentDateMixin(TrackChangesModel):
         return self.get_document_date(self.doc_date_standard, self.original_date)
 
     def get_doc_date(self):
-        date_to_check = self.doc_date_standard
+        date_to_check = (
+            self.doc_date_standard.split("/") if self.doc_date_standard else None
+        )
         if not date_to_check and self.doc_date_original:
             date_to_check = self.standardize_date(update=False).split("/")
+        if date_to_check:
             date_to_check = (
                 date_to_check[len(date_to_check) - 1]
                 if len(date_to_check) > 1

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -247,12 +247,11 @@ class DocumentDateMixin(TrackChangesModel):
         date_to_check = self.doc_date_standard
         if not self.doc_date_standard and self.doc_date_original:
             date_to_check = self.standardize_date(update=False)
-        if (
-            date.fromisoformat(
-                PartialDate(date_to_check).isoformat(mode="max", fmt="full")
-            )
-            >= date.today()
-        ):
+        date_to_check = (
+            self.end_date if self.parsed_date else PartialDate(date_to_check)
+        )
+        date_to_check = date_to_check.isoformat(mode="max", fmt="full")
+        if date.fromisoformat(date_to_check) > date.today():
             raise ValidationError("Can't input a date in the future!")
 
     def standardize_date(self, update=False):

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -238,11 +238,21 @@ class DocumentDateMixin(TrackChangesModel):
     def get_doc_date(self):
         date_to_check = self.doc_date_standard
         if not date_to_check and self.doc_date_original:
-            date_to_check = self.standardize_date(update=False)
+            date_to_check = self.standardize_date(update=False).split("/")
+            date_to_check = (
+                date_to_check[len(date_to_check) - 1]
+                if len(date_to_check) > 1
+                else date_to_check[0]
+            )
+        date_to_check = PartialDate(date_to_check) if date_to_check else None
         date_to_check = (
-            self.end_date if self.parsed_date else PartialDate(date_to_check)
+            self.end_date if not date_to_check and self.parsed_date else date_to_check
         )
-        return date.fromisoformat(date_to_check.isoformat(mode="max", fmt="full"))
+        return (
+            date.fromisoformat(date_to_check.isoformat(mode="max", fmt="full"))
+            if date_to_check
+            else None
+        )
 
     def clean(self):
         """
@@ -253,7 +263,8 @@ class DocumentDateMixin(TrackChangesModel):
             raise ValidationError("Original date is required when calendar is set")
         if self.doc_date_original and not self.doc_date_calendar:
             raise ValidationError("Calendar is required when original date is set")
-        if self.get_doc_date() > date.today():
+        date_to_check = self.get_doc_date()
+        if date_to_check and date_to_check > date.today():
             raise ValidationError("Can't input a date in the future!")
 
     def standardize_date(self, update=False):

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -235,6 +235,15 @@ class DocumentDateMixin(TrackChangesModel):
         """Property: formatted display of combined original and standardized dates"""
         return self.get_document_date(self.doc_date_standard, self.original_date)
 
+    def get_doc_date(self):
+        date_to_check = self.doc_date_standard
+        if not date_to_check and self.doc_date_original:
+            date_to_check = self.standardize_date(update=False)
+        date_to_check = (
+            self.end_date if self.parsed_date else PartialDate(date_to_check)
+        )
+        return date.fromisoformat(date_to_check.isoformat(mode="max", fmt="full"))
+
     def clean(self):
         """
         Require doc_date_original and doc_date_calendar to be set
@@ -244,14 +253,7 @@ class DocumentDateMixin(TrackChangesModel):
             raise ValidationError("Original date is required when calendar is set")
         if self.doc_date_original and not self.doc_date_calendar:
             raise ValidationError("Calendar is required when original date is set")
-        date_to_check = self.doc_date_standard
-        if not self.doc_date_standard and self.doc_date_original:
-            date_to_check = self.standardize_date(update=False)
-        date_to_check = (
-            self.end_date if self.parsed_date else PartialDate(date_to_check)
-        )
-        date_to_check = date_to_check.isoformat(mode="max", fmt="full")
-        if date.fromisoformat(date_to_check) > date.today():
+        if self.get_doc_date() > date.today():
             raise ValidationError("Can't input a date in the future!")
 
     def standardize_date(self, update=False):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -602,32 +602,6 @@ class TestDocument:
         unsaved_doc = Document()
         assert str(unsaved_doc) == "?? (PGPID ??)"
 
-    def test_clean(self):
-        doc = Document()
-        # no dates; no error
-        doc.clean()
-
-        # original date but no calendar — error
-        doc.doc_date_original = "480"
-        with pytest.raises(ValidationError):
-            doc.clean()
-
-        # calendar but no date — error
-        doc.doc_date_original = ""
-        doc.doc_date_calendar = Calendar.HIJRI
-        with pytest.raises(ValidationError):
-            doc.clean()
-
-        # both — no error
-        doc.doc_date_original = "350"
-        doc.clean()
-
-        # future date - error
-        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
-        doc.doc_date_original = tomorrow.strftime("%Y-%m-%d")
-        with pytest.raises(ValidationError):
-            doc.clean()
-
     def test_original_date(self):
         """Should display the historical document date with its calendar name"""
         doc = Document.objects.create(

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -621,6 +621,12 @@ class TestDocument:
         # both — no error
         doc.doc_date_original = "350"
         doc.clean()
+
+        # future date - error
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        doc.doc_date_original = tomorrow.strftime("%Y-%m-%d")
+        with pytest.raises(ValidationError):
+            doc.clean()
 
     def test_original_date(self):
         """Should display the historical document date with its calendar name"""
@@ -2029,7 +2035,7 @@ def test_document_merge_with_log_entries(document, join):
     # create some log entries
     document_contenttype = ContentType.objects.get_for_model(Document)
     # creation
-    creation_date = timezone.make_aware(datetime(1991, 5, 1))
+    creation_date = timezone.make_aware(datetime.datetime(1991, 5, 1))
     creator = User.objects.get_or_create(username="editor")[0]
     LogEntry.objects.bulk_create(
         [

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -41,9 +41,25 @@ class TestDocumentDateMixin:
         doc.doc_date_original = "350"
         doc.clean()
 
+        # both full date — no error
+        doc.doc_date_original = "350-01-01"
+        doc.clean()
+
+        # both full date range — no error
+        doc.doc_date_original = "350-01-01/351-01-01"
+        doc.clean()
+
         # future date - error
-        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        today = datetime.date.today()
+        tomorrow = today + datetime.timedelta(days=1)
         doc.doc_date_original = tomorrow.strftime("%Y-%m-%d")
+        with pytest.raises(ValidationError):
+            doc.clean()
+
+        # future date range - error
+        doc.doc_date_original = (
+            f"{today.strftime('%Y-%m-%d')}/{tomorrow.strftime('%Y-%m-%d')}"
+        )
         with pytest.raises(ValidationError):
             doc.clean()
 
@@ -152,8 +168,16 @@ class TestPerson:
         person.date = "2024-06-12"
         person.clean()
 
+        # full past date range — no error
+        person.date = "2024-06-12/2025-06-12"
+        person.clean()
+
         # partial past date — no error
         person.date = "2024"
+        person.clean()
+
+        # partial past date range — no error
+        person.date = "2024/2025"
         person.clean()
 
         # future date - error

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -181,8 +181,14 @@ class TestPerson:
         person.clean()
 
         # future date - error
-        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        today = datetime.date.today()
+        tomorrow = today + datetime.timedelta(days=1)
         person.date = tomorrow.strftime("%Y-%m-%d")
+        with pytest.raises(ValidationError):
+            person.clean()
+
+        # future date range - error
+        person.date = f"{today.strftime('%Y-%m-%d')}/{tomorrow.strftime('%Y-%m-%d')}"
         with pytest.raises(ValidationError):
             person.clean()
 

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -15,6 +15,7 @@ from geniza.corpus.dates import (
     standard_date_display,
 )
 from geniza.corpus.models import Document
+from geniza.entities.models import Person
 
 
 class TestDocumentDateMixin:
@@ -138,6 +139,28 @@ class TestDocumentDateMixin:
         # end is beginning of date range
         doc.doc_date_standard = "1839-03-17/1840-03-04"
         assert doc.end_date == PartialDate("1840-03-04")
+
+
+class TestPerson:
+
+    def test_clean(self):
+        person = Person()
+        # no dates; no error
+        person.clean()
+
+        # full past date — no error
+        person.date = "2024-06-12"
+        person.clean()
+
+        # partial past date — no error
+        person.date = "2024"
+        person.clean()
+
+        # future date - error
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        person.date = tomorrow.strftime("%Y-%m-%d")
+        with pytest.raises(ValidationError):
+            person.clean()
 
 
 # test hebrew date conversion

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime
 
 import convertdate
 import pytest
@@ -39,6 +39,12 @@ class TestDocumentDateMixin:
         # both — no error
         doc.doc_date_original = "350"
         doc.clean()
+
+        # future date - error
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        doc.doc_date_original = tomorrow.strftime("%Y-%m-%d")
+        with pytest.raises(ValidationError):
+            doc.clean()
 
     def test_original_date(self):
         """Should display the historical document date with its calendar name"""
@@ -148,20 +154,20 @@ def test_convert_hebrew_date():
     # start/end should be the same
     assert converted_date[0] == converted_date[1]
     # expected converted date
-    assert converted_date[1] == date(1807, 9, 8)
+    assert converted_date[1] == datetime.date(1807, 9, 8)
 
     # single day, julian
     converted_date = convert_hebrew_date("Thursday, 16 Elul 5[2]09")
     # start/end should be the same
     assert converted_date[0] == converted_date[1]
     # expected converted date
-    assert converted_date[1] == date(1449, 9, 4)
+    assert converted_date[1] == datetime.date(1449, 9, 4)
 
     # month/year
     converted_date = convert_hebrew_date("Tishrei 4898")
     # expect 1137-09-18/1137-10-17
-    assert converted_date[0] == date(1137, 9, 18)
-    assert converted_date[1] == date(1137, 10, 17)
+    assert converted_date[0] == datetime.date(1137, 9, 18)
+    assert converted_date[1] == datetime.date(1137, 10, 17)
 
     # year only
     converted_date = convert_hebrew_date("5632")
@@ -169,14 +175,14 @@ def test_convert_hebrew_date():
     assert converted_date[0].year == 1871
     assert converted_date[1].year == 1872
     # hebrew civil calendar begins in Tishri, in September
-    assert converted_date[0] == date(1871, 9, 16)
-    assert converted_date[1] == date(1872, 10, 2)
+    assert converted_date[0] == datetime.date(1871, 9, 16)
+    assert converted_date[1] == datetime.date(1872, 10, 2)
 
     # season is currently ignored
     converted_date = convert_hebrew_date("spring 5632")
     # should be the same as year only
-    assert converted_date[0] == date(1871, 9, 16)
-    assert converted_date[1] == date(1872, 10, 2)
+    assert converted_date[0] == datetime.date(1871, 9, 16)
+    assert converted_date[1] == datetime.date(1872, 10, 2)
 
 
 # test seleucid date conversion
@@ -185,13 +191,13 @@ def test_convert_seleucid_date():
     # start/end should be the same
     assert converted_date[0] == converted_date[1]
     # expected converted date
-    assert converted_date[1] == date(1000, 9, 1)
+    assert converted_date[1] == datetime.date(1000, 9, 1)
 
     converted_date = convert_seleucid_date("23 Adar I 1475")
     # start/end should be the same
     assert converted_date[0] == converted_date[1]
     # expected converted date
-    assert converted_date[1] == date(1164, 2, 18)
+    assert converted_date[1] == datetime.date(1164, 2, 18)
 
     # month/year
     seleucid_year = 1458
@@ -205,7 +211,7 @@ def test_convert_seleucid_date():
 
     # leap day (Feb 29, 2020) should convert properly
     converted_date = convert_seleucid_date("4 Adar 2331")
-    assert converted_date[1] == date(2020, 2, 29)
+    assert converted_date[1] == datetime.date(2020, 2, 29)
 
     # leap year (4826 AM = 1377 Seleucid) should convert properly
     seleucid_year = 1377
@@ -216,7 +222,7 @@ def test_convert_seleucid_date():
     assert converted_date[0] == converted_date_am[0]
     assert converted_date[1] == converted_date_am[1]
     # and it should be converted to 1066-03-21 CE
-    assert converted_date[1] == date(1066, 3, 21)
+    assert converted_date[1] == datetime.date(1066, 3, 21)
 
 
 # test islamic date conversion
@@ -238,13 +244,13 @@ def test_convert_islamic_date():
     # start/end should be the same
     assert converted_date[0] == converted_date[1]
     # expected converted date
-    assert converted_date[1] == date(1235, 8, 13)
+    assert converted_date[1] == datetime.date(1235, 8, 13)
 
     # year/month
     converted_date = convert_islamic_date("Rajab 495")
     # expect 1102-04-21/1102-05-20
-    assert converted_date[0] == date(1102, 4, 21)
-    assert converted_date[1] == date(1102, 5, 20)
+    assert converted_date[0] == datetime.date(1102, 4, 21)
+    assert converted_date[1] == datetime.date(1102, 5, 20)
 
     # year only
     converted_date = convert_islamic_date("441")
@@ -252,14 +258,14 @@ def test_convert_islamic_date():
     assert converted_date[0].year == 1049
     assert converted_date[1].year == 1050
     # 1049-06-05/1050-05-25
-    assert converted_date[0] == date(1049, 6, 5)
-    assert converted_date[1] == date(1050, 5, 25)
+    assert converted_date[0] == datetime.date(1049, 6, 5)
+    assert converted_date[1] == datetime.date(1050, 5, 25)
 
     # failing unexpectedly
     converted_date = convert_islamic_date("14 Rabīʿ I 934")
-    assert converted_date[0] == date(1527, 12, 8)
+    assert converted_date[0] == datetime.date(1527, 12, 8)
     converted_date = convert_islamic_date("5 Jumädä I 556")
-    assert converted_date[0] == date(1161, 5, 2)
+    assert converted_date[0] == datetime.date(1161, 5, 2)
 
 
 class TestPartialDate:

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import datetime
+from datetime import date, datetime
 from math import modf
 from operator import itemgetter
 
@@ -470,6 +470,20 @@ class Person(
             return str(self.names.filter(primary=True).first())
         except Name.DoesNotExist:
             return str(self.names.first() or super().__str__())
+
+    def clean(self):
+        """
+        Require date_str is not a future date.
+        If date_str is a range, require its end not tobe a future date
+        """
+        # date_to_check = datetime.strptime(self.date_str, '%d %B %Y CE').date()
+        date_to_check = (
+            datetime.strptime(standard_date_display(self.date), "%d %B %Y CE").date()
+            if self.date
+            else None
+        )
+        if date_to_check and date_to_check > date.today():
+            raise ValidationError("Can't input a date in the future!")
 
     @property
     def date_str(self):

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -476,8 +476,6 @@ class Person(
         Require date_str is not a future date.
         If date_str is a range, require its end not tobe a future date
         """
-        # date_to_check = datetime.strptime(self.date_str, '%d %B %Y CE').date()
-
         if self.date:
             date_to_check = self.date.split("/")
             date_to_check = (

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -479,8 +479,14 @@ class Person(
         # date_to_check = datetime.strptime(self.date_str, '%d %B %Y CE').date()
 
         if self.date:
+            date_to_check = self.date.split("/")
+            date_to_check = (
+                date_to_check[len(date_to_check) - 1]
+                if len(date_to_check) > 1
+                else date_to_check[0]
+            )
             date_to_check = date.fromisoformat(
-                PartialDate(self.date).isoformat(mode="max", fmt="full")
+                PartialDate(date_to_check).isoformat(mode="max", fmt="full")
             )
             if date_to_check > date.today():
                 raise ValidationError("Can't input a date in the future!")

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -477,13 +477,13 @@ class Person(
         If date_str is a range, require its end not tobe a future date
         """
         # date_to_check = datetime.strptime(self.date_str, '%d %B %Y CE').date()
-        date_to_check = (
-            datetime.strptime(standard_date_display(self.date), "%d %B %Y CE").date()
-            if self.date
-            else None
-        )
-        if date_to_check and date_to_check > date.today():
-            raise ValidationError("Can't input a date in the future!")
+
+        if self.date:
+            date_to_check = date.fromisoformat(
+                PartialDate(self.date).isoformat(mode="max", fmt="full")
+            )
+            if date_to_check > date.today():
+                raise ValidationError("Can't input a date in the future!")
 
     @property
     def date_str(self):

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -371,7 +371,6 @@ class TestPersonAdmin:
         assert queryset.count() == Person.objects.all().count()
 
 
-@pytest.mark.mohamed
 @pytest.mark.django_db
 class TestNameInlineFormSet:
     def test_clean(self, admin_client):

--- a/geniza/entities/tests/test_entities_admin.py
+++ b/geniza/entities/tests/test_entities_admin.py
@@ -371,6 +371,7 @@ class TestPersonAdmin:
         assert queryset.count() == Person.objects.all().count()
 
 
+@pytest.mark.mohamed
 @pytest.mark.django_db
 class TestNameInlineFormSet:
     def test_clean(self, admin_client):


### PR DESCRIPTION
**Associated Issue(s):** resolves #1973

### Changes in this PR

- Validating documents' dates
- Testing attempting to input future dates
- Validating person's dates
- Testing attempting to add a person with a future date

### Reviewer Checklist

- [x] Create a new document with future CE date
- [x] Edit an existing document; change its CE date to a future one
- [x] Create a new document with future Date on document
- [x] Edit an existing document change its Date on document to a future one
- [x] Create a new person with future CE date
- [x] Edit an existing person; change his/her CE date to a future one
- [x] Tests pass 100%

