### PR TITLE
Add placeholder image filters to admin (#2014)

### DIFF
--- a/geniza/corpus/admin.py
+++ b/geniza/corpus/admin.py
@@ -277,6 +277,42 @@ class HasTranslationListFilter(admin.SimpleListFilter):
             )
 
 
+class PlaceholderCanvasListFilter(admin.SimpleListFilter):
+    """Custom list filters for documents with annotation content (transcription
+    or translation) on placeholder canvases.
+
+    Placeholder canvases are minted by this application rather than an external
+    IIIF image server, used when a document has no (or not enough) real IIIF
+    images. Their canvas URIs always have a path like:
+        /documents/<pk>/iiif/textblock/<tb_pk>/canvas/<n>/
+    """
+
+    title = "Placeholder images"
+    parameter_name = "placeholder_canvas"
+
+    # regex matching any placeholder canvas URI (old + current, relative + absolute)
+    PLACEHOLDER_CANVAS_RE = r"/documents/\d+/iiif/(canvas|textblock)/"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("yes", "Has content on placeholder image(s)"),
+            ("movable", "Has placeholder content and real image(s)"),
+        )
+
+    def queryset(self, request, queryset):
+        placeholder = Q(
+            footnotes__annotation__content__target__source__id__regex=self.PLACEHOLDER_CANVAS_RE
+        )
+        if self.value() == "yes":
+            # distinct(): a document may have several matching annotations
+            return queryset.filter(placeholder).distinct()
+        if self.value() == "movable":
+            # also require a real IIIF image the content could be moved onto
+            return queryset.filter(
+                placeholder & Q(textblock__fragment__iiif_url__gt="")
+            ).distinct()
+
+
 class TextInputListFilter(admin.SimpleListFilter):
     """
     Custom list filter class for text input, adapted from this solution by Haki Benita:
@@ -520,6 +556,7 @@ class DocumentAdmin(
         "doctype",
         HasTranscriptionListFilter,
         HasTranslationListFilter,
+        PlaceholderCanvasListFilter,
         (
             "textblock__fragment__iiif_url",
             custom_empty_field_list_filter("IIIF image", "Has image", "No image"),

--- a/geniza/corpus/tests/test_corpus_admin.py
+++ b/geniza/corpus/tests/test_corpus_admin.py
@@ -21,6 +21,7 @@ from pytest_django.asserts import assertContains, assertNotContains
 from requests.exceptions import ConnectionError
 from taggit.models import Tag
 
+from geniza.annotations.models import Annotation
 from geniza.common.views import SolrDownError
 from geniza.corpus.admin import (
     DateAfterListFilter,
@@ -35,6 +36,7 @@ from geniza.corpus.admin import (
     HasTranslationListFilter,
     InferredDatingListFilter,
     LanguageScriptAdmin,
+    PlaceholderCanvasListFilter,
 )
 from geniza.corpus.models import (
     Collection,
@@ -714,6 +716,85 @@ class TestHasTranslationListFilter(TestHasTranscriptionListFilter):
             ("yes_he", f"Has Hebrew {self.name}"),
             ("no", f"No {self.name}"),
         )
+
+
+class TestPlaceholderCanvasListFilter:
+    def init_filter(self):
+        # request, params, model, admin_site
+        return PlaceholderCanvasListFilter(Mock(), {}, Document, DocumentAdmin)
+
+    def test_lookups(self):
+        assert self.init_filter().lookups(Mock(), Mock()) == (
+            ("yes", "Has content on placeholder image(s)"),
+            ("movable", "Has placeholder content and real image(s)"),
+        )
+
+    def make_annotation(self, source, document, canvas_uri):
+        footnote = Footnote.objects.create(
+            source=source,
+            content_object=document,
+            doc_relation=Footnote.DIGITAL_EDITION,
+        )
+        return Annotation.objects.create(
+            footnote=footnote,
+            content={
+                "body": [{"value": "Test annotation"}],
+                "target": {"source": {"id": canvas_uri}},
+            },
+        )
+
+    @pytest.mark.django_db
+    def test_queryset(self, annotation, document, source):
+        # `annotation` fixture puts `document` on a real (external) canvas;
+        # add a second document on a programmatic placeholder canvas
+        placeholder_doc = Document.objects.create()
+        self.make_annotation(
+            source,
+            placeholder_doc,
+            f"/documents/{placeholder_doc.pk}/iiif/textblock/1/canvas/1/",
+        )
+
+        filter = self.init_filter()
+        with patch.object(filter, "value", return_value="yes"):
+            result = filter.queryset(Mock(), Document.objects.all())
+            # only the placeholder document matches; real-canvas doc does not
+            assert set(result.values_list("pk", flat=True)) == {placeholder_doc.pk}
+
+    @pytest.mark.django_db
+    def test_queryset_old_style_placeholder(self, document, source):
+        # old-style placeholder URIs (without a textblock id) should also match
+        self.make_annotation(
+            source, document, f"/documents/{document.pk}/iiif/canvas/2/"
+        )
+        filter = self.init_filter()
+        with patch.object(filter, "value", return_value="yes"):
+            result = filter.queryset(Mock(), Document.objects.all())
+            assert result.filter(pk=document.pk).exists()
+
+    @pytest.mark.django_db
+    @patch("geniza.corpus.models.GenizaManifestImporter")
+    def test_queryset_movable(self, mock_importer, document, source):
+        mock_importer.return_value.import_paths.return_value = []
+        placeholder_uri = f"/documents/{document.pk}/iiif/textblock/1/canvas/1/"
+        # `document` fixture has a fragment with a real IIIF url, so its
+        # placeholder content can be moved to a real image -> matches
+        self.make_annotation(source, document, placeholder_uri)
+
+        # a document whose only fragment has no IIIF url has nowhere to move
+        # its placeholder content -> does not match
+        no_image_doc = Document.objects.create()
+        no_image_frag = Fragment.objects.create(shelfmark="No image 1", iiif_url="")
+        TextBlock.objects.create(document=no_image_doc, fragment=no_image_frag, order=1)
+        self.make_annotation(
+            source,
+            no_image_doc,
+            f"/documents/{no_image_doc.pk}/iiif/textblock/1/canvas/1/",
+        )
+
+        filter = self.init_filter()
+        with patch.object(filter, "value", return_value="movable"):
+            result = filter.queryset(Mock(), Document.objects.all())
+            assert set(result.values_list("pk", flat=True)) == {document.pk}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Associated Issue(s):** #2014

### Changes in this PR

- Add a filter to the Document admin list view that shows documents with any transcription or translation content on placeholder images
- Add a second filter in the same place that only shows documents that have content on placeholder images AND that have real IIIF images—in other words, placeholder content that can be moved to real images