### PR TITLE
Prototype feature to search/browse document images

### DIFF
--- a/geniza/corpus/templates/corpus/document_image_list.html
+++ b/geniza/corpus/templates/corpus/document_image_list.html
@@ -1,0 +1,211 @@
+{% extends 'base.html' %}
+{% load static i18n humanize widget_tweaks %}
+
+{% block meta_title %}{{ page_title }}{% endblock meta_title %}
+{% block meta_description %}{{ page_description }}{% endblock meta_description %}
+
+{% block main %}
+    <h1>{{ page_title }}</h1>
+    <form data-controller="search" data-turbo-frame="main" data-turbo-action="advance" data-page="image">
+        <div>
+        <fieldset id="query">
+            <div id="mode-controls">
+                <span class="fieldname">{{ form.mode.label }}</span>
+                <dialog data-search-target="helpDialog">
+                    {# Translators: heading for search mode help text #}
+                    <h2>
+                        <span>{% translate "How to Search" %}</span>
+                        <button type="button" id="close-search-help" data-action="search#toggleHelpDialog">
+                            {# Translators: accessibility label for button to close search mode help dialog #}
+                            <span class="sr-only">{% translate "Close search mode help" %}</span>
+                        </button>
+                    </h2>
+                    {% include "corpus/snippets/document_search_helptext.html" %}
+                </dialog>
+                <button type="button" id="search-help" data-action="search#toggleHelpDialog">
+                    {# Translators: accessibility label for button to open search mode help dialog #}
+                    <span class="sr-only">{% translate "Open search mode help" %}</span>
+                </button>
+                {% render_field form.mode data-action="change->search#update" %}
+            </div>
+            {# Translators: Search submit button #}
+            {% translate 'Search' as search_label %}
+            {% if request.GET.mode != 'regex' %}
+                <div id="search-input">
+                    <div>
+                        {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
+                        <button type="submit" aria-label="{{ search_label }}" />
+                    </div>
+                    <span class="shelfmark-help">
+                        {# translators: help text for shelfmark general search #}
+                        {% blocktrans with example_search="<code>shelfmark:&quot;Bodl ms. Heb a 2/3&quot;</code>"|safe %}
+                            Trouble finding a shelfmark? Try {{ example_search }}
+                        {% endblocktrans %}
+                    </span>
+                </div>
+            {% endif %}
+        </fieldset>
+        {% if request.GET.mode == 'regex' %}
+            <fieldset id="regex-search">
+                {% render_field form.q data-search-target="query" data-action="input->search#autoUpdateSort change->search#update" %}
+
+                {# translators: "in" label between search query form and field dropdown #}
+
+                <label for="{{ form.regex_field.auto_id }}">
+                    <span class="regex-label">{% translate 'in' %}</span>
+
+                    <span class="sr-only">{{ form.regex_field.label }}</span>
+                    {% render_field form.regex_field data-action="change->search#update" %}
+                </label>
+
+                {# Translators: Search submit button #}
+                <button type="submit"><span>{{ search_label }}</span></button>
+
+                {% if request.GET.regex_field == 'shelfmark' %}
+                    <span class="shelfmark-help">
+                        {# translators: help text for shelfmark regex search #}
+                        {% blocktrans %}
+                            Case sensitive, must match entire shelfmark. Type one shelfmark,
+                            even if part of a join, for best results.
+                        {% endblocktrans %}
+                    </span>
+                {% endif %}
+            </fieldset>
+        {% endif %}
+        <div id="filters-header">
+            <a href="#filters" role="button" id="filters-button" data-search-target="filtersButton" data-action="click->search#toggleFiltersOpen">
+                <svg><use xlink:href="{% static 'img/ui/all/all/search-filter-icon.svg' %}#filter-icon" /></svg>
+                <span>{% translate "Filters" %}</span>
+                {% if applied_filters %}
+                    <span class="filter-count">{{ applied_filters|length }}</span>
+                {% endif %}
+            </a>
+            {% if applied_filters %}
+                {# convenient unapply filter buttons; aria role set to presentation as functionality duplicated below #}
+                <div id="applied-filters" role="presentation">
+                    {% for filter in applied_filters %}
+                        <button
+                            data-field="{{ filter.field }}"
+                            value="{{ filter.value }}"
+                            data-action="click->search#unapplyFilter"
+                        >
+                            {{ filter.label }}
+                            <i class="ph-x"></i>
+                        </button>
+                    {% endfor %}
+                </div>
+                <button id="clear-filters" data-action="click->search#clearFilters">
+                    {# Translators: label for button to clear all applied filters #}
+                    {% translate "Clear all" %}
+                </button>
+            {% endif %}
+        </div>
+
+        <div class="modal-backdrop" aria-hidden="true" data-action="click->search#closeFilters"></div>
+        <fieldset id="filters" aria-expanded="false" data-search-target="filterModal">
+            <legend>{% translate "Filters" %}</legend>
+            <a href="#" role="button" id="close-filters-modal" data-action="click->search#closeFilters">
+                {# Translators: label for 'filters' close button for mobile navigation #}
+                {% translate "Close filter options" as close_button %}
+                <span class="sr-only">{{ close_button }}</span>
+            </a>
+            <div class="fieldset-left-column">
+                <label for="{{ form.docdate.auto_id }}" class="docdate-range-label">
+                    <span class="fieldname">{{ form.docdate.label }}</span>
+                    {# NOTE: stimulus action is configured via django widget attrs #}
+                    {{ form.docdate }}
+                </label>
+                <label for="{{ form.exclude_inferred.auto_id }}">
+                    {% render_field form.exclude_inferred data-action="search#update" %}
+                    <span>{{ form.exclude_inferred.label }}</span>
+                    <div class="thumb" aria-hidden="true"></div>
+                </label>
+            </div>
+            <fieldset class="includes-fields">
+                <legend><span class="fieldname">{% translate "Includes" %}</span></legend>
+                <ul>
+                    <li>
+                        <label for="{{ form.has_image.auto_id }}">
+                            {% render_field form.has_image data-action="search#update" %}
+                            {{ form.has_image.label }}
+                        </label>
+                    </li>
+                    <li>
+                        <label for="{{ form.has_transcription.auto_id }}">
+                            {% render_field form.has_transcription data-action="search#update" %}
+                            {{ form.has_transcription.label }}
+                        </label>
+                    </li>
+                    <li>
+                        <label for="{{ form.has_translation.auto_id }}" class="has-translation-label">
+                            {% render_field form.has_translation data-action="search#update" %}
+                            {{ form.has_translation.label }}
+                        </label>
+                        <label for="{{ form.translation_language.auto_id }}">
+                            <span class="sr-only">{{ form.translation_language.label }}</span>
+                            {% render_field form.translation_language data-action="search#update" %}
+                        </label>
+                    </li>
+                    <li>
+                        <label for="{{ form.has_discussion.auto_id }}">
+                            {% render_field form.has_discussion data-action="search#update" %}
+                            {{ form.has_discussion.label }}
+                        </label>
+                    </li>
+                </ul>
+            </fieldset>
+            <label for="{{ form.doctype.auto_id }}">
+                <span class="fieldname">{{ form.doctype.label }}</span>
+                {% render_field form.doctype data-action="search#update" %}
+            </label>
+            {# hidden input, accessible from admin or by URL params #}
+            {% if form.no_transcription.value %}
+                {# only render if set to prevent polluting params #}
+                {% render_field form.no_transcription %}
+            {% endif %}
+        </fieldset>
+        <div class="header-row">
+            <h2>
+                {# Translators: search results section header #}
+                {% translate "Results" %}
+            </h2>
+            <span class="result-count">
+                {% comment %}Translators: number of search results{% endcomment %}
+                {% blocktranslate with count_humanized=paginator.count|intcomma count counter=paginator.count trimmed %}
+                    1 result
+                {% plural %}
+                    {{ count_humanized }} results
+                {% endblocktranslate %}
+            </span>
+            <fieldset id="sort-field">
+                <label for="{{ form.sort.html_name }}">{{ form.sort.label }}</label>
+                {% render_field form.sort id="sort" data-search-target="sort" data-action="input->search#update" %}
+                {# caret icon for <select>; since we also have the select element, role=presentation #}
+                <i class="ph-caret-down" role="presentation"></i>
+            </fieldset>
+        </div>
+
+        {% if form.errors %}
+            <ul id="search-errors">
+                {% for field, errors in form.errors.items %}
+                    {# no clean way to get field labels here, so we just collapse the error lists #}
+                    {% for error in errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        </div>
+
+            <!--<ol>-->
+                {% for document in documents %}
+                    {% include "corpus/snippets/document_image_result.html" %}
+                {% endfor %}
+            <!--</ol>-->
+            {% if is_paginated %}
+                {% include "corpus/snippets/pagination.html" %}
+            {% endif %}
+        <!--</section>-->
+    </form>
+{% endblock main %}

--- a/geniza/corpus/templates/corpus/snippets/document_image_result.html
+++ b/geniza/corpus/templates/corpus/snippets/document_image_result.html
@@ -1,0 +1,13 @@
+{% load i18n corpus_extras %}
+{% spaceless %}
+{# images are indexed as a list of tuples of (IIIF image, label, rotation) #}
+{% for image in document.iiif_images|slice:":3" %}
+{% with deg=image.2|stringformat:"i" %}
+    {% with rotation="rotation:degrees="|add:deg %}
+        <div class="image">
+            <img src="{{ image.0|iiif_image:"size:width=250"|iiif_image:rotation }}" loading="lazy" alt="{{ image.1 }}">
+        </div>
+    {% endwith %}
+{% endwith %}
+{% endfor %}
+{% endspaceless %}

--- a/geniza/corpus/urls.py
+++ b/geniza/corpus/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path(
         "documents/", corpus_views.DocumentSearchView.as_view(), name="document-search"
     ),
+    path("images/", corpus_views.ImageSearchView.as_view(), name="image-search"),
     path(
         "documents/<int:pk>/",
         corpus_views.DocumentDetailView.as_view(),

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -460,6 +460,21 @@ class DocumentSearchView(
         return context_data
 
 
+class ImageSearchView(DocumentSearchView):
+    context_object_name = "documents"
+    template_name = "corpus/document_image_list.html"
+    page_title = _("Document images")
+    # Translators: description of document search page, for search engines
+    page_description = _("Search and browse Geniza document images.")
+    paginate_by = 100
+    initial = {
+        "sort": "random",
+        "mode": "general",
+        "regex_field": "transcription",
+        "has_image": True,
+    }
+
+
 class DocumentDetailBase(SolrLastModifiedMixin):
     """View mixin to handle lastmodified and redirects for documents with old PGPIDs.
     Overrides get request in the case of a 404, looking for any records
@@ -1045,9 +1060,9 @@ class DocumentTranscribeView(PermissionRequiredMixin, DocumentDetailView):
                     context_data["images"][canvas_uri] = deepcopy(
                         Document.PLACEHOLDER_CANVAS
                     )
-                    context_data["images"][canvas_uri][
-                        "shelfmark"
-                    ] = b.fragment.shelfmark
+                    context_data["images"][canvas_uri]["shelfmark"] = (
+                        b.fragment.shelfmark
+                    )
                     context_data["images"][canvas_uri]["label"] = (
                         "recto" if i == 1 else "verso"
                     )

--- a/sitemedia/scss/base/_breakpoints.scss
+++ b/sitemedia/scss/base/_breakpoints.scss
@@ -23,3 +23,10 @@
         @content;
     }
 }
+
+@mixin for-widescreen {
+    /* 4K UHD */
+    @media (min-width: 3840px) {
+        @content;
+    }
+}

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -14,6 +14,9 @@ main.people * {
     @include breakpoints.for-tablet-landscape-up {
         max-width: 56rem; // = 896px
     }
+    @include breakpoints.for-widescreen {
+        max-width: none;
+    }
 }
 main.search,
 main.people {
@@ -37,5 +40,34 @@ main.people {
 }
 
 main.search > h1 {
+    width: 100%;
+}
+
+/* for image search/browse */
+
+main.search > * {
+    @include breakpoints.for-widescreen {
+        padding: 0 2rem;
+    }
+}
+
+main.search form[data-page="image"] {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    max-width: none;
+    padding-left: 2rem;
+}
+
+form[data-page="image"] div {
+    max-width: none;
+    width: fit-content;
+}
+
+form[data-page="image"] div.image {
+    padding: 0.5rem;
+}
+
+form[data-page="image"] nav.pagination {
     width: 100%;
 }

--- a/sitemedia/scss/pages/_search.scss
+++ b/sitemedia/scss/pages/_search.scss
@@ -70,4 +70,5 @@ form[data-page="image"] div.image {
 
 form[data-page="image"] nav.pagination {
     width: 100%;
+    max-width: none;
 }


### PR DESCRIPTION
Creating a draft PR so you can see the changes I made for the prototype we looked at in the CURVE together this week.  Thought it might be helpful to see, so you could assess what would be needed to turn this into a production-worthy feature. 

### Changes in this PR

- Added new document image search view as a subclass of the existing document search view; uses the same form filter, pre-selects documents with images
- Added new document image search templates based on existing document search templates
- Adjusted styles and layout for image search results for wide screen

### Notes

- This is a **document-centric** image search using existing document indexing.
- I'm displaying images only, real version would need some document context and link to document detail pages.
- There is substantial overlap between the templates; if pursued, would be good to consider shared snippets for common  content like the form
- I moved everything associated with the form into a div so I could make the whole page a flow container, trying to use as much real estate as possible for the actual images.
- I was focused on large screens and didn't think about mobile layout or LTR at all.  I may not have put the style overrides in the best place.
