### PR TITLE
Disallowing invalid date ranges 

### DIFF
--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -252,10 +252,25 @@ class DocumentDateMixin(TrackChangesModel):
         date_to_check = (
             self.end_date if not date_to_check and self.parsed_date else date_to_check
         )
+        start_to_return, end_to_return = None, None
+        range_splitted = (
+            self.doc_date_original.split("/") if self.doc_date_original else None
+        )
+        if range_splitted and len(range_splitted) > 1:
+            start = PartialDate(range_splitted[0])
+            end = PartialDate(range_splitted[1])
+            start_to_return = date.fromisoformat(
+                start.isoformat(mode="max", fmt="full")
+            )
+            end_to_return = date.fromisoformat(end.isoformat(mode="max", fmt="full"))
         return (
-            date.fromisoformat(date_to_check.isoformat(mode="max", fmt="full"))
-            if date_to_check
-            else None
+            (
+                date.fromisoformat(date_to_check.isoformat(mode="max", fmt="full"))
+                if date_to_check
+                else None
+            ),
+            start_to_return,
+            end_to_return,
         )
 
     def clean(self):
@@ -267,9 +282,11 @@ class DocumentDateMixin(TrackChangesModel):
             raise ValidationError("Original date is required when calendar is set")
         if self.doc_date_original and not self.doc_date_calendar:
             raise ValidationError("Calendar is required when original date is set")
-        date_to_check = self.get_doc_date()
+        date_to_check, start_date, end_date = self.get_doc_date()
         if date_to_check and date_to_check > date.today():
             raise ValidationError("Can't input a date in the future!")
+        if start_date and end_date and end_date < start_date:
+            raise ValidationError("End date can't be earlier than start date!")
 
     def standardize_date(self, update=False):
         """

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -261,12 +261,24 @@ class DocumentDateMixin(TrackChangesModel):
                     original_range_splitted[0], self.doc_date_calendar
                 )
                 converted_start = display_date_range(*start_std)
-                range_splitted.append(converted_start)
+                converted_str = (
+                    converted_start[0]
+                    if isinstance(converted_start, tuple)
+                    else converted_start
+                )
+                converted0 = converted_str.split("/")[0]
+                range_splitted.append(converted0)
                 end_std = standardize_date(
                     original_range_splitted[1], self.doc_date_calendar
                 )
                 converted_end = display_date_range(*end_std)
-                range_splitted.append(converted_end)
+                converted_str = (
+                    converted_end[0]
+                    if isinstance(converted_end, tuple)
+                    else converted_end
+                )
+                converted1 = converted_str.split("/")[0]
+                range_splitted.append(converted1)
         elif self.doc_date_standard:
             range_splitted = self.doc_date_standard.split("/")
         if range_splitted and len(range_splitted) > 1:

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -253,9 +253,20 @@ class DocumentDateMixin(TrackChangesModel):
             self.end_date if not date_to_check and self.parsed_date else date_to_check
         )
         start_to_return, end_to_return = None, None
-        range_splitted = None
+        range_splitted = []
         if self.doc_date_original:
-            range_splitted = self.doc_date_original.split("/")
+            original_range_splitted = self.doc_date_original.split("/")
+            if len(original_range_splitted) > 1:
+                start_std = standardize_date(
+                    original_range_splitted[0], self.doc_date_calendar
+                )
+                converted_start = display_date_range(*start_std)
+                range_splitted.append(converted_start)
+                end_std = standardize_date(
+                    original_range_splitted[1], self.doc_date_calendar
+                )
+                converted_end = display_date_range(*end_std)
+                range_splitted.append(converted_end)
         elif self.doc_date_standard:
             range_splitted = self.doc_date_standard.split("/")
         if range_splitted and len(range_splitted) > 1:

--- a/geniza/corpus/dates.py
+++ b/geniza/corpus/dates.py
@@ -253,9 +253,11 @@ class DocumentDateMixin(TrackChangesModel):
             self.end_date if not date_to_check and self.parsed_date else date_to_check
         )
         start_to_return, end_to_return = None, None
-        range_splitted = (
-            self.doc_date_original.split("/") if self.doc_date_original else None
-        )
+        range_splitted = None
+        if self.doc_date_original:
+            range_splitted = self.doc_date_original.split("/")
+        elif self.doc_date_standard:
+            range_splitted = self.doc_date_standard.split("/")
         if range_splitted and len(range_splitted) > 1:
             start = PartialDate(range_splitted[0])
             end = PartialDate(range_splitted[1])

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -21,7 +21,6 @@ from geniza.entities.models import Person
 class TestDocumentDateMixin:
     # for convenience, use the Document model to test the date mixin
 
-    @pytest.mark.mohamed
     def test_clean(self):
         doc = Document()
         # no dates; no error

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -21,6 +21,7 @@ from geniza.entities.models import Person
 class TestDocumentDateMixin:
     # for convenience, use the Document model to test the date mixin
 
+    @pytest.mark.mohamed
     def test_clean(self):
         doc = Document()
         # no dates; no error
@@ -51,6 +52,17 @@ class TestDocumentDateMixin:
 
         # both full date range (star later than end) — error
         doc.doc_date_original = "351-01-01/350-01-01"
+        with pytest.raises(ValidationError):
+            doc.clean()
+
+        # only std (CE) full date range and no calendar — no error
+        doc.doc_date_calendar = None
+        doc.doc_date_original = None
+        doc.doc_date_standard = "2020/2021"
+        doc.clean()
+
+        # only std (CE) full date range and no calendar (star later than end) — error
+        doc.doc_date_standard = "2021/2020"
         with pytest.raises(ValidationError):
             doc.clean()
 

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -49,6 +49,11 @@ class TestDocumentDateMixin:
         doc.doc_date_original = "350-01-01/351-01-01"
         doc.clean()
 
+        # both full date range (star later than end) — error
+        doc.doc_date_original = "351-01-01/350-01-01"
+        with pytest.raises(ValidationError):
+            doc.clean()
+
         # future date - error
         today = datetime.date.today()
         tomorrow = today + datetime.timedelta(days=1)
@@ -59,6 +64,14 @@ class TestDocumentDateMixin:
         # future date range - error
         doc.doc_date_original = (
             f"{today.strftime('%Y-%m-%d')}/{tomorrow.strftime('%Y-%m-%d')}"
+        )
+        with pytest.raises(ValidationError):
+            doc.clean()
+
+        # date_original with no calendar (star later than end) — error
+        yesterday = today - datetime.timedelta(days=1)
+        doc.doc_date_original = (
+            f"{yesterday.strftime('%Y-%m-%d')}/{today.strftime('%Y-%m-%d')}"
         )
         with pytest.raises(ValidationError):
             doc.clean()

--- a/geniza/corpus/tests/test_dates.py
+++ b/geniza/corpus/tests/test_dates.py
@@ -185,6 +185,11 @@ class TestPerson:
         person.date = "2024-06-12/2025-06-12"
         person.clean()
 
+        # full past date range with end earlier than start —  error
+        person.date = "2025-06-12/2024-06-12"
+        with pytest.raises(ValidationError):
+            person.clean()
+
         # partial past date — no error
         person.date = "2024"
         person.clean()
@@ -192,6 +197,11 @@ class TestPerson:
         # partial past date range — no error
         person.date = "2024/2025"
         person.clean()
+
+        # partial past date range with end earlier than start — error
+        person.date = "2025/2024"
+        with pytest.raises(ValidationError):
+            person.clean()
 
         # future date - error
         today = datetime.date.today()
@@ -202,6 +212,12 @@ class TestPerson:
 
         # future date range - error
         person.date = f"{today.strftime('%Y-%m-%d')}/{tomorrow.strftime('%Y-%m-%d')}"
+        with pytest.raises(ValidationError):
+            person.clean()
+
+        # date range with end earlier than start - error
+        yesterday = today - datetime.timedelta(days=1)
+        person.date = f"{today.strftime('%Y-%m-%d')}/{yesterday.strftime('%Y-%m-%d')}"
         with pytest.raises(ValidationError):
             person.clean()
 

--- a/geniza/entities/models.py
+++ b/geniza/entities/models.py
@@ -473,21 +473,31 @@ class Person(
 
     def clean(self):
         """
