### PR TITLE
Ensure admin pages handle mixed placeholders/IIIF (#1986)

### DIFF
--- a/geniza/corpus/models.py
+++ b/geniza/corpus/models.py
@@ -2038,33 +2038,68 @@ class TextBlock(models.Model):
 
     def thumbnail(self):
         """iiif thumbnails for this TextBlock, with selected images highlighted"""
-        canvases = []
-        if not self.fragment.iiif_images():
-            # if no IIIF, get placeholder canvas URIs using annotations
-            annotated_canvases = (
-                Annotation.objects.filter(
-                    footnote__content_type=ContentType.objects.get_for_model(Document),
-                    footnote__object_id=self.document.pk,
-                    content__target__source__id__isnull=False,
-                )
-                .order_by()
-                .values_list("content__target__source__id", flat=True)
-                .distinct()
+        # get any placeholder canvas URIs that have been annotated
+        annotated_canvases = (
+            Annotation.objects.filter(
+                footnote__content_type=ContentType.objects.get_for_model(Document),
+                footnote__object_id=self.document.pk,
+                content__target__source__id__isnull=False,
             )
-            # match placeholder on document and textblock PK; extract canvas number
-            placeholder_re = re.compile(
-                rf"{self.document.pk}/iiif/textblock/{self.pk}/canvas/(\d+)/"
+            .order_by()
+            .values_list("content__target__source__id", flat=True)
+            .distinct()
+        )
+        # match placeholder on document and textblock PK; extract canvas number
+        placeholder_re = re.compile(
+            rf"{self.document.pk}/iiif/textblock/{self.pk}/canvas/(\d+)/"
+        )
+        placeholder_canvases = [
+            canvas_uri
+            for canvas_uri in annotated_canvases
+            if placeholder_re.search(canvas_uri)
+        ]
+        # ensure order of placeholders is 1, 2 (recto, verso) by canvas number
+        placeholder_canvases.sort(
+            key=lambda uri: int(placeholder_re.search(uri).group(1))
+        )
+
+        # get any real iiif images
+        iiif_images = self.fragment.iiif_images()
+        if not iiif_images:
+            # if none, return placeholders
+            return self.fragment.iiif_thumbnails(
+                selected=self.selected_images, canvases=placeholder_canvases
             )
-            canvases = [
-                canvas_uri
-                for canvas_uri in annotated_canvases
-                if placeholder_re.search(canvas_uri)
-            ]
-            # ensure order of placeholders is 1, 2 (recto, verso) by canvas number
-            canvases.sort(key=lambda uri: int(placeholder_re.search(uri).group(1)))
-        return self.fragment.iiif_thumbnails(
+
+        _, _, canvases = iiif_images
+        thumbnails = self.fragment.iiif_thumbnails(
             selected=self.selected_images, canvases=canvases
         )
+
+        # if we have both, combine their thumbnails
+        if placeholder_canvases:
+            # generate placeholder thumbnails and append
+            recto_img = static("img/ui/all/all/recto-placeholder.svg")
+            verso_img = static("img/ui/all/all/verso-placeholder.svg")
+            placeholder_images = []
+            placeholder_labels = []
+            for uri in placeholder_canvases:
+                canvas_num = int(placeholder_re.search(uri).group(1))
+                if canvas_num == 1:
+                    placeholder_images.append(recto_img)
+                    placeholder_labels.append(f"{self.fragment.shelfmark} recto")
+                else:
+                    placeholder_images.append(verso_img)
+                    placeholder_labels.append(f"{self.fragment.shelfmark} verso")
+            placeholder_thumbs = Fragment.admin_thumbnails(
+                images=placeholder_images,
+                labels=placeholder_labels,
+                canvases=placeholder_canvases,
+                selected=self.selected_images,
+            )
+            thumbnails += placeholder_thumbs
+
+        return thumbnails
 
 
 class Dating(models.Model):

--- a/geniza/corpus/tests/test_corpus_models.py
+++ b/geniza/corpus/tests/test_corpus_models.py
@@ -267,7 +267,7 @@ class TestFragment(TestCase):
         )
         frag.save()
         # should return one IIIFImage and one label
-        (images, labels, _) = frag.iiif_images()
+        images, labels, _ = frag.iiif_images()
         assert len(images) == 1
         assert isinstance(images[0], IIIFImage)
         assert len(labels) == 1
@@ -1742,8 +1742,8 @@ class TestDocument:
 
     def test_fragments_by_provenance(self, document):
         assert not document.fragments_by_provenance
-        (g, _) = Provenance.objects.get_or_create(name="Geniza")
-        (ng, _) = Provenance.objects.get_or_create(name="Not Geniza")
+        g, _ = Provenance.objects.get_or_create(name="Geniza")
+        ng, _ = Provenance.objects.get_or_create(name="Not Geniza")
         f1 = Fragment.objects.create(shelfmark="CUL 123", provenance_display=g)
         f2 = Fragment.objects.create(shelfmark="CUL 456", provenance_display=ng)
         TextBlock.objects.create(fragment=f1, document=document)
@@ -1753,8 +1753,8 @@ class TestDocument:
 
     def test_fragments_by_material_support(self, document):
         assert not document.fragments_by_material_support
-        (paper, _) = MaterialSupport.objects.get_or_create(name="Paper")
-        (parch, _) = MaterialSupport.objects.get_or_create(name="Parchment")
+        paper, _ = MaterialSupport.objects.get_or_create(name="Paper")
+        parch, _ = MaterialSupport.objects.get_or_create(name="Parchment")
         f1 = Fragment.objects.create(shelfmark="CUL 123", material_support=paper)
         f2 = Fragment.objects.create(shelfmark="CUL 456", material_support=parch)
         TextBlock.objects.create(fragment=f1, document=document)
@@ -2189,9 +2189,9 @@ def test_document_merge_with_related_entities(
     document, join, person, person_diacritic, person_multiname
 ):
     # add person-document relationships
-    (mentioned, _) = PersonDocumentRelationType.objects.get_or_create(name="Mentioned")
-    (author, _) = PersonDocumentRelationType.objects.get_or_create(name="Author")
-    (recipient, _) = PersonDocumentRelationType.objects.get_or_create(name="Recipient")
+    mentioned, _ = PersonDocumentRelationType.objects.get_or_create(name="Mentioned")
+    author, _ = PersonDocumentRelationType.objects.get_or_create(name="Author")
+    recipient, _ = PersonDocumentRelationType.objects.get_or_create(name="Recipient")
     # same person and type, different notes
     mentioned_rel = PersonDocumentRelation.objects.create(
         document=document, person=person, type=mentioned, notes="Mentioned on line 5."
@@ -2312,9 +2312,16 @@ class TestTextBlock:
         block = TextBlock.objects.create(
             document=doc, fragment=frag, selected_images=[0]
         )
-        with patch.object(frag, "iiif_thumbnails") as mock_frag_thumbnails:
-            assert block.thumbnail() == mock_frag_thumbnails.return_value
-            mock_frag_thumbnails.assert_called_with(selected=[0], canvases=[])
+        with (
+            patch.object(frag, "iiif_images") as mock_iiif_images,
+            patch.object(frag, "iiif_thumbnails") as mock_frag_thumbnails,
+        ):
+            mock_iiif_images.return_value = (["img1"], ["label1"], ["real_canvas_1"])
+            mock_frag_thumbnails.return_value = "real_thumbs"
+            assert block.thumbnail() == "real_thumbs"
+            mock_frag_thumbnails.assert_called_with(
+                selected=[0], canvases=["real_canvas_1"]
+            )
 
         # case 2: fragment has no IIIF images, should use placeholder path
         block2 = TextBlock.objects.create(document=doc, fragment=frag)
@@ -2345,6 +2352,55 @@ class TestTextBlock:
                     f"{doc.pk}/iiif/textblock/{block2.pk}/canvas/2/",
                 ]
                 assert result2 == "placeholder_thumbs"
+
+        # case 3: fragment has BOTH real IIIF images AND placeholder annotations
+        block3 = TextBlock.objects.create(document=doc, fragment=frag)
+        for i in range(2):
+            Annotation.objects.create(
+                footnote=footnote,
+                content={
+                    "target": {
+                        "source": {
+                            "id": f"{doc.pk}/iiif/textblock/{block3.pk}/canvas/{i+1}/"
+                        }
+                    },
+                    "body": [{"label": "Recto or Verso"}],
+                },
+            )
+
+        with (
+            patch.object(frag, "iiif_images") as mock_iiif_images,
+            patch.object(frag, "iiif_thumbnails") as mock_frag_thumbs,
+            patch(
+                "geniza.corpus.models.Fragment.admin_thumbnails"
+            ) as mock_admin_thumbs,
+        ):
+            # mock data
+            mock_iiif_images.return_value = (
+                ["real_img"],
+                ["real_label"],
+                ["real_canvas"],
+            )
+            mock_frag_thumbs.return_value = "(real_thumbs)"
+            mock_admin_thumbs.return_value = "(placeholder_thumbs)"
+
+            result3 = block3.thumbnail()
+
+            # should build the real thumbs
+            mock_frag_thumbs.assert_called_with(selected=[], canvases=["real_canvas"])
+            # should build the placeholder thumbs
+            mock_admin_thumbs.assert_called_once()
+            # thumbnail canvases should be from annotations
+            kwargs = mock_admin_thumbs.call_args[1]
+            assert "recto-placeholder.svg" in kwargs["images"][0]
+            assert "verso-placeholder.svg" in kwargs["images"][1]
+            assert kwargs["labels"] == ["T-S 8J22.21 recto", "T-S 8J22.21 verso"]
+            assert kwargs["canvases"] == [
+                f"{doc.pk}/iiif/textblock/{block3.pk}/canvas/1/",
+                f"{doc.pk}/iiif/textblock/{block3.pk}/canvas/2/",
+            ]
+            # should combine the two
+            assert result3 == "(real_thumbs)(placeholder_thumbs)"
 
     def test_side(self):
         doc = Document.objects.create()


### PR DESCRIPTION
**Associated Issue(s):** #1986

### Changes in this PR

Per #1986:
- The JS error in this issue resulted from the work in #1942 to allow reordering placeholders. That work was done assuming that all annotation content per fragment would either be on placeholders _OR_ iiif images, but didn't account for both.
- That resulted in the `thumbnails` section no longer rendering placeholder thumbnails once the fragment had been populated with IIIF images. Thus, the JS script failed on trying to match "annotated canvases for reordering" with "rendered thumbnails on fragments".
- This PR ensures that `Fragment.thumbnail` always renders any annotated placeholders as well as any IIIF images, so that the reordering section and the thumbnails are never out of sync.