### PR TITLE
Adding date_range to the people export

### DIFF
--- a/geniza/entities/metadata_export.py
+++ b/geniza/entities/metadata_export.py
@@ -41,7 +41,7 @@ class PublicPersonExporter(Exporter):
         "gender",
         "social_roles",
         # TODO: floruit vs mentioned as dead date columns
-        "auto_date_range",
+        "active_date_range",
         "manual_date_range",
         "description",
         "tags",


### PR DESCRIPTION
**Associated Issue(s):** resolves #2003 

### Changes in this PR
- Changing the column name to match the date range so that it populates the people exports

### Reviewer Checklist

- [x] Date ranges populate correctly in people exports
- [x] Tests pass 100%
