### PR TITLE
One-off management command script to ingest Posen sources and footnotes (#2013)

### DIFF
--- a/DEPLOYNOTES.md
+++ b/DEPLOYNOTES.md
@@ -1,5 +1,9 @@
 # Deploy Notes
 
+## 4.31
+
+-   Ingest the Posen spreadsheet's source and footnote records using the CSV downloaded from Google Drive, with the new management command: `python manage.py import_posen_translations /path/to/posen.csv`
+
 ## 4.30
 
 -   Replace FrankRuhl with the new `FrankRuhl1924MFMediumPro.woff` and `FrankRuhl1924MFMediumPro.woff2` in `sitemedia/fonts`. The original font was missing certain combining vowel marks. (If using CDH Ansible to deploy, no action is required.)

--- a/geniza/footnotes/management/commands/import_posen_translations.py
+++ b/geniza/footnotes/management/commands/import_posen_translations.py
@@ -1,0 +1,339 @@
+import csv
+from collections import Counter
+
+from django.conf import settings
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from parasolr.django.signals import IndexableSignalHandler
+
+from geniza.corpus.models import Document
+from geniza.footnotes.models import (
+    Authorship,
+    Creator,
+    Footnote,
+    Source,
+    SourceLanguage,
+    SourceType,
+)
+
+
+class SkipRow(Exception):
+    """Raised to skip a CSV row for a stated reason without aborting the run."""
+
+
+class Command(BaseCommand):
+    """One-off ingest of Posen Library translations from a CSV. Creates a new
+    "Book Section" Source per row, and either:
+
+    * Column H == "no": also creates a new "Translation" (content-less)
+      `Footnote` linking the source to the document matched by the row's PGPID;
+      existing footnotes are left untouched.
+    * Column H == "yes": reassigns the existing "Digital Translation" footnote
+      (id in Column I) from its current source to the new source.
+
+    Skips and reports any data issues."""
+
+    help = __doc__
+
+    # zero-indexed CSV columns, matching spreadsheet columns A-M
+    COL_PGPID = 1  # pgpid
+    COL_PGP_URL = 4  # url
+    COL_TITLE = 6  # Source title / chapter name
+    COL_REASSIGN = 7  # "no" => new source + footnote; "yes" => reassign
+    COL_FOOTNOTE_ID = 8  # existing footnote to reassign, for "yes" rows
+    COL_CREATOR_IDS = 10  # Creator pks, separated by ";" or ","
+    COL_POSEN_URL = 11  # stable Posen URL -> Source.url
+
+    # constant Source field values shared by every created Posen source
+    SOURCE_YEAR = 2026
+    SOURCE_PUBLISHER = "Yale University Press"
+    SOURCE_PLACE = "New Haven, Connecticut and London"
+    SOURCE_JOURNAL = "Posen Library of Jewish Culture and Civilization"
+    SOURCE_VOLUME = "3"
+    SOURCE_TYPE = "Book Section"
+    SOURCE_LANGUAGE = "English"
+
+    def add_arguments(self, parser):
+        parser.add_argument("csv", type=str, help="Path to the input CSV file")
+        parser.add_argument(
+            "-d",
+            "--dryrun",
+            action="store_true",
+            help="Process the CSV and report actions, but roll back all changes",
+        )
+        parser.add_argument(
+            "--skip-indexing",
+            action="store_true",
+            default=False,
+            help="Turn off Solr indexing as changes are made (on by default)",
+        )
+
+    def handle(self, *args, **options):
+        self.dryrun = options["dryrun"]
+        self.stats = Counter()
+        # (row number, pgpid, reason) tuples for reporting
+        self.skipped = []
+
+        if options["skip_indexing"]:
+            IndexableSignalHandler.disconnect()
+
+        # look up shared/related records once; fail if setup is missing
+        try:
+            self.script_user = User.objects.get(username=settings.SCRIPT_USERNAME)
+        except User.DoesNotExist:
+            raise CommandError(
+                "Script user '%s' not found; cannot record log entries"
+                % settings.SCRIPT_USERNAME
+            )
+        try:
+            self.book_section = SourceType.objects.get(type=self.SOURCE_TYPE)
+        except SourceType.DoesNotExist:
+            raise CommandError("SourceType '%s' not found" % self.SOURCE_TYPE)
+        try:
+            self.english = SourceLanguage.objects.get(name=self.SOURCE_LANGUAGE)
+        except SourceLanguage.DoesNotExist:
+            raise CommandError("SourceLanguage '%s' not found" % self.SOURCE_LANGUAGE)
+
+        self.document_contenttype = ContentType.objects.get_for_model(Document)
+        self.source_contenttype = ContentType.objects.get_for_model(Source)
+        self.footnote_contenttype = ContentType.objects.get_for_model(Footnote)
+
+        try:
+            with open(options["csv"]) as f:
+                # index by column position rather than header name;
+                # headers are long and contain commas/newlines
+                reader = csv.reader(f)
+                # discard header row
+                next(reader, None)
+                with transaction.atomic():
+                    for i, row in enumerate(reader, start=2):
+                        self.process_row(i, row)
+                    if self.dryrun:
+                        transaction.set_rollback(True)
+        except FileNotFoundError:
+            raise CommandError("CSV file not found: %s" % options["csv"])
+
+        self.report()
+
+    def process_row(self, row_num, row):
+        """Process a single CSV row, skipping (and recording) any row that
+        cannot be processed cleanly"""
+        # ignore empty row
+        if not any(cell.strip() for cell in row):
+            return
+
+        pgpid_raw = self.cell(row, self.COL_PGPID)
+        try:
+            # use one atomic transaction per row to allow rollback
+            with transaction.atomic():
+                reassign = self.cell(row, self.COL_REASSIGN).strip().lower()
+                creator_ids = self.parse_creator_ids(row)
+
+                if reassign == "no":
+                    self.create_source_and_footnote(row, creator_ids)
+                elif reassign == "yes":
+                    self.create_source_and_reassign(row, creator_ids)
+                else:
+                    raise SkipRow(
+                        "unrecognized Column H value %r (expected 'yes' or 'no')"
+                        % self.cell(row, self.COL_REASSIGN).strip()
+                    )
+        except SkipRow as err:
+            self.stats["skipped"] += 1
+            self.skipped.append((row_num, pgpid_raw, str(err)))
+            self.stdout.write(
+                self.style.WARNING(
+                    "Row %d (PGPID %r) skipped: %s" % (row_num, pgpid_raw, err)
+                )
+            )
+
+    def create_source_and_footnote(self, row, creator_ids):
+        """Handle a Column H == "no" row: create the Posen source and a new
+        content-less Translation footnote on the row's single document."""
+        document = self.get_document(row)
+        source, created = self.get_or_create_source(row, creator_ids)
+
+        # idempotent: don't create a second footnote linking this source + document
+        if Footnote.objects.filter(
+            source=source,
+            content_type=self.document_contenttype,
+            object_id=document.pk,
+        ).exists():
+            return
+
+        footnote = Footnote.objects.create(
+            content_object=document,
+            source=source,
+            doc_relation=[Footnote.TRANSLATION],
+        )
+        self.stats["footnotes_created"] += 1
+        self.log(
+            self.footnote_contenttype,
+            footnote,
+            ADDITION,
+            "Created Translation footnote for Posen Library source",
+        )
+
+    def create_source_and_reassign(self, row, creator_ids):
+        """Handle a Column H == "yes" row: create the Posen source and reassign
+        the existing digital-translation footnote (Column I) to it."""
+        footnote = self.get_footnote(row)
+        source, created = self.get_or_create_source(row, creator_ids)
+
+        if footnote.source_id == source.pk:
+            return  # already reassigned (e.g. re-run)
+
+        if Footnote.DIGITAL_TRANSLATION not in (footnote.doc_relation or []):
+            # proceed as instructed, but flag the unexpected relation type
+            self.stdout.write(
+                self.style.WARNING(
+                    "Footnote %d is not a Digital Translation; reassigning anyway"
+                    % footnote.pk
+                )
+            )
+
+        old_source = footnote.source
+        footnote.source = source
+        footnote.save()
+        self.stats["footnotes_reassigned"] += 1
+        self.log(
+            self.footnote_contenttype,
+            footnote,
+            CHANGE,
+            "Reassigned footnote from source %r to new Posen Library source"
+            % str(old_source),
+        )
+
+    def get_or_create_source(self, row, creator_ids):
+        """Return the Posen source for this row, creating it (with authorship,
+        language, and slug) if an equivalent one does not already exist.
+        Matching on title + authors keeps the command safe to re-run."""
+        title = self.cell(row, self.COL_TITLE).strip()
+        if not title:
+            raise SkipRow("missing title (Column G)")
+
+        # reuse an existing identical source if present;
+        # prefetch authorships for efficiency
+        for candidate in Source.objects.filter(
+            title=title,
+            journal=self.SOURCE_JOURNAL,
+            volume=self.SOURCE_VOLUME,
+            year=self.SOURCE_YEAR,
+            source_type=self.book_section,
+        ).prefetch_related("authorship_set"):
+            existing_ids = [
+                a.creator_id
+                for a in candidate.authorship_set.all().order_by("sort_order")
+            ]
+            if existing_ids == creator_ids:
+                return candidate, False
+
+        source = Source.objects.create(
+            title=title,
+            year=self.SOURCE_YEAR,
+            publisher=self.SOURCE_PUBLISHER,
+            place_published=self.SOURCE_PLACE,
+            journal=self.SOURCE_JOURNAL,
+            volume=self.SOURCE_VOLUME,
+            url=self.cell(row, self.COL_POSEN_URL).strip(),
+            source_type=self.book_section,
+        )
+        source.languages.add(self.english)
+        for order, creator_id in enumerate(creator_ids, start=1):
+            Authorship.objects.create(
+                source=source, creator_id=creator_id, sort_order=order
+            )
+        # slug generation depends on the related creators, so run it last
+        source.generate_slug()
+        source.save()
+
+        self.stats["sources_created"] += 1
+        self.log(
+            self.source_contenttype,
+            source,
+            ADDITION,
+            "Created Posen Library book section source",
+        )
+        return source, True
+
+    def parse_creator_ids(self, row):
+        """Parse Column K into an ordered list of existing Creator pks."""
+        raw = self.cell(row, self.COL_CREATOR_IDS)
+        creator_ids = []
+        for part in raw.replace(";", ",").split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if not part.isdigit():
+                raise SkipRow("non-numeric Creator ID %r (Column K)" % part)
+            creator_ids.append(int(part))
+
+        if not creator_ids:
+            raise SkipRow("missing Creator ID(s) (Column K)")
+
+        found = set(
+            Creator.objects.filter(pk__in=creator_ids).values_list("pk", flat=True)
+        )
+        missing = [cid for cid in creator_ids if cid not in found]
+        if missing:
+            raise SkipRow(
+                "Creator ID(s) not found: %s" % ", ".join(str(cid) for cid in missing)
+            )
+        return creator_ids
+
+    def get_document(self, row):
+        """Resolve PGPID in Column B to a Document, skipping rows
+        with multiple/blank/non-numeric ids."""
+        raw = self.cell(row, self.COL_PGPID).strip()
+        if not raw.isdigit():
+            raise SkipRow(
+                "Column B is not a single numeric PGPID (%r); handle manually" % raw
+            )
+        try:
+            return Document.objects.get(pk=int(raw))
+        except Document.DoesNotExist:
+            raise SkipRow("no Document found for PGPID %s" % raw)
+
+    def get_footnote(self, row):
+        """Resolve the existing footnote id in Column I for a "yes" row."""
+        raw = self.cell(row, self.COL_FOOTNOTE_ID).strip()
+        if not raw.isdigit():
+            raise SkipRow("missing/invalid footnote id %r (Column I)" % raw)
+        try:
+            return Footnote.objects.get(pk=int(raw))
+        except Footnote.DoesNotExist:
+            raise SkipRow("no Footnote found for id %s (Column I)" % raw)
+
+    @staticmethod
+    def cell(row, index):
+        """Safely read a column, tolerating short rows"""
+        return row[index] if index < len(row) else ""
+
+    def log(self, content_type, obj, action_flag, message):
+        """Record an admin log entry"""
+        LogEntry.objects.log_action(
+            user_id=self.script_user.pk,
+            content_type_id=content_type.pk,
+            object_id=obj.pk,
+            object_repr=str(obj),
+            change_message=message,
+            action_flag=action_flag,
+        )
+
+    def report(self):
+        """Summarize created/reassigned records and list skipped rows."""
+        if self.dryrun:
+            self.stdout.write(self.style.NOTICE("DRY RUN — no changes committed"))
+        self.stdout.write("Sources created: %d" % self.stats["sources_created"])
+        self.stdout.write("Footnotes created: %d" % self.stats["footnotes_created"])
+        self.stdout.write(
+            "Footnotes reassigned: %d" % self.stats["footnotes_reassigned"]
+        )
+        self.stdout.write("Rows skipped: %d" % self.stats["skipped"])
+        if self.skipped:
+            self.stdout.write("\nSkipped rows (need manual handling):")
+            for row_num, pgpid, reason in self.skipped:
+                self.stdout.write("  row %d (PGPID %r): %s" % (row_num, pgpid, reason))

--- a/geniza/footnotes/tests/test_import_posen_translations.py
+++ b/geniza/footnotes/tests/test_import_posen_translations.py
@@ -1,0 +1,243 @@
+import csv
+import io
+from unittest.mock import mock_open, patch
+
+import pytest
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from geniza.corpus.models import Document, DocumentType
+from geniza.footnotes.models import Creator, Footnote, Source, SourceType
+
+# full set of column headers is irrelevant (the command indexes by position),
+# but the row must be wide enough to reach the Posen URL column (index 11)
+ROW_WIDTH = 13
+
+
+def make_row(
+    pgpid="",
+    reassign="",
+    title="A Test Chapter",
+    footnote_id="",
+    creator_ids="",
+    posen_url="https://www.posenlibrary.com/node/1",
+    pgp_url="",
+):
+    """Build a CSV row (list of cells) positioned to match spreadsheet columns."""
+    row = [""] * ROW_WIDTH
+    row[1] = str(pgpid)  # B pgpid
+    row[4] = pgp_url  # E pgp_url
+    row[6] = title  # G title
+    row[7] = reassign  # H yes/no
+    row[8] = str(footnote_id)  # I existing footnote id
+    row[10] = creator_ids  # K creator pks
+    row[11] = posen_url  # L stable Posen url
+    return row
+
+
+def csv_text(rows):
+    """Serialize a header row plus data rows to CSV text (with proper quoting)."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["col%d" % i for i in range(ROW_WIDTH)])
+    writer.writerows(rows)
+    return buf.getvalue()
+
+
+def run_command(rows, *args):
+    """Invoke the command with an in-memory CSV of the given rows."""
+    with patch(
+        "geniza.footnotes.management.commands.import_posen_translations.open",
+        mock_open(read_data=csv_text(rows)),
+    ):
+        call_command("import_posen_translations", "posen.csv", *args)
+
+
+def make_document():
+    """Create a minimal document to attach footnotes to."""
+    return Document.objects.create(
+        doctype=DocumentType.objects.get_or_create(name_en="Legal")[0]
+    )
+
+
+@pytest.mark.django_db
+def test_creates_source_and_translation_footnote():
+    doc = make_document()
+    ashur = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    outhwaite = Creator.objects.create(first_name_en="Ben", last_name_en="Outhwaite")
+
+    run_command(
+        [
+            make_row(
+                pgpid=doc.pk,
+                reassign="no",
+                title="Posen Source",
+                creator_ids="%d; %d" % (ashur.pk, outhwaite.pk),
+                posen_url="https://www.posenlibrary.com/node/13542",
+            )
+        ]
+    )
+
+    # a new Book Section source with the shared Posen field values
+    source = Source.objects.get(title="Posen Source")
+    assert source.source_type.type == "Book Section"
+    assert source.year == 2026
+    assert source.publisher == "Yale University Press"
+    assert source.place_published == "New Haven, Connecticut and London"
+    assert source.journal == "Posen Library of Jewish Culture and Civilization"
+    assert source.volume == "3"
+    assert source.url == "https://www.posenlibrary.com/node/13542"
+    assert list(source.languages.values_list("name", flat=True)) == ["English"]
+    assert source.slug  # slug generated from authors/title/year
+    # authors preserved in spreadsheet order
+    assert [
+        (a.sort_order, a.creator_id)
+        for a in source.authorship_set.order_by("sort_order")
+    ] == [(1, ashur.pk), (2, outhwaite.pk)]
+
+    # a content-less Translation footnote linking the source to the document
+    footnote = Footnote.objects.get(source=source)
+    assert footnote.get_doc_relation_display() == "Translation"
+    assert footnote.content is None
+    assert footnote.object_id == doc.pk
+    assert footnote.content_type == ContentType.objects.get_for_model(Document)
+
+    # both creations are logged as additions under the script user
+    assert LogEntry.objects.filter(action_flag=ADDITION).count() == 2
+
+
+@pytest.mark.django_db
+def test_leaves_other_footnotes_untouched():
+    # translations already attached to a separate source must not be reassigned
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Geoffrey", last_name_en="Khan")
+    other_source = Source.objects.create(
+        title="Other Source",
+        source_type=SourceType.objects.get(type="Book"),
+    )
+    existing = Footnote.objects.create(
+        source=other_source,
+        content_object=doc,
+        doc_relation=[Footnote.EDITION],
+    )
+
+    run_command([make_row(pgpid=doc.pk, reassign="no", creator_ids=str(creator.pk))])
+
+    existing.refresh_from_db()
+    assert existing.source_id == other_source.pk  # unchanged
+
+
+@pytest.mark.django_db
+def test_reassigns_existing_footnote():
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Arnold", last_name_en="Franklin")
+    old_source = Source.objects.create(
+        title="Wrong Source",
+        source_type=SourceType.objects.get(type="Book"),
+    )
+    footnote = Footnote.objects.create(
+        source=old_source,
+        content_object=doc,
+        doc_relation=[Footnote.DIGITAL_TRANSLATION],
+        content={"body": "translation content"},
+    )
+
+    run_command(
+        [
+            make_row(
+                reassign="yes",
+                title="Test Source",
+                footnote_id=footnote.pk,
+                creator_ids=str(creator.pk),
+            )
+        ]
+    )
+
+    new_source = Source.objects.get(title="Test Source")
+    footnote.refresh_from_db()
+    # reassigned to the new source, but content and relation preserved
+    assert footnote.source_id == new_source.pk
+    assert footnote.content == {"body": "translation content"}
+    assert footnote.get_doc_relation_display() == "Digital Translation"
+    # no new footnote created; old source is left in place
+    assert Footnote.objects.count() == 1
+    assert Source.objects.filter(pk=old_source.pk).exists()
+    # reassignment logged as a change
+    assert (
+        LogEntry.objects.filter(action_flag=CHANGE, object_id=footnote.pk).count() == 1
+    )
+
+
+@pytest.mark.django_db
+def test_idempotent_reruns():
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    rows = [
+        make_row(
+            pgpid=doc.pk,
+            reassign="no",
+            title="Posen Source",
+            creator_ids=str(creator.pk),
+        )
+    ]
+
+    # running twice should not result in duplicates
+    run_command(rows)
+    run_command(rows)
+    assert Source.objects.filter(title="Posen Source").count() == 1
+    assert Footnote.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_dryrun_makes_no_changes():
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+
+    run_command(
+        [make_row(pgpid=doc.pk, reassign="no", creator_ids=str(creator.pk))],
+        "--dryrun",
+    )
+
+    assert not Source.objects.filter(journal__startswith="Posen").exists()
+    assert Footnote.objects.count() == 0
+    assert LogEntry.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_skips_bad_rows_and_reports():
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    cid = str(creator.pk)
+    missing_creator_id = str(creator.pk + 1000)
+
+    rows = [
+        # "no" row with multiple PGPIDs = ambiguous, skip
+        make_row(pgpid="19297, 19296", reassign="no", creator_ids=cid),
+        # "no" row with a non-numeric PGPID
+        make_row(pgpid="not in PGP", reassign="no", creator_ids=cid),
+        # "no" row whose document does not exist
+        make_row(pgpid="99999999", reassign="no", creator_ids=cid),
+        # "yes" row missing the footnote id
+        make_row(reassign="yes", footnote_id="", creator_ids=cid),
+        # "yes" row referencing a nonexistent footnote
+        make_row(reassign="yes", footnote_id="99999999", creator_ids=cid),
+        # unknown Column H value
+        make_row(pgpid=doc.pk, reassign="bad", creator_ids=cid),
+        # unknown creator id
+        make_row(pgpid=doc.pk, reassign="no", creator_ids=missing_creator_id),
+        # non-numeric creator id
+        make_row(pgpid=doc.pk, reassign="no", creator_ids="abc"),
+    ]
+    run_command(rows)
+
+    # every row was skipped; nothing created
+    assert Source.objects.count() == 0
+    assert Footnote.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_file_not_found():
+    with pytest.raises(CommandError):
+        call_command("import_posen_translations", "nonexistent.csv")

--- a/geniza/footnotes/tests/test_import_posen_translations.py
+++ b/geniza/footnotes/tests/test_import_posen_translations.py
@@ -3,13 +3,21 @@ import io
 from unittest.mock import mock_open, patch
 
 import pytest
+from django.conf import settings
 from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from geniza.corpus.models import Document, DocumentType
-from geniza.footnotes.models import Creator, Footnote, Source, SourceType
+from geniza.footnotes.models import (
+    Creator,
+    Footnote,
+    Source,
+    SourceLanguage,
+    SourceType,
+)
 
 # full set of column headers is irrelevant (the command indexes by position),
 # but the row must be wide enough to reach the Posen URL column (index 11)
@@ -241,6 +249,96 @@ def test_skips_bad_rows_and_reports():
     # every row was skipped; nothing created
     assert Source.objects.count() == 0
     assert Footnote.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_creator_ids_tolerate_blank_parts():
+    # separators with empty segments (e.g. a trailing ";") are ignored
+    doc = make_document()
+    ashur = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    outhwaite = Creator.objects.create(first_name_en="Ben", last_name_en="Outhwaite")
+
+    run_command(
+        [
+            make_row(
+                pgpid=doc.pk,
+                reassign="no",
+                creator_ids="%d; ; %d;" % (ashur.pk, outhwaite.pk),
+            )
+        ]
+    )
+
+    source = Source.objects.get()
+    assert list(
+        source.authorship_set.order_by("sort_order").values_list(
+            "creator_id", flat=True
+        )
+    ) == [ashur.pk, outhwaite.pk]
+
+
+@pytest.mark.django_db
+def test_reassign_non_digital_translation_and_rerun():
+    # a footnote that is not a Digital Translation is still reassigned (with a
+    # warning), and reassigning again is a no-op
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    old_source = Source.objects.create(
+        title="Wrong Source", source_type=SourceType.objects.get(type="Book")
+    )
+    footnote = Footnote.objects.create(
+        source=old_source,
+        content_object=doc,
+        doc_relation=[Footnote.EDITION],
+    )
+    rows = [
+        make_row(reassign="yes", footnote_id=footnote.pk, creator_ids=str(creator.pk))
+    ]
+
+    run_command(rows)
+    footnote.refresh_from_db()
+    new_source = Source.objects.get(title="A Test Chapter")
+    assert footnote.source_id == new_source.pk
+
+    # second run: footnote is already on the new source, so nothing changes
+    run_command(rows)
+    assert (
+        LogEntry.objects.filter(action_flag=CHANGE, object_id=footnote.pk).count() == 1
+    )
+
+
+@pytest.mark.django_db
+def test_skip_indexing_disconnects_signal_handler():
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+
+    with patch(
+        "geniza.footnotes.management.commands.import_posen_translations."
+        "IndexableSignalHandler.disconnect"
+    ) as mock_disconnect:
+        run_command(
+            [make_row(pgpid=doc.pk, reassign="no", creator_ids=str(creator.pk))],
+            "--skip-indexing",
+        )
+    mock_disconnect.assert_called_once()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    # the command checks these records in order and raises on the first missing
+    # one, so each must be deleted in its own run to cover all three branches
+    "records",
+    [
+        User.objects.filter(username=settings.SCRIPT_USERNAME),
+        SourceType.objects.filter(type="Book Section"),
+        SourceLanguage.objects.filter(name="English"),
+    ],
+    ids=["script_user", "book_section", "english"],
+)
+def test_errors_when_required_records_missing(records):
+    # command should raise error if required records are missing
+    records.delete()
+    with pytest.raises(CommandError):
+        run_command([make_row(pgpid=1, reassign="no", creator_ids="1")])
 
 
 @pytest.mark.django_db

--- a/geniza/footnotes/tests/test_import_posen_translations.py
+++ b/geniza/footnotes/tests/test_import_posen_translations.py
@@ -229,6 +229,12 @@ def test_skips_bad_rows_and_reports():
         make_row(pgpid=doc.pk, reassign="no", creator_ids=missing_creator_id),
         # non-numeric creator id
         make_row(pgpid=doc.pk, reassign="no", creator_ids="abc"),
+        # no creator id at all
+        make_row(pgpid=doc.pk, reassign="no", creator_ids=""),
+        # valid document and creator, but no title
+        make_row(pgpid=doc.pk, reassign="no", title="", creator_ids=cid),
+        # fully blank row is silently ignored (not counted as a skip)
+        [""] * ROW_WIDTH,
     ]
     run_command(rows)
 


### PR DESCRIPTION
**Associated Issue(s):** #2013

### Changes in this PR

- Adds a new management command to ingest the new Source and Footnote records per #2013 from a CSV, run with 
   ```
   python manage.py import_posen_translations /path/to/posen.csv
   ```
  - Creates new Source records for existing Footnotes on digital translations that need to be reassigned
  - Creates new Source and Footnote records for digital translations that need a separate Translation footnote
  - Uses atomic transactions so that changes can be rolled back if an error is encountered
  - Logs errors and issues while running, and at the end of a run
  - Records LogEntries for auditing in the admin

### Notes

- If running this locally, you'll need a recent data dump. [Here is one from 8/25/2026](https://drive.google.com/file/d/1vJz0y0c24SbXTLsVlD6su352s-_LVeGG/view?usp=sharing). 
   - As a reminder, in case it's useful: typically I extract the `.sql` file; use `sed` to replace all instances of `cdh_geniza` in it with my local postgres username; create a new db with `createdb dbname` and load it with `psql dbname < filename.sql`; change my `local_settings.py` to point to the new db; and then run `./manage.py migrate` to apply all migrations and `./manage.py createsuperuser` to create a user/pass admin user
- And [here is a version of the current spreadsheet as a CSV](https://drive.google.com/file/d/1UINWvEKJxA1mUsuSb86c-i2BGrLntlp1/view?usp=sharing) for easy import
   - Per https://github.com/Princeton-CDH/geniza/issues/2013#issuecomment-5447896815, entries that say they are not yet in PGP are skipped