-        Require date_str is not a future date.
-        If date_str is a range, require its end not tobe a future date
+        Disallowing date_str from being a future date.
+        If date_str is a range, require its end not to be a future date
         """
         if self.date:
-            date_to_check = self.date.split("/")
+            range_splitted = self.date.split("/")
+            start_to_check, end_to_check = None, None
+            if len(range_splitted) > 1:
+                start = PartialDate(range_splitted[0])
+                end = PartialDate(range_splitted[1])
+                start_to_check = date.fromisoformat(
+                    start.isoformat(mode="max", fmt="full")
+                )
+                end_to_check = date.fromisoformat(end.isoformat(mode="max", fmt="full"))
             date_to_check = (
-                date_to_check[len(date_to_check) - 1]
-                if len(date_to_check) > 1
-                else date_to_check[0]
+                range_splitted[len(range_splitted) - 1]
+                if len(range_splitted) > 1
+                else range_splitted[0]
             )
             date_to_check = date.fromisoformat(
                 PartialDate(date_to_check).isoformat(mode="max", fmt="full")
             )
             if date_to_check > date.today():
                 raise ValidationError("Can't input a date in the future!")
+            if start_to_check and end_to_check and end_to_check < start_to_check:
+                raise ValidationError("End date can't be earlier than start date!")
 
     @property
     def date_str(self):


### PR DESCRIPTION
**Associated Issue(s):** resolves #1981

### Changes in this PR

- Disallowing invalid date ranges for documents module
- Disallowing invalid date ranges for people module


### Reviewer Checklist

- [x] Create a new document with CE date range whose end is earlier than the start
- [x] Edit an existing document; change its CE date to a date range whose end is earlier than the start
- [x] Create a new document with (non CE) date range whose end is earlier than the start
- [x] Edit an existing document change its (non CE) date range whose end is earlier than the start
- [x] Create a new person with date range whose end is earlier than the start
- [x] Edit an existing person; change his/her (non CE) date range whose end is earlier than the start
- [x] Tests pass 100%
