### PR TITLE
Add pagination to related documents page, set to 50 documents per page (#1995)

### DIFF
--- a/geniza/corpus/templates/corpus/related_documents.html
+++ b/geniza/corpus/templates/corpus/related_documents.html
@@ -11,9 +11,12 @@
     {% include "corpus/snippets/document_tabs.html" %}
     <section id="document-list" class="related-documents">
         <ol>
-            {% for document in document.related_documents %}
+            {% for document in page_obj %}
                 {% include "corpus/snippets/document_result.html" %}
             {% endfor %}
         </ol>
+        {% if is_paginated %}
+            {% include "corpus/snippets/pagination.html" %}
+        {% endif %}
     </section>
 {% endblock main %}

--- a/geniza/corpus/tests/test_corpus_views.py
+++ b/geniza/corpus/tests/test_corpus_views.py
@@ -2191,6 +2191,20 @@ class TestRelatdDocumentview:
             == doc_response.context["page_includes_transcriptions"]
         )
 
+    def test_pagination(self, document, join, client, empty_solr):
+        """should paginate related documents using a Solr-backed page_obj"""
+        Document.index_items([document, join])
+        SolrClient().update.index([], commit=True)
+
+        response = client.get(reverse("corpus:related-documents", args=(document.id,)))
+        page_obj = response.context["page_obj"]
+        # "join" fixture = 1 related document, fits on a single page
+        assert page_obj.paginator.count == 1
+        assert page_obj.number == 1
+        assert response.context["is_paginated"] is False
+        # related document should be present in the paginated results
+        assert page_obj.object_list[0]["pgpid"] == join.id
+
 
 class TestDocumentTranscribeView:
     def test_page_title(self, document, source, admin_client):

--- a/geniza/corpus/views.py
+++ b/geniza/corpus/views.py
@@ -12,6 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.search import SearchVector
 from django.core.exceptions import ValidationError
+from django.core.paginator import Paginator
 from django.db.models import Q
 from django.db.models.query import Prefetch
 from django.http import Http404, HttpResponse, JsonResponse
@@ -622,6 +623,8 @@ class RelatedDocumentView(DocumentDetailView):
 
     template_name = "corpus/related_documents.html"
     viewname = "corpus:related-documents"
+    #: number of related documents to show per page; matches document search
+    paginate_by = 50
 
     def page_title(self):
         # Translators: title of related documents page
@@ -644,7 +647,19 @@ class RelatedDocumentView(DocumentDetailView):
         # if there are no related documents, don't serve out this page
         if not doc.related_documents.count():
             raise Http404
-        return super().get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
+        # paginate the related documents Solr queryset, reusing the same
+        # pagination behavior and template snippet as document search
+        paginator = Paginator(doc.related_documents, self.paginate_by)
+        page_obj = paginator.get_page(self.request.GET.get("page"))
+        context.update(
+            {
+                "paginator": paginator,
+                "page_obj": page_obj,
+                "is_paginated": page_obj.has_other_pages(),
+            }
+        )
+        return context
 
 
 class DocumentTranscriptionText(DocumentDetailView):


### PR DESCRIPTION
**Associated Issue(s):** #1995

### Changes in this PR

- Allow more than 10 documents to be viewed on the Related Documents page by showing 50 documents per page, and paginating further results