### PR TITLE
Fixes for "excluded image" related document link style (#2005)

### DIFF
--- a/geniza/corpus/templates/corpus/snippets/document_transcription.html
+++ b/geniza/corpus/templates/corpus/snippets/document_transcription.html
@@ -240,7 +240,7 @@
                                     {% if image_info.image|stringformat:"s" in related.images %}
                                         <li><a class="view-link" href="{% url 'corpus:document' related.document.pgpid %}">
                                             {% translate 'Unknown type' as unknown_type %}
-                                            {% with doctype=related.document.type|default:unknown_type shelfmark=related.document.shelfmark|shelfmark_wrap %}
+                                            {% with doctype=related.document.type|default:unknown_type|stringformat:"s" shelfmark=related.document.shelfmark|shelfmark_wrap %}
                                                 {# translators: link to view a related document #}
                                                 {% blocktranslate with related_doc="<span>"|add:doctype|add:": "|add:shelfmark|add:"</span>"|safe trimmed %}
                                                     View {{ related_doc }}

--- a/sitemedia/scss/components/_transcription.scss
+++ b/sitemedia/scss/components/_transcription.scss
@@ -1101,6 +1101,11 @@
                     & > span {
                         margin-left: 0.25em;
                     }
+                    /* balance the "+" join separator: the flex parent trims the
+                       whitespace around it, so add space before each "+" too */
+                    & > span:not(:last-child) {
+                        margin-right: 0.25em;
+                    }
                 }
                 &:hover {
                     border-bottom-color: var(--icon-button);


### PR DESCRIPTION
**Associated Issue(s):** #2005

### Changes in this PR

- Coerce `DocumentType` to a string in template snippet to fix string concatenation issues (doctype not showing, extra arrows between join shelfmarks)
- Fix an issue where `+` between joined shelfmarks had uneven spacing in this section

### Notes

- `Document.related_documents`, the source of these links, returns Solr result dicts where `type` is resolved to a `DocumentType` model instance. The template logic expects a string there instead (as it uses the `|add` string method) and thus was silently failing. That resulted in the `shelfmark_wrap` fragment spans being direct children of `a.view-link`, so the arrow pseudo-element repeated on each.