### PR TITLE
Fix unicode encoding issues in Posen ingest script (#2013)

### DIFF
--- a/geniza/footnotes/management/commands/import_posen_translations.py
+++ b/geniza/footnotes/management/commands/import_posen_translations.py
@@ -1,4 +1,5 @@
 import csv
+import unicodedata
 from collections import Counter
 
 from django.conf import settings
@@ -102,7 +103,7 @@ class Command(BaseCommand):
         self.footnote_contenttype = ContentType.objects.get_for_model(Footnote)
 
         try:
-            with open(options["csv"]) as f:
+            with open(options["csv"], encoding="utf-8-sig") as f:
                 # index by column position rather than header name;
                 # headers are long and contain commas/newlines
                 reader = csv.reader(f)
@@ -211,7 +212,9 @@ class Command(BaseCommand):
         """Return the Posen source for this row, creating it (with authorship,
         language, and slug) if an equivalent one does not already exist.
         Matching on title + authors keeps the command safe to re-run."""
-        title = self.cell(row, self.COL_TITLE).strip()
+        # normalize to NFC so visually identical titles compare equal.
+        # the spreadsheet mixes precomposed and decomposed forms
+        title = unicodedata.normalize("NFC", self.cell(row, self.COL_TITLE).strip())
         if not title:
             raise SkipRow("missing title (Column G)")
 
@@ -326,7 +329,7 @@ class Command(BaseCommand):
     def report(self):
         """Summarize created/reassigned records and list skipped rows."""
         if self.dryrun:
-            self.stdout.write(self.style.NOTICE("DRY RUN — no changes committed"))
+            self.stdout.write(self.style.NOTICE("DRY RUN - no changes committed"))
         self.stdout.write("Sources created: %d" % self.stats["sources_created"])
         self.stdout.write("Footnotes created: %d" % self.stats["footnotes_created"])
         self.stdout.write(

--- a/geniza/footnotes/tests/test_import_posen_translations.py
+++ b/geniza/footnotes/tests/test_import_posen_translations.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import unicodedata
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -339,6 +340,40 @@ def test_errors_when_required_records_missing(records):
     records.delete()
     with pytest.raises(CommandError):
         run_command([make_row(pgpid=1, reassign="no", creator_ids="1")])
+
+
+@pytest.mark.django_db
+def test_reads_utf8_file_and_normalizes_title(tmp_path):
+    # read from a real file (not mock_open, which ignores encoding) so the
+    # UTF-8 decode path is exercised; title mixes a curly quote and a
+    # decomposed u + combining macron (NFD)
+    doc = make_document()
+    creator = Creator.objects.create(first_name_en="Amir", last_name_en="Ashur")
+    nfc_title = "Letter to Abraham Ben Yijū ‘Eli ibn Hilāl"
+    # write the decomposed (NFD) form so normalization has work to do
+    nfd_title = unicodedata.normalize("NFD", nfc_title)
+    assert nfd_title != nfc_title
+
+    csv_path = tmp_path / "posen.csv"
+    csv_path.write_text(
+        csv_text(
+            [
+                make_row(
+                    pgpid=doc.pk,
+                    reassign="no",
+                    title=nfd_title,
+                    creator_ids=str(creator.pk),
+                )
+            ]
+        ),
+        encoding="utf-8",
+    )
+    call_command("import_posen_translations", str(csv_path), "--skip-indexing")
+
+    source = Source.objects.get()
+    # should be decoded correctly and normalized to NFC without combining mark
+    assert source.title == nfc_title
+    assert "̄" not in source.title
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Associated Issue(s):** #2013

### Changes in this PR

When doing the Posen ingest on the test server, I noticed a few things:
- When running under an environment with latin-1 encoding (i.e. the server) as opposed to unicode (i.e. my Mac), the file would be opened with an incorrect encoding
- Some titles in the spreadsheet use NFC combined character encoding and some use NFD decomposed character encoding, which can cause equivalence-checking failures between otherwise identical strings
- A unicode "—" character in the dry run reporting text caused an error

This PR addresses those by:
- Opening and reading the csv as `utf-8-sig`
- Normalizing all titles to NFC to ensure they compare correctly
- Changing "—" to "-" in the dry run report