### PR TITLE
Ingesting provenance and material_support

### DIFF
--- a/geniza/corpus/management/commands/add_fragment_urls.py
+++ b/geniza/corpus/management/commands/add_fragment_urls.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandError
 from parasolr.django.signals import IndexableSignalHandler
 
-from geniza.corpus.models import Fragment
+from geniza.corpus.models import Fragment, MaterialSupport, Provenance
 
 
 class Command(BaseCommand):
@@ -87,6 +87,8 @@ class Command(BaseCommand):
 
         url = row.get("url")
         iiif_url = row.get("iiif_url") or Fragment.view_to_iiif_url(row["url"])
+        provenance = row.get("provenance")
+        material_support = row.get("material_support")
         save_needed = False
         log_message = []
 
@@ -124,6 +126,14 @@ class Command(BaseCommand):
                     fragment.iiif_url = iiif_url
                     save_needed = True
                     log_message.append("updated IIIF URL")
+
+        if material_support:
+            ms = MaterialSupport.objects.get_or_create(name=material_support)
+            fragment.material_support = ms[0]
+
+        if provenance:
+            prov = Provenance.objects.get_or_create(name=provenance)
+            fragment.provenance_display = row.get(prov[0])
 
         if save_needed:
             if self.dryrun:

--- a/geniza/corpus/management/commands/add_fragment_urls.py
+++ b/geniza/corpus/management/commands/add_fragment_urls.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
 
         if provenance:
             prov = Provenance.objects.get_or_create(name=provenance)
-            fragment.provenance_display = row.get(prov[0])
+            fragment.provenance_display = prov[0]
 
         if save_needed:
             if self.dryrun:

--- a/geniza/corpus/tests/test_add_fragment_urls.py
+++ b/geniza/corpus/tests/test_add_fragment_urls.py
@@ -123,12 +123,16 @@ def test_add_fragment_urls(mock_log_change):
         {
             "shelfmark": orig_frag.shelfmark,
             "url": "https://cudl.lib.cam.ac.uk/view/MS-TS-NS-J-00600",
+            "material_support": "Paper",
+            "provenance": "Geniza",
         }
     )
     command.add_fragment_urls(row)
     fragment = Fragment.objects.get(shelfmark=orig_frag.shelfmark)
     assert fragment.url == row["url"]
     assert fragment.iiif_url == orig_frag.iiif_url
+    assert fragment.material_support.name == row["material_support"]
+    assert fragment.provenance_display.name == row["provenance"]
     assert command.stats["url_added"] == 1
     assert not command.stats["iiif_added"]
     assert not command.stats["iiif_updated"]


### PR DESCRIPTION
**Associated Issue(s):** resolves #1984 

### Changes in this PR
Create (or get) instances of those MaterialSupport and Provenance models and attach them as foreign keys to the fragments record before it is saved / persisted into the db

- Adding the ability to ingest fragments' material_support
- Adding the ability to ingest fragments' provenance


### Reviewer Checklist

- [x] Manually check (at least 1) fragment's material_support is added successfully
- [x] Manually check (at least 1) fragment's provenance is added successfully
- [x] All tests pass 100%
